### PR TITLE
Add Sessions REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ drizzle/meta/
 # Claude Code
 .claude/settings.local.json
 .claude/local/
+
+# TanStack Router
+.tanstack/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,25 +45,40 @@ Do not create ADRs for routine feature work — only for decisions where "why" m
 ## Commands
 
 ```bash
-# Development
-make install          # Install dependencies
-make db-up            # Start PostgreSQL container (port 5434)
-make dev              # Start dev server with hot reload (port 3000)
+# Setup
+cp modelguide-api/.env.example modelguide-api/.env  # Create local env config
+
+# API
+make api-install              # Install API dependencies
+make api-dev                  # Start API dev server with hot reload (port 3000)
+make api-build                # Build API for production
+make api-start                # Run API production build
+make api-test                 # Run all API tests
+make api-test-unit            # Run API unit tests
+make api-test-integration     # Run API integration tests (requires Docker)
+make api-typecheck            # TypeScript type checking
+make api-lint                 # Lint with auto-fix
+make api-lint-check           # Lint check only
+
+# UI
+make ui-install               # Install UI dependencies
+make ui-dev                   # Start UI dev server (port 3001)
+make ui-test                  # Run UI tests
+make ui-typecheck             # TypeScript type checking
+make ui-lint                  # Lint UI code
 
 # Database
-make db-generate      # Generate Drizzle migrations (always use: drizzle-kit generate --name <descriptive-name>)
-make db-migrate       # Run migrations
-make db-push          # Push schema changes (dev only)
-make db-studio        # Open Drizzle Studio
+make db-up                    # Start PostgreSQL container (port 5434)
+make db-down                  # Stop PostgreSQL container
+make db-generate              # Generate Drizzle migrations (always use: drizzle-kit generate --name <descriptive-name>)
+make db-migrate               # Run migrations
+make db-push                  # Push schema changes (dev only)
+make db-studio                # Open Drizzle Studio
+make db-seed                  # Seed database with test data
 
-# Production
-make build            # Build for production
-make start            # Run production build
-
-# Utilities
-make db-down          # Stop PostgreSQL
-make reset            # Stop containers and remove volumes
-make logs             # View container logs
+# General
+make reset                    # Stop containers and remove volumes
+make logs                     # View container logs
 ```
 
 ## Architecture

--- a/modelguide-api/drizzle/0005_session_message_sequence_unique.sql
+++ b/modelguide-api/drizzle/0005_session_message_sequence_unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "session_messages_sequence_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "session_messages_session_sequence_unique" ON "session_messages" USING btree ("session_id","sequence_number");--> statement-breakpoint

--- a/modelguide-api/drizzle/meta/_journal.json
+++ b/modelguide-api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770414792944,
       "tag": "0004_wealthy_wrecker",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1770414800000,
+      "tag": "0005_session_message_sequence_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/modelguide-api/src/app.ts
+++ b/modelguide-api/src/app.ts
@@ -6,6 +6,7 @@ import { agentRoutes } from "@features/agents";
 import { connectorRoutes } from "@features/connectors";
 import { organizationRoutes } from "@features/organizations";
 import { secretsRoutes } from "@features/secrets";
+import { sessionRoutes } from "@features/sessions";
 import { authRoutes, userRoutes } from "@features/users";
 import { createApp, createRouter } from "@lib/create-app";
 
@@ -46,6 +47,7 @@ apiRouter.route("/auth", authRoutes);
 apiRouter.route("/connectors", connectorRoutes);
 apiRouter.route("/organizations", organizationRoutes);
 apiRouter.route("/secrets", secretsRoutes);
+apiRouter.route("/sessions", sessionRoutes);
 apiRouter.route("/users", userRoutes);
 
 const app = createApp();

