### PR TITLE
Add connectors system with code-first module architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help api-install api-dev api-build api-start api-test api-test-unit api-test-integration api-typecheck api-lint api-lint-check api-format ui-install ui-dev ui-test ui-typecheck ui-lint ui-format db-up db-down db-generate db-migrate db-push db-studio db-seed clean reset logs
+.PHONY: help api-install api-dev api-build api-start api-test api-test-unit api-test-integration api-typecheck api-lint api-lint-check api-format sync-connectors ui-install ui-dev ui-test ui-typecheck ui-lint ui-format db-up db-down db-generate db-migrate db-push db-studio db-seed clean reset logs
 
 .DEFAULT_GOAL := help
 
@@ -43,6 +43,9 @@ api-lint-check: ## [API] Run linter (check only)
 
 api-format: ## [API] Format code
 	cd modelguide-api && bun run format
+
+sync-connectors: ## [API] Sync connector catalog from code to database
+	cd modelguide-api && bun run sync:connectors
 
 # =============================================================================
 # UI

--- a/modelguide-api/package.json
+++ b/modelguide-api/package.json
@@ -18,7 +18,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "bun run src/db/seed/index.ts"
+    "db:seed": "bun run src/db/seed/index.ts",
+    "sync:connectors": "bun run src/features/connectors/catalog/sync.ts"
   },
   "dependencies": {
     "@hono/zod-openapi": "^0.18.0",

--- a/modelguide-api/src/app.ts
+++ b/modelguide-api/src/app.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { apiReference } from "@scalar/hono-api-reference";
 
 import { env } from "@/env";
+import { connectorRoutes } from "@features/connectors";
 import { organizationRoutes } from "@features/organizations";
 import { secretsRoutes } from "@features/secrets";
 import { authRoutes, userRoutes } from "@features/users";
@@ -40,6 +41,7 @@ apiRouter.openapi(healthRoute, (c) => {
 });
 
 apiRouter.route("/auth", authRoutes);
+apiRouter.route("/connectors", connectorRoutes);
 apiRouter.route("/organizations", organizationRoutes);
 apiRouter.route("/secrets", secretsRoutes);
 apiRouter.route("/users", userRoutes);

--- a/modelguide-api/src/features/connectors/catalog/medusa/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/index.ts
@@ -1,0 +1,221 @@
+/**
+ * Medusa E-commerce connector module.
+ * Provides cart, order, and address management tools.
+ */
+
+import type { ConnectorManifest, ConnectorToolDefinition } from "../types";
+
+function stubHandler(toolName: string): ConnectorToolDefinition["handler"] {
+  return async (ctx) => ({
+    success: true,
+    data: {
+      message: `${toolName} executed (stub)`,
+      input: ctx.input,
+    },
+  });
+}
+
+const tools: ConnectorToolDefinition[] = [
+  {
+    catalog: {
+      name: "Add to Cart",
+      description: "Add an item to the customer's shopping cart",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cartId: { type: "string", description: "Cart ID" },
+          variantId: { type: "string", description: "Product variant ID" },
+          quantity: {
+            type: "integer",
+            description: "Quantity to add",
+            minimum: 1,
+          },
+        },
+        required: ["cartId", "variantId", "quantity"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 30,
+    },
+    handler: stubHandler("Add to Cart"),
+  },
+  {
+    catalog: {
+      name: "Get Cart",
+      description: "Retrieve the current contents of a shopping cart",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cartId: { type: "string", description: "Cart ID" },
+        },
+        required: ["cartId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 30,
+    },
+    handler: stubHandler("Get Cart"),
+  },
+  {
+    catalog: {
+      name: "Create Draft Order",
+      description: "Create a draft order from the cart",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cartId: {
+            type: "string",
+            description: "Cart ID to convert to order",
+          },
+        },
+        required: ["cartId"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 60,
+    },
+    handler: stubHandler("Create Draft Order"),
+  },
+  {
+    catalog: {
+      name: "Set Delivery Address",
+      description: "Set or update the delivery address for a cart",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cartId: { type: "string", description: "Cart ID" },
+          address: {
+            type: "object",
+            properties: {
+              firstName: { type: "string" },
+              lastName: { type: "string" },
+              address1: { type: "string" },
+              address2: { type: "string" },
+              city: { type: "string" },
+              postalCode: { type: "string" },
+              countryCode: { type: "string" },
+              phone: { type: "string" },
+            },
+            required: [
+              "firstName",
+              "lastName",
+              "address1",
+              "city",
+              "postalCode",
+              "countryCode",
+            ],
+          },
+        },
+        required: ["cartId", "address"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 30,
+    },
+    handler: stubHandler("Set Delivery Address"),
+  },
+  {
+    catalog: {
+      name: "Confirm Order",
+      description: "Confirm and finalize an order",
+      inputSchema: {
+        type: "object",
+        properties: {
+          orderId: { type: "string", description: "Order ID to confirm" },
+        },
+        required: ["orderId"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 60,
+    },
+    handler: stubHandler("Confirm Order"),
+  },
+  {
+    catalog: {
+      name: "Get Order",
+      description: "Retrieve details of an existing order",
+      inputSchema: {
+        type: "object",
+        properties: {
+          orderId: { type: "string", description: "Order ID" },
+        },
+        required: ["orderId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 30,
+    },
+    handler: stubHandler("Get Order"),
+  },
+  {
+    catalog: {
+      name: "Update Order Address",
+      description: "Update the shipping address of an existing order",
+      inputSchema: {
+        type: "object",
+        properties: {
+          orderId: { type: "string", description: "Order ID" },
+          address: {
+            type: "object",
+            properties: {
+              firstName: { type: "string" },
+              lastName: { type: "string" },
+              address1: { type: "string" },
+              address2: { type: "string" },
+              city: { type: "string" },
+              postalCode: { type: "string" },
+              countryCode: { type: "string" },
+              phone: { type: "string" },
+            },
+          },
+        },
+        required: ["orderId", "address"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 30,
+    },
+    handler: stubHandler("Update Order Address"),
+  },
+  {
+    catalog: {
+      name: "Cancel Order",
+      description: "Cancel an existing order",
+      inputSchema: {
+        type: "object",
+        properties: {
+          orderId: { type: "string", description: "Order ID to cancel" },
+          reason: { type: "string", description: "Reason for cancellation" },
+        },
+        required: ["orderId"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 60,
+    },
+    handler: stubHandler("Cancel Order"),
+  },
+];
+
+const medusaManifest: ConnectorManifest = {
+  name: "Medusa",
+  slug: "medusa",
+  description:
+    "E-commerce platform connector for managing carts, orders, and customers",
+  connectorType: "api",
+  configSchema: {
+    baseUrl: {
+      type: "string",
+      required: true,
+      description: "Medusa API base URL",
+    },
+    apiToken: {
+      type: "secret",
+      required: true,
+      description: "API authentication token",
+    },
+    publishableKey: {
+      type: "string",
+      required: false,
+      description: "Publishable API key for storefront",
+    },
+  },
+  authMethods: ["api_key"],
+  iconUrl: "https://medusajs.com/images/logo.svg",
+  tools,
+};
+
+export default medusaManifest;

--- a/modelguide-api/src/features/connectors/catalog/registry.ts
+++ b/modelguide-api/src/features/connectors/catalog/registry.ts
@@ -1,0 +1,31 @@
+/**
+ * In-memory connector registry for O(1) manifest lookups.
+ */
+
+import type { ConnectorManifest } from "./types";
+
+const registry = new Map<string, ConnectorManifest>();
+
+export function registerConnector(manifest: ConnectorManifest): void {
+  registry.set(manifest.slug, manifest);
+}
+
+export function getConnectorManifest(
+  slug: string,
+): ConnectorManifest | undefined {
+  return registry.get(slug);
+}
+
+export function getAllManifests(): ConnectorManifest[] {
+  return Array.from(registry.values());
+}
+
+export async function loadAllManifests(): Promise<ConnectorManifest[]> {
+  const modules = await Promise.all([import("./medusa/index")]);
+
+  for (const mod of modules) {
+    registerConnector(mod.default);
+  }
+
+  return getAllManifests();
+}

--- a/modelguide-api/src/features/connectors/catalog/sync.ts
+++ b/modelguide-api/src/features/connectors/catalog/sync.ts
@@ -1,0 +1,74 @@
+/**
+ * CLI script to sync connector manifests from code into the connectors_catalog DB table.
+ *
+ * Usage: bun run src/features/connectors/catalog/sync.ts
+ */
+
+import { db } from "@db/client";
+import type { NewConnectorCatalog } from "@db/schema";
+import { connectorsCatalog } from "@db/schema";
+import { notInArray } from "drizzle-orm";
+import { loadAllManifests } from "./registry";
+
+async function sync() {
+  console.log("Loading connector manifests...");
+  const manifests = await loadAllManifests();
+  console.log(`Found ${manifests.length} connector(s)`);
+
+  const slugs = manifests.map((m) => m.slug);
+
+  for (const manifest of manifests) {
+    const row: NewConnectorCatalog = {
+      name: manifest.name,
+      slug: manifest.slug,
+      description: manifest.description,
+      connectorType: manifest.connectorType,
+      configSchema: manifest.configSchema,
+      tools: manifest.tools.map((t) => t.catalog),
+      authMethods: manifest.authMethods,
+      iconUrl: manifest.iconUrl,
+      isActive: true,
+    };
+
+    await db
+      .insert(connectorsCatalog)
+      .values(row)
+      .onConflictDoUpdate({
+        target: connectorsCatalog.slug,
+        set: {
+          name: row.name,
+          description: row.description,
+          connectorType: row.connectorType,
+          configSchema: row.configSchema,
+          tools: row.tools,
+          authMethods: row.authMethods,
+          iconUrl: row.iconUrl,
+          isActive: true,
+        },
+      });
+
+    console.log(`  Upserted: ${manifest.name} (${manifest.slug})`);
+  }
+
+  if (slugs.length > 0) {
+    const deactivated = await db
+      .update(connectorsCatalog)
+      .set({ isActive: false })
+      .where(notInArray(connectorsCatalog.slug, slugs))
+      .returning({ slug: connectorsCatalog.slug });
+
+    if (deactivated.length > 0) {
+      for (const d of deactivated) {
+        console.log(`  Deactivated: ${d.slug}`);
+      }
+    }
+  }
+
+  console.log("Sync complete.");
+  process.exit(0);
+}
+
+sync().catch((err) => {
+  console.error("Sync failed:", err);
+  process.exit(1);
+});

--- a/modelguide-api/src/features/connectors/catalog/types.ts
+++ b/modelguide-api/src/features/connectors/catalog/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types for the connector module system.
+ * Each connector is a TypeScript module with a manifest and executable tool handlers.
+ */
+
+import type { CatalogTool } from "@db/schema/core";
+
+export interface ToolExecutionContext {
+  config: Record<string, string>;
+  input: Record<string, unknown>;
+  organizationId: string;
+  connectorId: string;
+}
+
+export interface ToolExecutionResult {
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface ConnectorToolDefinition {
+  catalog: CatalogTool;
+  handler: (ctx: ToolExecutionContext) => Promise<ToolExecutionResult>;
+}
+
+export interface ConfigFieldSchema {
+  type: "string" | "secret" | "number" | "boolean";
+  required: boolean;
+  description: string;
+  default?: string | number | boolean;
+}
+
+export type ConnectorType = "api" | "webhook" | "database" | "messaging";
+
+export interface ConnectorManifest {
+  name: string;
+  slug: string;
+  description: string;
+  connectorType: ConnectorType;
+  configSchema: Record<string, ConfigFieldSchema>;
+  authMethods: string[];
+  iconUrl: string;
+  tools: ConnectorToolDefinition[];
+}

--- a/modelguide-api/src/features/connectors/connectors.routes.ts
+++ b/modelguide-api/src/features/connectors/connectors.routes.ts
@@ -1,0 +1,586 @@
+/**
+ * Connector management routes
+ */
+
+import type { Connector, ConnectorCatalog, ConnectorTool } from "@db/schema";
+import { createRoute, z } from "@hono/zod-openapi";
+import { createRouter } from "@lib/create-app";
+import {
+  getOrganizationId,
+  requireOrganization,
+  requirePermission,
+  requireUser,
+} from "@lib/middleware";
+import { paginatedResponseSchema, paginationSchema } from "@lib/pagination";
+import { errorResponseSchema } from "@lib/schemas";
+import {
+  createConnector,
+  deleteConnector,
+  getCatalogEntry,
+  getConnectorById,
+  listCatalog,
+  listConnectorTools,
+  listConnectors,
+  updateConnector,
+  updateConnectorTool,
+} from "./connectors.service";
+
+const router = createRouter();
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const catalogToolSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  inputSchema: z.record(z.unknown()),
+  defaultRequiresConfirmation: z.boolean(),
+  defaultTimeoutSeconds: z.number(),
+});
+
+const catalogResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  connectorType: z.enum(["api", "webhook", "database", "messaging"]),
+  configSchema: z.record(z.unknown()),
+  tools: z.array(catalogToolSchema),
+  authMethods: z.array(z.string()).nullable(),
+  iconUrl: z.string().nullable(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+});
+
+const connectorResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  connectorCatalogId: z.string().uuid(),
+  config: z.record(z.unknown()),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string().nullable(),
+});
+
+const connectorToolResponseSchema = z.object({
+  id: z.string().uuid(),
+  connectorId: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  toolSchema: z.record(z.unknown()),
+  timeoutSeconds: z.number(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+});
+
+const createConnectorSchema = z.object({
+  connectorCatalogId: z.string().uuid().openapi({
+    description: "ID of the catalog entry to create from",
+  }),
+  name: z.string().min(1).max(255).openapi({
+    example: "My Medusa Store",
+  }),
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(
+      /^[a-z0-9][a-z0-9_-]*$/,
+      "Slug must start with a letter or number and contain only lowercase letters, numbers, hyphens, or underscores",
+    )
+    .openapi({
+      example: "my-medusa-store",
+    }),
+  config: z.record(z.unknown()).optional().openapi({
+    description: "Connector configuration",
+  }),
+});
+
+const updateConnectorSchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    config: z.record(z.unknown()).optional(),
+    isActive: z.boolean().optional(),
+  })
+  .refine(
+    (data) =>
+      data.name !== undefined ||
+      data.config !== undefined ||
+      data.isActive !== undefined,
+    {
+      message:
+        "At least one of 'name', 'config', or 'isActive' must be provided",
+    },
+  );
+
+const updateToolSchema = z
+  .object({
+    isActive: z.boolean().optional(),
+    timeoutSeconds: z.number().int().min(1).max(300).optional(),
+  })
+  .refine(
+    (data) => data.isActive !== undefined || data.timeoutSeconds !== undefined,
+    {
+      message:
+        "At least one of 'isActive' or 'timeoutSeconds' must be provided",
+    },
+  );
+
+const catalogIdParams = z.object({
+  catalogId: z.string().uuid().openapi({
+    description: "Catalog entry ID",
+  }),
+});
+
+const connectorIdParams = z.object({
+  id: z.string().uuid().openapi({
+    description: "Connector ID",
+  }),
+});
+
+const toolIdParams = z.object({
+  toolId: z.string().uuid().openapi({
+    description: "Tool ID",
+  }),
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function errorResponse(description: string) {
+  return {
+    description,
+    content: { "application/json": { schema: errorResponseSchema } },
+  };
+}
+
+function formatCatalog(entry: ConnectorCatalog) {
+  return {
+    id: entry.id,
+    name: entry.name,
+    slug: entry.slug,
+    description: entry.description,
+    connectorType: entry.connectorType,
+    configSchema: entry.configSchema ?? {},
+    tools: entry.tools ?? [],
+    authMethods: entry.authMethods,
+    iconUrl: entry.iconUrl,
+    isActive: entry.isActive,
+    createdAt: entry.createdAt.toISOString(),
+  };
+}
+
+function formatConnector(connector: Connector) {
+  return {
+    id: connector.id,
+    name: connector.name,
+    slug: connector.slug,
+    connectorCatalogId: connector.connectorCatalogId,
+    config: connector.config ?? {},
+    isActive: connector.isActive,
+    createdAt: connector.createdAt.toISOString(),
+    updatedAt: connector.updatedAt?.toISOString() ?? null,
+  };
+}
+
+function formatTool(tool: ConnectorTool) {
+  return {
+    id: tool.id,
+    connectorId: tool.connectorId,
+    name: tool.name,
+    slug: tool.slug,
+    description: tool.description,
+    toolSchema: tool.toolSchema ?? {},
+    timeoutSeconds: tool.timeoutSeconds,
+    isActive: tool.isActive,
+    createdAt: tool.createdAt.toISOString(),
+  };
+}
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+// GET /catalog
+router.get(
+  "/catalog",
+  requireUser(),
+  requirePermission("connectors:read"),
+  requireOrganization(),
+);
+router.get(
+  "/catalog/:catalogId",
+  requireUser(),
+  requirePermission("connectors:read"),
+  requireOrganization(),
+);
+const listCatalogRoute = createRoute({
+  method: "get",
+  path: "/catalog",
+  tags: ["Connectors"],
+  summary: "List connector catalog",
+  description: "Returns paginated list of active connector catalog entries.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: paginationSchema,
+  },
+  responses: {
+    200: {
+      description: "Paginated list of catalog entries",
+      content: {
+        "application/json": {
+          schema: paginatedResponseSchema(catalogResponseSchema),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+  },
+});
+
+router.openapi(listCatalogRoute, async (c) => {
+  const query = c.req.valid("query");
+  const result = await listCatalog(query);
+
+  return c.json(
+    {
+      data: result.data.map(formatCatalog),
+      pagination: result.pagination,
+    },
+    200,
+  );
+});
+
+// GET /catalog/:catalogId
+const getCatalogRoute = createRoute({
+  method: "get",
+  path: "/catalog/{catalogId}",
+  tags: ["Connectors"],
+  summary: "Get catalog entry",
+  description: "Returns a single connector catalog entry with tools array.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: catalogIdParams,
+  },
+  responses: {
+    200: {
+      description: "Catalog entry detail",
+      content: {
+        "application/json": { schema: catalogResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Catalog entry not found"),
+  },
+});
+
+router.openapi(getCatalogRoute, async (c) => {
+  const { catalogId } = c.req.valid("param");
+  const entry = await getCatalogEntry(catalogId);
+
+  return c.json(formatCatalog(entry), 200);
+});
+
+// GET /
+router.get(
+  "/",
+  requireUser(),
+  requirePermission("connectors:read"),
+  requireOrganization(),
+);
+router.post(
+  "/",
+  requireUser(),
+  requirePermission("connectors:create"),
+  requireOrganization(),
+);
+
+const listConnectorsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Connectors"],
+  summary: "List connectors",
+  description: "Returns paginated list of organization connector instances.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: paginationSchema,
+  },
+  responses: {
+    200: {
+      description: "Paginated list of connectors",
+      content: {
+        "application/json": {
+          schema: paginatedResponseSchema(connectorResponseSchema),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+  },
+});
+
+router.openapi(listConnectorsRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const query = c.req.valid("query");
+  const result = await listConnectors(orgId, query);
+
+  return c.json(
+    {
+      data: result.data.map(formatConnector),
+      pagination: result.pagination,
+    },
+    200,
+  );
+});
+
+// POST /
+const createConnectorRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Connectors"],
+  summary: "Create connector",
+  description:
+    "Creates a new connector instance from a catalog entry. Auto-creates connector tools.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: createConnectorSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Connector created",
+      content: {
+        "application/json": { schema: connectorResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Catalog entry not found"),
+    409: errorResponse("Connector slug already exists"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(createConnectorRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const body = c.req.valid("json");
+  const connector = await createConnector(orgId, body);
+
+  return c.json(formatConnector(connector), 201);
+});
+
+// GET /:id
+router.get(
+  "/:id",
+  requireUser(),
+  requirePermission("connectors:read"),
+  requireOrganization(),
+);
+router.patch(
+  "/:id",
+  requireUser(),
+  requirePermission("connectors:update"),
+  requireOrganization(),
+);
+router.delete(
+  "/:id",
+  requireUser(),
+  requirePermission("connectors:delete"),
+  requireOrganization(),
+);
+
+const getConnectorRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Connectors"],
+  summary: "Get connector",
+  description: "Returns a single connector instance.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: connectorIdParams,
+  },
+  responses: {
+    200: {
+      description: "Connector detail",
+      content: {
+        "application/json": { schema: connectorResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Connector not found"),
+  },
+});
+
+router.openapi(getConnectorRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { id } = c.req.valid("param");
+  const connector = await getConnectorById(orgId, id);
+
+  return c.json(formatConnector(connector), 200);
+});
+
+// PATCH /:id
+const updateConnectorRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["Connectors"],
+  summary: "Update connector",
+  description: "Updates a connector's name, config, or active status.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: connectorIdParams,
+    body: {
+      content: {
+        "application/json": { schema: updateConnectorSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Connector updated",
+      content: {
+        "application/json": { schema: connectorResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Connector not found"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(updateConnectorRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const connector = await updateConnector(orgId, id, body);
+
+  return c.json(formatConnector(connector), 200);
+});
+
+// DELETE /:id
+const deleteConnectorRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Connectors"],
+  summary: "Delete connector",
+  description:
+    "Deletes a connector and all its tools (cascade via foreign key).",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: connectorIdParams,
+  },
+  responses: {
+    204: { description: "Connector deleted" },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Connector not found"),
+  },
+});
+
+router.openapi(deleteConnectorRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { id } = c.req.valid("param");
+  await deleteConnector(orgId, id);
+
+  return c.body(null, 204);
+});
+
+// GET /:id/tools
+router.get(
+  "/:id/tools",
+  requireUser(),
+  requirePermission("tools:read"),
+  requireOrganization(),
+);
+router.patch(
+  "/tools/:toolId",
+  requireUser(),
+  requirePermission("connectors:update"),
+  requireOrganization(),
+);
+
+const listToolsRoute = createRoute({
+  method: "get",
+  path: "/{id}/tools",
+  tags: ["Connectors"],
+  summary: "List connector tools",
+  description: "Returns all tools for a connector instance.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: connectorIdParams,
+  },
+  responses: {
+    200: {
+      description: "List of connector tools",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.array(connectorToolResponseSchema),
+          }),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Connector not found"),
+  },
+});
+
+router.openapi(listToolsRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { id } = c.req.valid("param");
+  const tools = await listConnectorTools(orgId, id);
+
+  return c.json({ data: tools.map(formatTool) }, 200);
+});
+
+// PATCH /tools/:toolId
+const updateToolRoute = createRoute({
+  method: "patch",
+  path: "/tools/{toolId}",
+  tags: ["Connectors"],
+  summary: "Update connector tool",
+  description: "Updates a tool's active status or timeout.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: toolIdParams,
+    body: {
+      content: {
+        "application/json": { schema: updateToolSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Tool updated",
+      content: {
+        "application/json": { schema: connectorToolResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Tool not found"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(updateToolRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { toolId } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const tool = await updateConnectorTool(orgId, toolId, body);
+
+  return c.json(formatTool(tool), 200);
+});
+
+export default router;

--- a/modelguide-api/src/features/connectors/connectors.service.ts
+++ b/modelguide-api/src/features/connectors/connectors.service.ts
@@ -1,0 +1,236 @@
+/**
+ * Connectors service - business logic for connector and tool management
+ */
+
+import { db } from "@db/client";
+import { forOrg } from "@db/rls";
+import { connectorTools, connectors, connectorsCatalog } from "@db/schema";
+import { Errors } from "@lib/errors";
+import {
+  type PaginationParams,
+  buildPaginationMeta,
+  getOffset,
+} from "@lib/pagination";
+import { and, asc, count, eq } from "drizzle-orm";
+
+// ============================================================================
+// Catalog queries (no RLS — global table)
+// ============================================================================
+
+export async function listCatalog(pagination: PaginationParams) {
+  const { page, pageSize } = pagination;
+  const offset = getOffset(page, pageSize);
+
+  const [items, [{ total }]] = await Promise.all([
+    db
+      .select()
+      .from(connectorsCatalog)
+      .where(eq(connectorsCatalog.isActive, true))
+      .orderBy(asc(connectorsCatalog.name))
+      .limit(pageSize)
+      .offset(offset),
+    db
+      .select({ total: count() })
+      .from(connectorsCatalog)
+      .where(eq(connectorsCatalog.isActive, true)),
+  ]);
+
+  return {
+    data: items,
+    pagination: buildPaginationMeta(page, pageSize, total),
+  };
+}
+
+export async function getCatalogEntry(catalogId: string) {
+  const [entry] = await db
+    .select()
+    .from(connectorsCatalog)
+    .where(eq(connectorsCatalog.id, catalogId));
+
+  if (!entry) {
+    throw Errors.notFound("Catalog entry", catalogId);
+  }
+
+  return entry;
+}
+
+// ============================================================================
+// Connector instance queries (RLS via forOrg)
+// ============================================================================
+
+export async function listConnectors(
+  orgId: string,
+  pagination: PaginationParams,
+) {
+  const { page, pageSize } = pagination;
+  const offset = getOffset(page, pageSize);
+
+  return forOrg(orgId, async (tx) => {
+    const [items, [{ total }]] = await Promise.all([
+      tx
+        .select()
+        .from(connectors)
+        .orderBy(asc(connectors.createdAt))
+        .limit(pageSize)
+        .offset(offset),
+      tx.select({ total: count() }).from(connectors),
+    ]);
+
+    return {
+      data: items,
+      pagination: buildPaginationMeta(page, pageSize, total),
+    };
+  });
+}
+
+export async function getConnectorById(orgId: string, connectorId: string) {
+  const [connector] = await forOrg(orgId, (tx) =>
+    tx.select().from(connectors).where(eq(connectors.id, connectorId)),
+  );
+
+  if (!connector) {
+    throw Errors.connectorNotFound(connectorId);
+  }
+
+  return connector;
+}
+
+export async function createConnector(
+  orgId: string,
+  data: {
+    connectorCatalogId: string;
+    name: string;
+    slug: string;
+    config?: Record<string, unknown>;
+  },
+) {
+  const [catalogEntry] = await db
+    .select()
+    .from(connectorsCatalog)
+    .where(
+      and(
+        eq(connectorsCatalog.id, data.connectorCatalogId),
+        eq(connectorsCatalog.isActive, true),
+      ),
+    );
+
+  if (!catalogEntry) {
+    throw Errors.notFound("Catalog entry", data.connectorCatalogId);
+  }
+
+  return forOrg(orgId, async (tx) => {
+    const [existing] = await tx
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(eq(connectors.slug, data.slug));
+
+    if (existing) {
+      throw Errors.alreadyExists("Connector", "slug");
+    }
+
+    const [connector] = await tx
+      .insert(connectors)
+      .values({
+        organizationId: orgId,
+        connectorCatalogId: data.connectorCatalogId,
+        name: data.name,
+        slug: data.slug,
+        config: data.config ?? {},
+      })
+      .returning();
+
+    const catalogTools = catalogEntry.tools ?? [];
+    if (catalogTools.length > 0) {
+      await tx.insert(connectorTools).values(
+        catalogTools.map((tool) => ({
+          organizationId: orgId,
+          connectorId: connector.id,
+          name: tool.name,
+          slug: tool.name.toLowerCase().replace(/\s+/g, "_"),
+          description: tool.description,
+          toolSchema: tool.inputSchema,
+          timeoutSeconds: tool.defaultTimeoutSeconds,
+          isActive: true,
+        })),
+      );
+    }
+
+    return connector;
+  });
+}
+
+export async function updateConnector(
+  orgId: string,
+  connectorId: string,
+  data: {
+    name?: string;
+    config?: Record<string, unknown>;
+    isActive?: boolean;
+  },
+) {
+  const [updated] = await forOrg(orgId, (tx) =>
+    tx
+      .update(connectors)
+      .set(data)
+      .where(eq(connectors.id, connectorId))
+      .returning(),
+  );
+
+  if (!updated) {
+    throw Errors.connectorNotFound(connectorId);
+  }
+
+  return updated;
+}
+
+export async function deleteConnector(
+  orgId: string,
+  connectorId: string,
+): Promise<void> {
+  const [deleted] = await forOrg(orgId, (tx) =>
+    tx
+      .delete(connectors)
+      .where(eq(connectors.id, connectorId))
+      .returning({ id: connectors.id }),
+  );
+
+  if (!deleted) {
+    throw Errors.connectorNotFound(connectorId);
+  }
+}
+
+// ============================================================================
+// Connector tool queries (RLS via forOrg)
+// ============================================================================
+
+export async function listConnectorTools(orgId: string, connectorId: string) {
+  await getConnectorById(orgId, connectorId);
+
+  return forOrg(orgId, (tx) =>
+    tx
+      .select()
+      .from(connectorTools)
+      .where(eq(connectorTools.connectorId, connectorId))
+      .orderBy(asc(connectorTools.name)),
+  );
+}
+
+export async function updateConnectorTool(
+  orgId: string,
+  toolId: string,
+  data: { isActive?: boolean; timeoutSeconds?: number },
+) {
+  const [updated] = await forOrg(orgId, (tx) =>
+    tx
+      .update(connectorTools)
+      .set(data)
+      .where(eq(connectorTools.id, toolId))
+      .returning(),
+  );
+
+  if (!updated) {
+    throw Errors.toolNotFound(toolId);
+  }
+
+  return updated;
+}

--- a/modelguide-api/src/features/connectors/index.ts
+++ b/modelguide-api/src/features/connectors/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Connectors feature exports
+ */
+
+export { default as connectorRoutes } from "./connectors.routes";
+export {
+  listCatalog,
+  getCatalogEntry,
+  listConnectors,
+  getConnectorById,
+  createConnector,
+  updateConnector,
+  deleteConnector,
+  listConnectorTools,
+  updateConnectorTool,
+} from "./connectors.service";

--- a/modelguide-api/tests/integration/connectors.test.ts
+++ b/modelguide-api/tests/integration/connectors.test.ts
@@ -1,0 +1,650 @@
+/**
+ * Integration tests for Connectors API
+ * Tests the full HTTP request/response cycle with RLS isolation
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import app from "@/app";
+import { forApp } from "@db/rls";
+import { connectors } from "@db/schema";
+import { eq } from "drizzle-orm";
+import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+
+let s: TestSeed;
+let pizzaAdminHeaders: Record<string, string>;
+let pizzaSupportHeaders: Record<string, string>;
+let burgerAdminHeaders: Record<string, string>;
+
+/** IDs of connectors created during tests (for cleanup) */
+const createdConnectorIds: string[] = [];
+
+function request(path: string, options?: RequestInit) {
+  return app.fetch(new Request(`http://localhost${path}`, options));
+}
+
+beforeAll(async () => {
+  s = await getTestSeed();
+  pizzaAdminHeaders = await authHeadersFor(s.pizzaAdmin);
+  pizzaSupportHeaders = await authHeadersFor(s.pizzaSupport);
+  burgerAdminHeaders = await authHeadersFor(s.burgerAdmin);
+});
+
+afterAll(async () => {
+  if (createdConnectorIds.length > 0) {
+    await forApp(async (tx) => {
+      for (const id of createdConnectorIds) {
+        // Tools are cascade-deleted by FK
+        await tx.delete(connectors).where(eq(connectors.id, id));
+      }
+    });
+  }
+});
+
+// ============================================================================
+// GET /api/connectors/catalog - List catalog
+// ============================================================================
+
+describe("GET /api/connectors/catalog", () => {
+  test("returns active catalog entries with pagination (200)", async () => {
+    const response = await request("/api/connectors/catalog", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data).toBeArray();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    expect(body.pagination).toBeDefined();
+    expect(body.pagination.page).toBe(1);
+
+    const entry = body.data[0];
+    expect(entry.id).toBeDefined();
+    expect(entry.name).toBeDefined();
+    expect(entry.slug).toBeDefined();
+    expect(entry.tools).toBeArray();
+  });
+
+  test("accessible by support role (200)", async () => {
+    const response = await request("/api/connectors/catalog", {
+      headers: pizzaSupportHeaders,
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/connectors/catalog");
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// GET /api/connectors/catalog/:catalogId - Get catalog entry
+// ============================================================================
+
+describe("GET /api/connectors/catalog/:catalogId", () => {
+  test("returns single catalog entry with tools array (200)", async () => {
+    const response = await request(`/api/connectors/catalog/${s.catalogId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.catalogId);
+    expect(body.name).toBeDefined();
+    expect(body.slug).toBeDefined();
+    expect(body.tools).toBeArray();
+    expect(body.tools.length).toBeGreaterThan(0);
+    expect(body.configSchema).toBeDefined();
+  });
+
+  test("returns 404 for non-existent catalog entry", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/catalog/${fakeId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("accessible by support role (200)", async () => {
+    const response = await request(`/api/connectors/catalog/${s.catalogId}`, {
+      headers: pizzaSupportHeaders,
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+// ============================================================================
+// POST /api/connectors - Create connector
+// ============================================================================
+
+describe("POST /api/connectors", () => {
+  test("creates connector instance (201)", async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Test Medusa Store",
+        slug: "test-medusa-store",
+        config: { baseUrl: "https://test.medusa.com" },
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+
+    expect(body.id).toBeDefined();
+    expect(body.name).toBe("Test Medusa Store");
+    expect(body.slug).toBe("test-medusa-store");
+    expect(body.connectorCatalogId).toBe(s.catalogId);
+    expect(body.isActive).toBe(true);
+    expect(body.createdAt).toBeDefined();
+
+    createdConnectorIds.push(body.id);
+  });
+
+  test("auto-creates connector_tools matching catalog tool count", async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Tool Count Test",
+        slug: "tool-count-test",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const connector = await response.json();
+    createdConnectorIds.push(connector.id);
+
+    // Get the tools
+    const toolsResponse = await request(
+      `/api/connectors/${connector.id}/tools`,
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(toolsResponse.status).toBe(200);
+    const toolsBody = await toolsResponse.json();
+
+    // Medusa has 8 tools
+    expect(toolsBody.data.length).toBe(8);
+
+    // Verify slug format
+    for (const tool of toolsBody.data) {
+      expect(tool.slug).toMatch(/^[a-z_]+$/);
+      expect(tool.isActive).toBe(true);
+    }
+  });
+
+  test("rejects duplicate slug within same org (409)", async () => {
+    // Create first
+    const first = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Duplicate Test",
+        slug: "duplicate-slug-test",
+      }),
+    });
+    expect(first.status).toBe(201);
+    const firstBody = await first.json();
+    createdConnectorIds.push(firstBody.id);
+
+    // Create second with same slug
+    const second = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Duplicate Test 2",
+        slug: "duplicate-slug-test",
+      }),
+    });
+    expect(second.status).toBe(409);
+  });
+
+  test("rejects non-existent catalog ID (404)", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: fakeId,
+        name: "Bad Catalog",
+        slug: "bad-catalog",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects support role (403)", async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaSupportHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Support Attempt",
+        slug: "support-attempt",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  test("validates required fields (422)", async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ name: "Missing fields" }),
+    });
+
+    expect(response.status).toBe(422);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "No Auth",
+        slug: "no-auth",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// GET /api/connectors - List connectors
+// ============================================================================
+
+describe("GET /api/connectors", () => {
+  test("returns org connectors with pagination (200)", async () => {
+    const response = await request("/api/connectors", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data).toBeArray();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    expect(body.pagination).toBeDefined();
+    expect(body.pagination.page).toBe(1);
+  });
+
+  test("supports pagination parameters", async () => {
+    const response = await request("/api/connectors?page=1&pageSize=5", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.pagination.pageSize).toBe(5);
+  });
+
+  test("accessible by support role (200)", async () => {
+    const response = await request("/api/connectors", {
+      headers: pizzaSupportHeaders,
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+// ============================================================================
+// GET /api/connectors/:id - Get connector
+// ============================================================================
+
+describe("GET /api/connectors/:id", () => {
+  test("returns connector details (200)", async () => {
+    const response = await request(`/api/connectors/${s.pizzaConnectorId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.pizzaConnectorId);
+    expect(body.name).toBeDefined();
+    expect(body.slug).toBeDefined();
+    expect(body.isActive).toBeDefined();
+  });
+
+  test("returns 404 for non-existent connector", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/${fakeId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// PATCH /api/connectors/:id - Update connector
+// ============================================================================
+
+describe("PATCH /api/connectors/:id", () => {
+  let updateConnectorId: string;
+
+  beforeAll(async () => {
+    const response = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Update Target",
+        slug: "update-target",
+      }),
+    });
+    const body = await response.json();
+    updateConnectorId = body.id;
+    createdConnectorIds.push(updateConnectorId);
+  });
+
+  test("updates name (200)", async () => {
+    const response = await request(`/api/connectors/${updateConnectorId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ name: "Updated Name" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.name).toBe("Updated Name");
+  });
+
+  test("updates config (200)", async () => {
+    const response = await request(`/api/connectors/${updateConnectorId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ config: { baseUrl: "https://new.url" } }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.config.baseUrl).toBe("https://new.url");
+  });
+
+  test("updates isActive (200)", async () => {
+    const response = await request(`/api/connectors/${updateConnectorId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ isActive: false }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.isActive).toBe(false);
+  });
+
+  test("rejects support role (403)", async () => {
+    const response = await request(`/api/connectors/${updateConnectorId}`, {
+      method: "PATCH",
+      headers: pizzaSupportHeaders,
+      body: JSON.stringify({ name: "Hijacked" }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  test("rejects empty body (422)", async () => {
+    const response = await request(`/api/connectors/${updateConnectorId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(422);
+  });
+
+  test("returns 404 for non-existent connector", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/${fakeId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ name: "Ghost" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// DELETE /api/connectors/:id - Delete connector
+// ============================================================================
+
+describe("DELETE /api/connectors/:id", () => {
+  test("deletes connector and cascading tools (204)", async () => {
+    const createResponse = await request("/api/connectors", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        connectorCatalogId: s.catalogId,
+        name: "Delete Target",
+        slug: "delete-target",
+      }),
+    });
+    const { id } = await createResponse.json();
+
+    // Verify tools exist
+    const toolsResponse = await request(`/api/connectors/${id}/tools`, {
+      headers: pizzaAdminHeaders,
+    });
+    const toolsBody = await toolsResponse.json();
+    expect(toolsBody.data.length).toBeGreaterThan(0);
+
+    // Delete
+    const response = await request(`/api/connectors/${id}`, {
+      method: "DELETE",
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(204);
+
+    // Verify it's gone
+    const getResponse = await request(`/api/connectors/${id}`, {
+      headers: pizzaAdminHeaders,
+    });
+    expect(getResponse.status).toBe(404);
+  });
+
+  test("returns 404 for non-existent connector", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/${fakeId}`, {
+      method: "DELETE",
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects support role (403)", async () => {
+    const response = await request(`/api/connectors/${s.pizzaConnectorId}`, {
+      method: "DELETE",
+      headers: pizzaSupportHeaders,
+    });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ============================================================================
+// GET /api/connectors/:id/tools - List tools
+// ============================================================================
+
+describe("GET /api/connectors/:id/tools", () => {
+  test("returns tools for connector (200)", async () => {
+    const response = await request(
+      `/api/connectors/${s.pizzaConnectorId}/tools`,
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data).toBeArray();
+    expect(body.data.length).toBeGreaterThan(0);
+
+    const tool = body.data[0];
+    expect(tool.id).toBeDefined();
+    expect(tool.connectorId).toBe(s.pizzaConnectorId);
+    expect(tool.name).toBeDefined();
+    expect(tool.slug).toBeDefined();
+    expect(tool.isActive).toBeDefined();
+  });
+
+  test("returns 404 for non-existent connector", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/${fakeId}/tools`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("accessible by support role (200)", async () => {
+    const response = await request(
+      `/api/connectors/${s.pizzaConnectorId}/tools`,
+      { headers: pizzaSupportHeaders },
+    );
+
+    expect(response.status).toBe(200);
+  });
+});
+
+// ============================================================================
+// PATCH /api/connectors/tools/:toolId - Update tool
+// ============================================================================
+
+describe("PATCH /api/connectors/tools/:toolId", () => {
+  let testToolId: string;
+
+  beforeAll(async () => {
+    // Get a tool from the pizza connector
+    const response = await request(
+      `/api/connectors/${s.pizzaConnectorId}/tools`,
+      { headers: pizzaAdminHeaders },
+    );
+    const body = await response.json();
+    testToolId = body.data[0].id;
+  });
+
+  test("updates isActive (200)", async () => {
+    const response = await request(`/api/connectors/tools/${testToolId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ isActive: false }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.isActive).toBe(false);
+
+    // Restore
+    await request(`/api/connectors/tools/${testToolId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ isActive: true }),
+    });
+  });
+
+  test("updates timeoutSeconds (200)", async () => {
+    const response = await request(`/api/connectors/tools/${testToolId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ timeoutSeconds: 60 }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.timeoutSeconds).toBe(60);
+  });
+
+  test("rejects empty body (422)", async () => {
+    const response = await request(`/api/connectors/tools/${testToolId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(422);
+  });
+
+  test("returns 404 for non-existent tool", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/connectors/tools/${fakeId}`, {
+      method: "PATCH",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({ isActive: true }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// RLS isolation
+// ============================================================================
+
+describe("RLS isolation", () => {
+  test("Burger Barn cannot see Pizza Palace connectors in list", async () => {
+    const response = await request("/api/connectors", {
+      headers: burgerAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    const ids = body.data.map((c: { id: string }) => c.id);
+    expect(ids).not.toContain(s.pizzaConnectorId);
+  });
+
+  test("Burger Barn cannot get Pizza Palace connector by ID (404)", async () => {
+    const response = await request(`/api/connectors/${s.pizzaConnectorId}`, {
+      headers: burgerAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("Burger Barn cannot update Pizza Palace connector (404)", async () => {
+    const response = await request(`/api/connectors/${s.pizzaConnectorId}`, {
+      method: "PATCH",
+      headers: burgerAdminHeaders,
+      body: JSON.stringify({ name: "Hijacked" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("Burger Barn cannot delete Pizza Palace connector (404)", async () => {
+    const response = await request(`/api/connectors/${s.pizzaConnectorId}`, {
+      method: "DELETE",
+      headers: burgerAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("Burger Barn cannot see Pizza Palace connector tools (404)", async () => {
+    const response = await request(
+      `/api/connectors/${s.pizzaConnectorId}/tools`,
+      { headers: burgerAdminHeaders },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/modelguide-api/tests/unit/connectors/manifest.test.ts
+++ b/modelguide-api/tests/unit/connectors/manifest.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for Medusa connector manifest
+ */
+
+import { describe, expect, test } from "bun:test";
+import medusaManifest from "@features/connectors/catalog/medusa/index";
+
+describe("Medusa manifest", () => {
+  test("has correct slug, name, and connectorType", () => {
+    expect(medusaManifest.slug).toBe("medusa");
+    expect(medusaManifest.name).toBe("Medusa");
+    expect(medusaManifest.connectorType).toBe("api");
+  });
+
+  test("has 8 tools", () => {
+    expect(medusaManifest.tools).toHaveLength(8);
+  });
+
+  test("each tool has catalog and handler", () => {
+    for (const tool of medusaManifest.tools) {
+      expect(tool.catalog).toBeDefined();
+      expect(tool.catalog.name).toBeTruthy();
+      expect(tool.catalog.description).toBeTruthy();
+      expect(tool.catalog.inputSchema).toBeDefined();
+      expect(typeof tool.catalog.defaultRequiresConfirmation).toBe("boolean");
+      expect(typeof tool.catalog.defaultTimeoutSeconds).toBe("number");
+      expect(tool.handler).toBeDefined();
+      expect(typeof tool.handler).toBe("function");
+    }
+  });
+
+  test("all handler functions are async", async () => {
+    for (const tool of medusaManifest.tools) {
+      const result = tool.handler({
+        config: {},
+        input: {},
+        organizationId: "test-org",
+        connectorId: "test-connector",
+      });
+      // Async functions return promises
+      expect(result).toBeInstanceOf(Promise);
+      const resolved = await result;
+      expect(resolved.success).toBe(true);
+    }
+  });
+
+  test("configSchema has required fields", () => {
+    expect(medusaManifest.configSchema.baseUrl).toBeDefined();
+    expect(medusaManifest.configSchema.baseUrl.required).toBe(true);
+    expect(medusaManifest.configSchema.baseUrl.type).toBe("string");
+
+    expect(medusaManifest.configSchema.apiToken).toBeDefined();
+    expect(medusaManifest.configSchema.apiToken.required).toBe(true);
+    expect(medusaManifest.configSchema.apiToken.type).toBe("secret");
+  });
+
+  test("tool names match expected set", () => {
+    const toolNames = medusaManifest.tools.map((t) => t.catalog.name);
+    expect(toolNames).toContain("Add to Cart");
+    expect(toolNames).toContain("Get Cart");
+    expect(toolNames).toContain("Create Draft Order");
+    expect(toolNames).toContain("Set Delivery Address");
+    expect(toolNames).toContain("Confirm Order");
+    expect(toolNames).toContain("Get Order");
+    expect(toolNames).toContain("Update Order Address");
+    expect(toolNames).toContain("Cancel Order");
+  });
+});

--- a/modelguide-api/tests/unit/connectors/registry.test.ts
+++ b/modelguide-api/tests/unit/connectors/registry.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit tests for connector registry
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  getAllManifests,
+  getConnectorManifest,
+  loadAllManifests,
+} from "@features/connectors/catalog/registry";
+
+describe("Connector registry", () => {
+  test("loadAllManifests returns expected count", async () => {
+    const manifests = await loadAllManifests();
+    expect(manifests.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("getConnectorManifest('medusa') returns the manifest", () => {
+    const manifest = getConnectorManifest("medusa");
+    expect(manifest).toBeDefined();
+    expect(manifest!.slug).toBe("medusa");
+    expect(manifest!.name).toBe("Medusa");
+  });
+
+  test("getConnectorManifest('nonexistent') returns undefined", () => {
+    const manifest = getConnectorManifest("nonexistent");
+    expect(manifest).toBeUndefined();
+  });
+
+  test("getAllManifests returns all loaded manifests", () => {
+    const manifests = getAllManifests();
+    expect(manifests.length).toBeGreaterThanOrEqual(1);
+    const slugs = manifests.map((m) => m.slug);
+    expect(slugs).toContain("medusa");
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces a **code-first connector module system** where each connector is a TypeScript module with a manifest (metadata) and executable tool handlers (in-memory only, never serialized to DB)
- Implements the **Medusa e-commerce connector** with 8 tools (Add to Cart, Get Cart, Create Draft Order, Set Delivery Address, Confirm Order, Get Order, Update Order Address, Cancel Order) — stub handlers for now, real HTTP calls in Phase 7
- Adds **in-memory registry** (`Map<slug, ConnectorManifest>`) for O(1) tool lookup during MCP execution
- Adds **CLI sync script** (`bun run sync:connectors`) that upserts manifests into `connectors_catalog` and deactivates stale entries
- Adds **9 REST API endpoints** for catalog browsing, connector CRUD, and tool management — all with OpenAPI docs, Zod validation, and RBAC
- **Auto-creates `connector_tools`** rows from catalog templates when a connector instance is created
- Full **RLS isolation** — connectors and tools are scoped to organizations

## New files

| File | Purpose |
|------|---------|
| `src/features/connectors/catalog/types.ts` | Shared interfaces (`ConnectorManifest`, `ToolExecutionContext`, etc.) |
| `src/features/connectors/catalog/medusa/index.ts` | Medusa manifest + 8 stub tool handlers |
| `src/features/connectors/catalog/registry.ts` | In-memory registry with static imports |
| `src/features/connectors/catalog/sync.ts` | CLI sync script for DB upsert |
| `src/features/connectors/connectors.service.ts` | Business logic (catalog queries, connector/tool CRUD) |
| `src/features/connectors/connectors.routes.ts` | 9 OpenAPI routes with middleware |
| `src/features/connectors/index.ts` | Feature barrel exports |
| `tests/integration/connectors.test.ts` | 39 integration tests |
| `tests/unit/connectors/manifest.test.ts` | Manifest structure tests |
| `tests/unit/connectors/registry.test.ts` | Registry load/lookup tests |

## API endpoints

| Method | Path | Permission |
|--------|------|-----------|
| `GET` | `/api/connectors/catalog` | `connectors:read` |
| `GET` | `/api/connectors/catalog/:catalogId` | `connectors:read` |
| `GET` | `/api/connectors` | `connectors:read` |
| `POST` | `/api/connectors` | `connectors:create` |
| `GET` | `/api/connectors/:id` | `connectors:read` |
| `PATCH` | `/api/connectors/:id` | `connectors:update` |
| `DELETE` | `/api/connectors/:id` | `connectors:delete` |
| `GET` | `/api/connectors/:id/tools` | `tools:read` |
| `PATCH` | `/api/connectors/tools/:toolId` | `connectors:update` |

## Test plan

- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] 96 unit tests pass (including new manifest + registry tests)
- [x] 164 integration tests pass (including 39 new connector tests)
- [ ] Smoke test: `GET /api/connectors/catalog` returns Medusa entry
- [ ] Smoke test: `POST /api/connectors` with catalog ID → 201 with auto-created tools
- [ ] Smoke test: `GET /api/connectors/:id/tools` → 8 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)