--- a/modelguide-api/src/db/schema/core.ts
+++ b/modelguide-api/src/db/schema/core.ts
@@ -566,7 +566,7 @@ export const sessionMessages = pgTable(
   },
   (table) => [
     index("session_messages_session_idx").on(table.sessionId),
-    index("session_messages_sequence_idx").on(
+    uniqueIndex("session_messages_session_sequence_unique").on(
       table.sessionId,
       table.sequenceNumber,
     ),

--- a/modelguide-api/src/features/sessions/index.ts
+++ b/modelguide-api/src/features/sessions/index.ts
@@ -1,0 +1,8 @@
+export { default as sessionRoutes } from "./sessions.routes";
+export {
+  listSessions,
+  getSessionById,
+  createSession,
+  updateSession,
+  addMessage,
+} from "./sessions.service";

--- a/modelguide-api/src/features/sessions/sessions.routes.ts
+++ b/modelguide-api/src/features/sessions/sessions.routes.ts
@@ -1,0 +1,576 @@
+/**
+ * Session management routes
+ */
+
+import type { Session, SessionFeedback, SessionMessage } from "@db/schema";
+import { createRoute, z } from "@hono/zod-openapi";
+import { createRouter } from "@lib/create-app";
+import {
+  getCurrentAgent,
+  getOrganizationId,
+  requireAgent,
+  requireOrganization,
+  requirePermission,
+  requireUser,
+} from "@lib/middleware";
+import { paginatedResponseSchema, paginationSchema } from "@lib/pagination";
+import { errorResponseSchema } from "@lib/schemas";
+import {
+  addMessage,
+  createSession,
+  getSessionById,
+  listSessions,
+  updateSession,
+} from "./sessions.service";
+
+const router = createRouter();
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const agentSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+});
+
+const feedbackSummarySchema = z.object({
+  hasFeedback: z.boolean(),
+});
+
+const sessionResponseSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  agentId: z.string().uuid(),
+  externalId: z.string().nullable(),
+  channelType: z.string(),
+  userIdentifier: z.string().nullable(),
+  userMetadata: z.record(z.unknown()),
+  status: z.enum(["active", "completed", "escalated", "abandoned"]),
+  escalationRef: z.string().nullable(),
+  startedAt: z.string(),
+  endedAt: z.string().nullable(),
+  metadata: z.record(z.unknown()),
+  agent: agentSummarySchema,
+  messageCount: z.number(),
+  durationSeconds: z.number().nullable(),
+  feedbackSummary: feedbackSummarySchema,
+});
+
+const messageResponseSchema = z.object({
+  id: z.string().uuid(),
+  sessionId: z.string().uuid(),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string().nullable(),
+  audioUrl: z.string().nullable(),
+  audioDurationMs: z.number().nullable(),
+  toolCallId: z.string().nullable(),
+  toolName: z.string().nullable(),
+  toolInput: z.record(z.unknown()).nullable(),
+  toolOutput: z.record(z.unknown()).nullable(),
+  modelUsed: z.string().nullable(),
+  tokensUsed: z.number().nullable(),
+  latencyMs: z.number().nullable(),
+  sequenceNumber: z.number(),
+  createdAt: z.string(),
+});
+
+const feedbackResponseSchema = z.object({
+  id: z.string().uuid(),
+  sessionId: z.string().uuid(),
+  messageId: z.string().uuid().nullable(),
+  rating: z.number(),
+  comment: z.string().nullable(),
+  feedbackSource: z.enum(["customer", "support", "system"]),
+  feedbackRef: z.string().nullable(),
+  feedbackTags: z.array(z.string()).nullable(),
+  userIdentifier: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const sessionDetailSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  agentId: z.string().uuid(),
+  externalId: z.string().nullable(),
+  channelType: z.string(),
+  userIdentifier: z.string().nullable(),
+  userMetadata: z.record(z.unknown()),
+  status: z.enum(["active", "completed", "escalated", "abandoned"]),
+  escalationRef: z.string().nullable(),
+  startedAt: z.string(),
+  endedAt: z.string().nullable(),
+  metadata: z.record(z.unknown()),
+  agent: agentSummarySchema,
+  durationSeconds: z.number().nullable(),
+  messages: z.array(messageResponseSchema),
+  feedback: z.array(feedbackResponseSchema),
+});
+
+const createSessionSchema = z.object({
+  externalId: z.string().max(255).optional().openapi({
+    description: "External reference ID",
+  }),
+  channelType: z
+    .enum([
+      "voice",
+      "web",
+      "api",
+      "slack",
+      "widget",
+      "sms",
+      "whatsapp",
+      "email",
+    ])
+    .openapi({ example: "voice" }),
+  userIdentifier: z.string().max(255).openapi({
+    description: "Customer identifier",
+    example: "+1234567890",
+  }),
+  userMetadata: z.record(z.unknown()).optional().openapi({
+    description: "Additional customer metadata",
+  }),
+});
+
+const updateSessionSchema = z
+  .object({
+    status: z
+      .enum(["completed", "escalated", "abandoned"])
+      .optional()
+      .openapi({ description: "New session status (terminal)" }),
+    escalationRef: z
+      .string()
+      .max(255)
+      .optional()
+      .openapi({ description: "Escalation reference" }),
+  })
+  .refine(
+    (data) => data.status !== undefined || data.escalationRef !== undefined,
+    {
+      message: "At least one of 'status' or 'escalationRef' must be provided",
+    },
+  );
+
+const createMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]).openapi({ example: "user" }),
+  content: z.string().optional().openapi({
+    description: "Message text content",
+    example: "I'd like to order a large pepperoni pizza",
+  }),
+  audioUrl: z.string().url().optional().openapi({
+    description: "URL to audio recording",
+  }),
+  toolCalls: z
+    .array(
+      z.object({
+        toolCallId: z.string(),
+        toolName: z.string(),
+        toolInput: z.record(z.unknown()).optional(),
+        toolOutput: z.record(z.unknown()).optional(),
+      }),
+    )
+    .optional()
+    .openapi({ description: "Tool calls for assistant messages" }),
+});
+
+const sessionFiltersSchema = paginationSchema.extend({
+  agentId: z.string().uuid().optional().openapi({
+    description: "Filter by agent ID",
+  }),
+  status: z
+    .enum(["active", "completed", "escalated", "abandoned"])
+    .optional()
+    .openapi({ description: "Filter by status" }),
+  channelType: z
+    .enum([
+      "voice",
+      "web",
+      "api",
+      "slack",
+      "widget",
+      "sms",
+      "whatsapp",
+      "email",
+    ])
+    .optional()
+    .openapi({ description: "Filter by channel type" }),
+  hasFeedback: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true"))
+    .openapi({ description: "Filter by feedback presence" }),
+  startedAfter: z.string().datetime().optional().openapi({
+    description: "Sessions started after this ISO timestamp",
+  }),
+  startedBefore: z.string().datetime().optional().openapi({
+    description: "Sessions started before this ISO timestamp",
+  }),
+  sortBy: z
+    .enum(["started_at", "ended_at", "status"])
+    .optional()
+    .openapi({ description: "Sort field" }),
+  sortOrder: z
+    .enum(["asc", "desc"])
+    .optional()
+    .openapi({ description: "Sort direction" }),
+});
+
+const sessionIdParams = z.object({
+  id: z.string().uuid().openapi({
+    description: "Session ID",
+  }),
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function errorResponse(description: string) {
+  return {
+    description,
+    content: { "application/json": { schema: errorResponseSchema } },
+  };
+}
+
+function formatSession(
+  session: Session & {
+    agent: { id: string; name: string };
+    messageCount: number;
+    durationSeconds: number | null;
+    feedbackSummary: { hasFeedback: boolean };
+  },
+) {
+  return {
+    id: session.id,
+    organizationId: session.organizationId,
+    agentId: session.agentId,
+    externalId: session.externalId,
+    channelType: session.channelType,
+    userIdentifier: session.userIdentifier,
+    userMetadata: session.userMetadata ?? {},
+    status: session.status,
+    escalationRef: session.escalationRef,
+    startedAt: session.startedAt.toISOString(),
+    endedAt: session.endedAt?.toISOString() ?? null,
+    metadata: session.metadata ?? {},
+    agent: session.agent,
+    messageCount: session.messageCount,
+    durationSeconds: session.durationSeconds,
+    feedbackSummary: session.feedbackSummary,
+  };
+}
+
+function formatSessionDetail(
+  session: Session & {
+    agent: { id: string; name: string };
+    durationSeconds: number | null;
+    messages: SessionMessage[];
+    feedback: SessionFeedback[];
+  },
+) {
+  return {
+    id: session.id,
+    organizationId: session.organizationId,
+    agentId: session.agentId,
+    externalId: session.externalId,
+    channelType: session.channelType,
+    userIdentifier: session.userIdentifier,
+    userMetadata: session.userMetadata ?? {},
+    status: session.status,
+    escalationRef: session.escalationRef,
+    startedAt: session.startedAt.toISOString(),
+    endedAt: session.endedAt?.toISOString() ?? null,
+    metadata: session.metadata ?? {},
+    agent: session.agent,
+    durationSeconds: session.durationSeconds,
+    messages: session.messages.map(formatMessage),
+    feedback: session.feedback.map(formatFeedback),
+  };
+}
+
+function formatMessage(message: SessionMessage) {
+  return {
+    id: message.id,
+    sessionId: message.sessionId,
+    role: message.role,
+    content: message.content,
+    audioUrl: message.audioUrl,
+    audioDurationMs: message.audioDurationMs,
+    toolCallId: message.toolCallId,
+    toolName: message.toolName,
+    toolInput: message.toolInput ?? null,
+    toolOutput: message.toolOutput ?? null,
+    modelUsed: message.modelUsed,
+    tokensUsed: message.tokensUsed,
+    latencyMs: message.latencyMs,
+    sequenceNumber: message.sequenceNumber,
+    createdAt: message.createdAt.toISOString(),
+  };
+}
+
+function formatFeedback(feedback: SessionFeedback) {
+  return {
+    id: feedback.id,
+    sessionId: feedback.sessionId,
+    messageId: feedback.messageId,
+    rating: feedback.rating,
+    comment: feedback.comment,
+    feedbackSource: feedback.feedbackSource,
+    feedbackRef: feedback.feedbackRef,
+    feedbackTags: feedback.feedbackTags,
+    userIdentifier: feedback.userIdentifier,
+    createdAt: feedback.createdAt.toISOString(),
+  };
+}
+
+function formatCreatedSession(session: Session) {
+  return {
+    id: session.id,
+    organizationId: session.organizationId,
+    agentId: session.agentId,
+    externalId: session.externalId,
+    channelType: session.channelType,
+    userIdentifier: session.userIdentifier,
+    userMetadata: session.userMetadata ?? {},
+    status: session.status,
+    escalationRef: session.escalationRef,
+    startedAt: session.startedAt.toISOString(),
+    endedAt: session.endedAt?.toISOString() ?? null,
+    metadata: session.metadata ?? {},
+  };
+}
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+// GET / — List sessions (User auth)
+router.get(
+  "/",
+  requireUser(),
+  requirePermission("sessions:read"),
+  requireOrganization(),
+);
+
+const listSessionsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Sessions"],
+  summary: "List sessions",
+  description:
+    "Returns paginated list of sessions with filters. Includes agent info, message count, and feedback summary.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: sessionFiltersSchema,
+  },
+  responses: {
+    200: {
+      description: "Paginated list of sessions",
+      content: {
+        "application/json": {
+          schema: paginatedResponseSchema(sessionResponseSchema),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+  },
+});
+
+router.openapi(listSessionsRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const query = c.req.valid("query");
+  const result = await listSessions(orgId, query);
+
+  return c.json(
+    {
+      data: result.data.map(formatSession),
+      pagination: result.pagination,
+    },
+    200,
+  );
+});
+
+// GET /:id — Session detail (User auth)
+router.get(
+  "/:id",
+  requireUser(),
+  requirePermission("sessions:read"),
+  requireOrganization(),
+);
+
+const getSessionRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Sessions"],
+  summary: "Get session detail",
+  description: "Returns a single session with messages and feedback.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: sessionIdParams,
+  },
+  responses: {
+    200: {
+      description: "Session detail with messages and feedback",
+      content: {
+        "application/json": { schema: sessionDetailSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Session not found"),
+  },
+});
+
+router.openapi(getSessionRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const { id } = c.req.valid("param");
+  const session = await getSessionById(orgId, id);
+
+  return c.json(formatSessionDetail(session), 200);
+});
+
+// POST / — Create session (Agent auth)
+router.post("/", requireAgent(), requireOrganization());
+
+const createSessionRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Sessions"],
+  summary: "Create session",
+  description:
+    "Creates a new session for the authenticated agent. Sets status to active.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: createSessionSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Session created",
+      content: {
+        "application/json": {
+          schema: sessionResponseSchema.omit({
+            agent: true,
+            messageCount: true,
+            durationSeconds: true,
+            feedbackSummary: true,
+          }),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(createSessionRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const body = c.req.valid("json");
+  const session = await createSession(orgId, agent.id, body);
+
+  return c.json(formatCreatedSession(session), 201);
+});
+
+// PATCH /:id — Update session (Agent auth)
+router.patch("/:id", requireAgent(), requireOrganization());
+
+const updateSessionRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["Sessions"],
+  summary: "Update session",
+  description:
+    "Updates session status or escalation ref. Only allows transitions from active to terminal states.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: sessionIdParams,
+    body: {
+      content: {
+        "application/json": { schema: updateSessionSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Session updated",
+      content: {
+        "application/json": {
+          schema: sessionResponseSchema.omit({
+            agent: true,
+            messageCount: true,
+            durationSeconds: true,
+            feedbackSummary: true,
+          }),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    404: errorResponse("Session not found"),
+    409: errorResponse("Session already ended"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(updateSessionRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const session = await updateSession(orgId, id, agent.id, body);
+
+  return c.json(formatCreatedSession(session), 200);
+});
+
+// POST /:id/messages — Add message (Agent auth)
+router.post("/:id/messages", requireAgent(), requireOrganization());
+
+const addMessageRoute = createRoute({
+  method: "post",
+  path: "/{id}/messages",
+  tags: ["Sessions"],
+  summary: "Add message",
+  description:
+    "Adds a message to an active session. Auto-increments sequence number. If role is assistant with toolCalls, creates tool messages.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: sessionIdParams,
+    body: {
+      content: {
+        "application/json": { schema: createMessageSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Message(s) created",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.array(messageResponseSchema),
+          }),
+        },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    404: errorResponse("Session not found"),
+    409: errorResponse("Session already ended"),
+    422: errorResponse("Validation error"),
+  },
+});
+
+router.openapi(addMessageRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const messages = await addMessage(orgId, id, agent.id, body);
+
+  return c.json({ data: messages.map(formatMessage) }, 201);
+});
+
+export default router;

--- a/modelguide-api/src/features/sessions/sessions.service.ts
+++ b/modelguide-api/src/features/sessions/sessions.service.ts
@@ -1,0 +1,418 @@
+/**
+ * Sessions service - business logic for session and message management
+ */
+
+import { db } from "@db/client";
+import { forOrg } from "@db/rls";
+import { agents, sessionFeedback, sessionMessages, sessions } from "@db/schema";
+import { Errors } from "@lib/errors";
+import {
+  type PaginationParams,
+  buildPaginationMeta,
+  getOffset,
+} from "@lib/pagination";
+import { and, asc, count, desc, eq, gt, gte, lte, max, sql } from "drizzle-orm";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SessionFilters extends PaginationParams {
+  agentId?: string;
+  status?: string;
+  channelType?: string;
+  hasFeedback?: boolean;
+  startedAfter?: string;
+  startedBefore?: string;
+  sortBy?: "started_at" | "ended_at" | "status";
+  sortOrder?: "asc" | "desc";
+}
+
+const TERMINAL_STATUSES = ["completed", "escalated", "abandoned"] as const;
+
+// ============================================================================
+// Session queries (RLS via forOrg)
+// ============================================================================
+
+export async function listSessions(orgId: string, filters: SessionFilters) {
+  const { page, pageSize } = filters;
+  const offset = getOffset(page, pageSize);
+
+  return forOrg(orgId, async (tx) => {
+    // Build where conditions
+    const conditions = [];
+
+    if (filters.agentId) {
+      conditions.push(eq(sessions.agentId, filters.agentId));
+    }
+    if (filters.status) {
+      conditions.push(
+        eq(
+          sessions.status,
+          filters.status as (typeof sessions.status.enumValues)[number],
+        ),
+      );
+    }
+    if (filters.channelType) {
+      conditions.push(
+        eq(
+          sessions.channelType,
+          filters.channelType as (typeof sessions.channelType.enumValues)[number],
+        ),
+      );
+    }
+    if (filters.startedAfter) {
+      conditions.push(gte(sessions.startedAt, new Date(filters.startedAfter)));
+    }
+    if (filters.startedBefore) {
+      conditions.push(lte(sessions.startedAt, new Date(filters.startedBefore)));
+    }
+
+    // Determine sort
+    const sortColumn =
+      filters.sortBy === "ended_at"
+        ? sessions.endedAt
+        : filters.sortBy === "status"
+          ? sessions.status
+          : sessions.startedAt;
+    const sortDir = filters.sortOrder === "asc" ? asc : desc;
+
+    // Message count subquery
+    const messageCountSq = db
+      .select({
+        sessionId: sessionMessages.sessionId,
+        messageCount: count().as("message_count"),
+      })
+      .from(sessionMessages)
+      .groupBy(sessionMessages.sessionId)
+      .as("msg_counts");
+
+    // Feedback summary subquery
+    const feedbackSq = db
+      .select({
+        sessionId: sessionFeedback.sessionId,
+        feedbackCount: count().as("feedback_count"),
+      })
+      .from(sessionFeedback)
+      .groupBy(sessionFeedback.sessionId)
+      .as("fb_counts");
+
+    // Build base query for data
+    let dataQuery = tx
+      .select({
+        session: sessions,
+        agentName: agents.name,
+        messageCount:
+          sql<number>`coalesce(${messageCountSq.messageCount}, 0)`.as(
+            "msg_count",
+          ),
+        feedbackCount: sql<number>`coalesce(${feedbackSq.feedbackCount}, 0)`.as(
+          "fb_count",
+        ),
+      })
+      .from(sessions)
+      .leftJoin(agents, eq(sessions.agentId, agents.id))
+      .leftJoin(messageCountSq, eq(sessions.id, messageCountSq.sessionId))
+      .leftJoin(feedbackSq, eq(sessions.id, feedbackSq.sessionId));
+
+    // Apply hasFeedback filter
+    if (filters.hasFeedback === true) {
+      conditions.push(gt(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
+    } else if (filters.hasFeedback === false) {
+      conditions.push(eq(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
+    }
+
+    const finalWhere = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Count query
+    const countQuery = tx
+      .select({ total: count() })
+      .from(sessions)
+      .leftJoin(feedbackSq, eq(sessions.id, feedbackSq.sessionId));
+
+    if (finalWhere) {
+      dataQuery = dataQuery.where(finalWhere) as typeof dataQuery;
+      countQuery.where(finalWhere);
+    }
+
+    const [items, [{ total }]] = await Promise.all([
+      dataQuery.orderBy(sortDir(sortColumn)).limit(pageSize).offset(offset),
+      countQuery,
+    ]);
+
+    const data = items.map((row) => ({
+      ...row.session,
+      agent: { id: row.session.agentId, name: row.agentName ?? "Unknown" },
+      messageCount: Number(row.messageCount),
+      durationSeconds: computeDuration(
+        row.session.startedAt,
+        row.session.endedAt,
+      ),
+      feedbackSummary: {
+        hasFeedback: Number(row.feedbackCount) > 0,
+      },
+    }));
+
+    return {
+      data,
+      pagination: buildPaginationMeta(page, pageSize, total),
+    };
+  });
+}
+
+export async function getSessionById(orgId: string, sessionId: string) {
+  return forOrg(orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        session: sessions,
+        agentName: agents.name,
+      })
+      .from(sessions)
+      .leftJoin(agents, eq(sessions.agentId, agents.id))
+      .where(eq(sessions.id, sessionId));
+
+    if (!row) {
+      throw Errors.sessionNotFound(sessionId);
+    }
+
+    const [messages, feedback] = await Promise.all([
+      tx
+        .select()
+        .from(sessionMessages)
+        .where(eq(sessionMessages.sessionId, sessionId))
+        .orderBy(asc(sessionMessages.sequenceNumber)),
+      tx
+        .select()
+        .from(sessionFeedback)
+        .where(eq(sessionFeedback.sessionId, sessionId))
+        .orderBy(asc(sessionFeedback.createdAt)),
+    ]);
+
+    return {
+      ...row.session,
+      agent: { id: row.session.agentId, name: row.agentName ?? "Unknown" },
+      durationSeconds: computeDuration(
+        row.session.startedAt,
+        row.session.endedAt,
+      ),
+      messages,
+      feedback,
+    };
+  });
+}
+
+export async function createSession(
+  orgId: string,
+  agentId: string,
+  data: {
+    externalId?: string;
+    channelType: string;
+    userIdentifier: string;
+    userMetadata?: Record<string, unknown>;
+  },
+) {
+  return forOrg(orgId, async (tx) => {
+    // Validate agent exists and belongs to org
+    const [agent] = await tx
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+
+    if (!agent) {
+      throw Errors.agentNotFound(agentId);
+    }
+
+    const [session] = await tx
+      .insert(sessions)
+      .values({
+        organizationId: orgId,
+        agentId,
+        externalId: data.externalId,
+        channelType:
+          data.channelType as (typeof sessions.channelType.enumValues)[number],
+        userIdentifier: data.userIdentifier,
+        userMetadata: data.userMetadata ?? {},
+        status: "active",
+        startedAt: new Date(),
+      })
+      .returning();
+
+    return session;
+  });
+}
+
+export async function updateSession(
+  orgId: string,
+  sessionId: string,
+  agentId: string,
+  data: {
+    status?: string;
+    escalationRef?: string;
+  },
+) {
+  return forOrg(orgId, async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(sessions)
+      .where(and(eq(sessions.id, sessionId), eq(sessions.agentId, agentId)));
+
+    if (!existing) {
+      throw Errors.sessionNotFound(sessionId);
+    }
+
+    // Check if session is already in a terminal state
+    if (
+      TERMINAL_STATUSES.includes(
+        existing.status as (typeof TERMINAL_STATUSES)[number],
+      )
+    ) {
+      throw Errors.sessionAlreadyEnded(sessionId);
+    }
+
+    const updateData: Partial<typeof sessions.$inferInsert> = {};
+
+    if (data.status) {
+      // Only allow transitions from active to terminal states
+      if (
+        !TERMINAL_STATUSES.includes(
+          data.status as (typeof TERMINAL_STATUSES)[number],
+        )
+      ) {
+        throw Errors.validationError(
+          `Invalid status transition. Allowed: ${TERMINAL_STATUSES.join(", ")}`,
+        );
+      }
+      updateData.status = data.status as typeof sessions.$inferInsert.status;
+      updateData.endedAt = new Date();
+    }
+
+    if (data.escalationRef !== undefined) {
+      updateData.escalationRef = data.escalationRef;
+    }
+
+    const [updated] = await tx
+      .update(sessions)
+      .set(updateData)
+      .where(eq(sessions.id, sessionId))
+      .returning();
+
+    return updated;
+  });
+}
+
+export async function addMessage(
+  orgId: string,
+  sessionId: string,
+  agentId: string,
+  data: {
+    role: string;
+    content?: string;
+    audioUrl?: string;
+    toolCalls?: Array<{
+      toolCallId: string;
+      toolName: string;
+      toolInput?: Record<string, unknown>;
+      toolOutput?: Record<string, unknown>;
+    }>;
+  },
+) {
+  const maxAttempts = 3;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await forOrg(orgId, async (tx) => {
+        // Validate session exists and belongs to agent
+        const [session] = await tx
+          .select()
+          .from(sessions)
+          .where(
+            and(eq(sessions.id, sessionId), eq(sessions.agentId, agentId)),
+          );
+
+        if (!session) {
+          throw Errors.sessionNotFound(sessionId);
+        }
+
+        if (
+          TERMINAL_STATUSES.includes(
+            session.status as (typeof TERMINAL_STATUSES)[number],
+          )
+        ) {
+          throw Errors.sessionAlreadyEnded(sessionId);
+        }
+
+        // Get the current max sequence number
+        const [maxSeq] = await tx
+          .select({ max: max(sessionMessages.sequenceNumber) })
+          .from(sessionMessages)
+          .where(eq(sessionMessages.sessionId, sessionId));
+
+        let nextSequence = (maxSeq?.max ?? 0) + 1;
+
+        const createdMessages = [];
+
+        // Insert the main message
+        const [mainMessage] = await tx
+          .insert(sessionMessages)
+          .values({
+            sessionId,
+            role: data.role as (typeof sessionMessages.role.enumValues)[number],
+            content: data.content ?? null,
+            audioUrl: data.audioUrl ?? null,
+            sequenceNumber: nextSequence,
+          })
+          .returning();
+
+        createdMessages.push(mainMessage);
+        nextSequence++;
+
+        // If assistant message has tool calls, create tool messages
+        if (data.role === "assistant" && data.toolCalls?.length) {
+          for (const toolCall of data.toolCalls) {
+            const [toolMessage] = await tx
+              .insert(sessionMessages)
+              .values({
+                sessionId,
+                role: "tool",
+                content: null,
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                toolInput: toolCall.toolInput ?? null,
+                toolOutput: toolCall.toolOutput ?? null,
+                sequenceNumber: nextSequence,
+              })
+              .returning();
+
+            createdMessages.push(toolMessage);
+            nextSequence++;
+          }
+        }
+
+        return createdMessages;
+      });
+    } catch (error: unknown) {
+      if (isSequenceConflict(error) && attempt < maxAttempts - 1) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error("Failed to add message after retries.");
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function computeDuration(startedAt: Date, endedAt: Date | null): number | null {
+  if (!endedAt) return null;
+  return Math.round((endedAt.getTime() - startedAt.getTime()) / 1000);
+}
+
+function isSequenceConflict(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as Error & { code?: string }).code;
+  if (code !== "23505") return false;
+  return error.message.includes("session_messages_session_sequence_unique");
+}

--- a/modelguide-api/tests/helpers/seed.ts
+++ b/modelguide-api/tests/helpers/seed.ts
@@ -8,11 +8,13 @@ import type { AuthUser } from "@/types";
 import { forApp } from "@db/rls";
 import {
   agents,
+  apiKeys,
   connectors,
   connectorsCatalog,
   organizations,
   users,
 } from "@db/schema";
+import { generateApiKey } from "@lib/crypto";
 import { generateJWT } from "@lib/jwt";
 import { and, eq } from "drizzle-orm";
 
@@ -176,4 +178,41 @@ export async function authHeadersFor(
   };
   const jwt = await generateJWT(authUser);
   return { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" };
+}
+
+/**
+ * Cache of generated agent API keys (agentId → raw key).
+ * We create a fresh API key per agent since raw keys are not stored in DB.
+ */
+const _agentKeyCache = new Map<string, string>();
+
+/** Build Authorization + Content-Type headers for an agent (API key auth). */
+export async function agentHeadersFor(
+  agentId: string,
+  organizationId: string,
+): Promise<Record<string, string>> {
+  let rawKey = _agentKeyCache.get(agentId);
+
+  if (!rawKey) {
+    const generated = generateApiKey();
+    rawKey = generated.key;
+
+    await forApp(async (tx) => {
+      await tx.insert(apiKeys).values({
+        organizationId,
+        agentId,
+        name: `test-key-${agentId.slice(0, 8)}`,
+        keyHash: generated.hash,
+        keyPrefix: generated.prefix,
+        isActive: true,
+      });
+    });
+
+    _agentKeyCache.set(agentId, rawKey);
+  }
+
+  return {
+    Authorization: `Bearer ${rawKey}`,
+    "Content-Type": "application/json",
+  };
 }

--- a/modelguide-api/tests/integration/sessions.test.ts
+++ b/modelguide-api/tests/integration/sessions.test.ts
@@ -1,0 +1,668 @@
+/**
+ * Integration tests for Sessions API
+ * Tests the full HTTP request/response cycle with RLS isolation
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import app from "@/app";
+import { forApp } from "@db/rls";
+import { sessions } from "@db/schema";
+import { eq } from "drizzle-orm";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
+
+let s: TestSeed;
+let pizzaAdminHeaders: Record<string, string>;
+let burgerAdminHeaders: Record<string, string>;
+let pizzaAgentHeaders: Record<string, string>;
+let burgerAgentHeaders: Record<string, string>;
+
+/** IDs of sessions created during tests (for cleanup) */
+const createdSessionIds: string[] = [];
+
+function request(path: string, options?: RequestInit) {
+  return app.fetch(new Request(`http://localhost${path}`, options));
+}
+
+beforeAll(async () => {
+  s = await getTestSeed();
+  [
+    pizzaAdminHeaders,
+    burgerAdminHeaders,
+    pizzaAgentHeaders,
+    burgerAgentHeaders,
+  ] = await Promise.all([
+    authHeadersFor(s.pizzaAdmin),
+    authHeadersFor(s.burgerAdmin),
+    agentHeadersFor(s.pizzaAgentId, s.pizzaOrg.id),
+    agentHeadersFor(s.burgerAgentId, s.burgerOrg.id),
+  ]);
+});
+
+afterAll(async () => {
+  if (createdSessionIds.length > 0) {
+    await forApp(async (tx) => {
+      for (const id of createdSessionIds) {
+        // Messages and feedback are cascade-deleted by FK
+        await tx.delete(sessions).where(eq(sessions.id, id));
+      }
+    });
+  }
+});
+
+// ============================================================================
+// POST /api/sessions - Create session (Agent auth)
+// ============================================================================
+
+describe("POST /api/sessions", () => {
+  test("creates session with valid agent key (201)", async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+1234567890",
+        userMetadata: { name: "Test Customer" },
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+
+    expect(body.id).toBeDefined();
+    expect(body.agentId).toBe(s.pizzaAgentId);
+    expect(body.status).toBe("active");
+    expect(body.channelType).toBe("voice");
+    expect(body.userIdentifier).toBe("+1234567890");
+    expect(body.startedAt).toBeDefined();
+    expect(body.endedAt).toBeNull();
+
+    createdSessionIds.push(body.id);
+  });
+
+  test("creates session with externalId (201)", async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        externalId: "ext-12345",
+        channelType: "web",
+        userIdentifier: "customer@test.com",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+
+    expect(body.externalId).toBe("ext-12345");
+    expect(body.channelType).toBe("web");
+
+    createdSessionIds.push(body.id);
+  });
+
+  test("rejects user auth (must be agent) (401)", async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAdminHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+1234567890",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+1234567890",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("validates required fields (422)", async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(422);
+  });
+});
+
+// ============================================================================
+// GET /api/sessions - List sessions (User auth)
+// ============================================================================
+
+describe("GET /api/sessions", () => {
+  test("returns paginated sessions for org (200)", async () => {
+    const response = await request("/api/sessions", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data).toBeArray();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    expect(body.pagination).toBeDefined();
+    expect(body.pagination.page).toBe(1);
+
+    // Verify response shape
+    const session = body.data[0];
+    expect(session.id).toBeDefined();
+    expect(session.agent).toBeDefined();
+    expect(session.agent.id).toBeDefined();
+    expect(session.agent.name).toBeDefined();
+    expect(typeof session.messageCount).toBe("number");
+    expect(session.feedbackSummary).toBeDefined();
+  });
+
+  test("filters by status (200)", async () => {
+    const response = await request("/api/sessions?status=active", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    for (const session of body.data) {
+      expect(session.status).toBe("active");
+    }
+  });
+
+  test("filters by agentId (200)", async () => {
+    const response = await request(`/api/sessions?agentId=${s.pizzaAgentId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    for (const session of body.data) {
+      expect(session.agentId).toBe(s.pizzaAgentId);
+    }
+  });
+
+  test("filters by channelType (200)", async () => {
+    const response = await request("/api/sessions?channelType=voice", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    for (const session of body.data) {
+      expect(session.channelType).toBe("voice");
+    }
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/sessions");
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects agent auth (must be user) (401)", async () => {
+    const response = await request("/api/sessions", {
+      headers: pizzaAgentHeaders,
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// GET /api/sessions/:id - Session detail (User auth)
+// ============================================================================
+
+describe("GET /api/sessions/:id", () => {
+  let detailSessionId: string;
+
+  beforeAll(async () => {
+    // Create a session with a message for detail testing
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+9999999999",
+      }),
+    });
+    const created = await createRes.json();
+    detailSessionId = created.id;
+    createdSessionIds.push(detailSessionId);
+
+    // Add a message
+    await request(`/api/sessions/${detailSessionId}/messages`, {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        role: "user",
+        content: "Hello, I want to order a pizza",
+      }),
+    });
+  });
+
+  test("returns session with messages and feedback (200)", async () => {
+    const response = await request(`/api/sessions/${detailSessionId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(detailSessionId);
+    expect(body.agent).toBeDefined();
+    expect(body.agent.name).toBeDefined();
+    expect(body.messages).toBeArray();
+    expect(body.messages.length).toBeGreaterThanOrEqual(1);
+    expect(body.feedback).toBeArray();
+  });
+
+  test("messages ordered by sequence number", async () => {
+    // Add a second message
+    await request(`/api/sessions/${detailSessionId}/messages`, {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        role: "assistant",
+        content: "What size pizza would you like?",
+      }),
+    });
+
+    const response = await request(`/api/sessions/${detailSessionId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    const body = await response.json();
+    const sequences = body.messages.map(
+      (m: { sequenceNumber: number }) => m.sequenceNumber,
+    );
+
+    // Verify ascending order
+    for (let i = 1; i < sequences.length; i++) {
+      expect(sequences[i]).toBeGreaterThan(sequences[i - 1]);
+    }
+  });
+
+  test("returns 404 for non-existent session", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/sessions/${fakeId}`, {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request(`/api/sessions/${detailSessionId}`);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// PATCH /api/sessions/:id - Update session (Agent auth)
+// ============================================================================
+
+describe("PATCH /api/sessions/:id", () => {
+  let updateSessionId: string;
+
+  beforeAll(async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+5555555555",
+      }),
+    });
+    const body = await response.json();
+    updateSessionId = body.id;
+    createdSessionIds.push(updateSessionId);
+  });
+
+  test("updates status from active to completed (200)", async () => {
+    const response = await request(`/api/sessions/${updateSessionId}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.status).toBe("completed");
+    expect(body.endedAt).toBeDefined();
+    expect(body.endedAt).not.toBeNull();
+  });
+
+  test("rejects transition from terminal state (409)", async () => {
+    // updateSessionId is now "completed", try to update again
+    const response = await request(`/api/sessions/${updateSessionId}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "abandoned" }),
+    });
+
+    expect(response.status).toBe(409);
+  });
+
+  test("updates escalationRef (200)", async () => {
+    // Create a new active session for this test
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+6666666666",
+      }),
+    });
+    const created = await createRes.json();
+    createdSessionIds.push(created.id);
+
+    const response = await request(`/api/sessions/${created.id}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        status: "escalated",
+        escalationRef: "TICKET-123",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.status).toBe("escalated");
+    expect(body.escalationRef).toBe("TICKET-123");
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request(`/api/sessions/${updateSessionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects empty body (422)", async () => {
+    // Create a new active session for this test
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+7777777777",
+      }),
+    });
+    const created = await createRes.json();
+    createdSessionIds.push(created.id);
+
+    const response = await request(`/api/sessions/${created.id}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(422);
+  });
+});
+
+// ============================================================================
+// POST /api/sessions/:id/messages - Add message (Agent auth)
+// ============================================================================
+
+describe("POST /api/sessions/:id/messages", () => {
+  let messageSessionId: string;
+
+  beforeAll(async () => {
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+8888888888",
+      }),
+    });
+    const body = await response.json();
+    messageSessionId = body.id;
+    createdSessionIds.push(messageSessionId);
+  });
+
+  test("adds message with auto-incremented sequence number (201)", async () => {
+    // First message
+    const res1 = await request(`/api/sessions/${messageSessionId}/messages`, {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        role: "user",
+        content: "I want a large pepperoni pizza",
+      }),
+    });
+
+    expect(res1.status).toBe(201);
+    const body1 = await res1.json();
+
+    expect(body1.data).toBeArray();
+    expect(body1.data.length).toBe(1);
+    expect(body1.data[0].sequenceNumber).toBe(1);
+    expect(body1.data[0].role).toBe("user");
+    expect(body1.data[0].content).toBe("I want a large pepperoni pizza");
+
+    // Second message
+    const res2 = await request(`/api/sessions/${messageSessionId}/messages`, {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        role: "assistant",
+        content: "Great choice! What size?",
+      }),
+    });
+
+    expect(res2.status).toBe(201);
+    const body2 = await res2.json();
+
+    expect(body2.data[0].sequenceNumber).toBe(2);
+  });
+
+  test("handles concurrent message inserts without sequence conflicts (201)", async () => {
+    // Create a fresh session
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+9990009999",
+      }),
+    });
+    const created = await createRes.json();
+    createdSessionIds.push(created.id);
+
+    const [res1, res2] = await Promise.all([
+      request(`/api/sessions/${created.id}/messages`, {
+        method: "POST",
+        headers: pizzaAgentHeaders,
+        body: JSON.stringify({
+          role: "user",
+          content: "First concurrent message",
+        }),
+      }),
+      request(`/api/sessions/${created.id}/messages`, {
+        method: "POST",
+        headers: pizzaAgentHeaders,
+        body: JSON.stringify({
+          role: "user",
+          content: "Second concurrent message",
+        }),
+      }),
+    ]);
+
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(201);
+
+    const body1 = await res1.json();
+    const body2 = await res2.json();
+    const sequences = [
+      body1.data[0].sequenceNumber,
+      body2.data[0].sequenceNumber,
+    ].sort((a: number, b: number) => a - b);
+
+    expect(sequences).toEqual([1, 2]);
+  });
+
+  test("handles tool_calls in assistant messages (201)", async () => {
+    const response = await request(
+      `/api/sessions/${messageSessionId}/messages`,
+      {
+        method: "POST",
+        headers: pizzaAgentHeaders,
+        body: JSON.stringify({
+          role: "assistant",
+          content: "Let me look up the menu for you.",
+          toolCalls: [
+            {
+              toolCallId: "call_123",
+              toolName: "pizzapalace_get_menu",
+              toolInput: { category: "pizza" },
+              toolOutput: { items: ["pepperoni", "margherita"] },
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+
+    // Should create both the assistant message and the tool message
+    expect(body.data.length).toBe(2);
+
+    const assistantMsg = body.data[0];
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content).toBe("Let me look up the menu for you.");
+
+    const toolMsg = body.data[1];
+    expect(toolMsg.role).toBe("tool");
+    expect(toolMsg.toolCallId).toBe("call_123");
+    expect(toolMsg.toolName).toBe("pizzapalace_get_menu");
+  });
+
+  test("rejects message to ended session (409)", async () => {
+    // End the session first
+    await request(`/api/sessions/${messageSessionId}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    const response = await request(
+      `/api/sessions/${messageSessionId}/messages`,
+      {
+        method: "POST",
+        headers: pizzaAgentHeaders,
+        body: JSON.stringify({
+          role: "user",
+          content: "One more thing...",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request(
+      `/api/sessions/${messageSessionId}/messages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          role: "user",
+          content: "Hello",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// RLS isolation
+// ============================================================================
+
+describe("RLS isolation", () => {
+  let pizzaSessionId: string;
+
+  beforeAll(async () => {
+    // Create a session in pizza org
+    const response = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+1111111111",
+      }),
+    });
+    const body = await response.json();
+    pizzaSessionId = body.id;
+    createdSessionIds.push(pizzaSessionId);
+  });
+
+  test("Burger Barn cannot see Pizza Palace sessions in list (200)", async () => {
+    const response = await request("/api/sessions", {
+      headers: burgerAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    const ids = body.data.map((s: { id: string }) => s.id);
+    expect(ids).not.toContain(pizzaSessionId);
+  });
+
+  test("Burger Barn cannot get Pizza Palace session by ID (404)", async () => {
+    const response = await request(`/api/sessions/${pizzaSessionId}`, {
+      headers: burgerAdminHeaders,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("Burger agent cannot update Pizza Palace session (404)", async () => {
+    const response = await request(`/api/sessions/${pizzaSessionId}`, {
+      method: "PATCH",
+      headers: burgerAgentHeaders,
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("Burger agent cannot add message to Pizza Palace session (404)", async () => {
+    const response = await request(`/api/sessions/${pizzaSessionId}/messages`, {
+      method: "POST",
+      headers: burgerAgentHeaders,
+      body: JSON.stringify({
+        role: "user",
+        content: "Cross-org attack attempt",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- **Sessions CRUD** — Create, list (paginated + filtered), get detail, and update sessions via REST API with full OpenAPI documentation
- **Message management** — Add messages with auto-sequencing, tool call expansion (assistant messages with `toolCalls` auto-create tool messages), and unique constraint with retry logic to prevent sequence race conditions
- **RLS isolation** — Every service function uses `forOrg()`, cross-org access returns 404. Integration tests explicitly verify isolation between orgs
- **Session state machine** — Active → completed/escalated/abandoned transitions with terminal status validation. `createMessage` role enum restricted to `user`/`assistant` only (tool/system messages are platform-generated)
- **Integration tests** — 20+ test cases covering auth, validation, state transitions, tool call handling, pagination, filtering, and RLS isolation
- **Housekeeping** — Updated CLAUDE.md commands to match Makefile targets, added `.tanstack/` to gitignore

## Test plan

- [x] `make api-test-integration` — 192 tests pass (472 assertions)
- [x] `make api-typecheck` — passes
- [x] Manual: `POST /api/sessions` with agent API key → 201
- [x] Manual: `GET /api/sessions` with user JWT → paginated list
- [x] Manual: `PATCH /api/sessions/:id` to terminal status → verify `endedAt` set
- [ ] Manual: Cross-org session access → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)