### PR TITLE
Refactor sessions service and expand test coverage

### DIFF
--- a/modelguide-api/src/features/sessions/sessions.service.ts
+++ b/modelguide-api/src/features/sessions/sessions.service.ts
@@ -30,6 +30,12 @@ interface SessionFilters extends PaginationParams {
 
 const TERMINAL_STATUSES = ["completed", "escalated", "abandoned"] as const;
 
+function isTerminal(status: string): boolean {
+  return TERMINAL_STATUSES.includes(
+    status as (typeof TERMINAL_STATUSES)[number],
+  );
+}
+
 // ============================================================================
 // Session queries (RLS via forOrg)
 // ============================================================================
@@ -39,45 +45,10 @@ export async function listSessions(orgId: string, filters: SessionFilters) {
   const offset = getOffset(page, pageSize);
 
   return forOrg(orgId, async (tx) => {
-    // Build where conditions
-    const conditions = [];
+    const conditions = buildFilterConditions(filters);
+    const { sortDir, sortColumn } = buildSort(filters);
 
-    if (filters.agentId) {
-      conditions.push(eq(sessions.agentId, filters.agentId));
-    }
-    if (filters.status) {
-      conditions.push(
-        eq(
-          sessions.status,
-          filters.status as (typeof sessions.status.enumValues)[number],
-        ),
-      );
-    }
-    if (filters.channelType) {
-      conditions.push(
-        eq(
-          sessions.channelType,
-          filters.channelType as (typeof sessions.channelType.enumValues)[number],
-        ),
-      );
-    }
-    if (filters.startedAfter) {
-      conditions.push(gte(sessions.startedAt, new Date(filters.startedAfter)));
-    }
-    if (filters.startedBefore) {
-      conditions.push(lte(sessions.startedAt, new Date(filters.startedBefore)));
-    }
-
-    // Determine sort
-    const sortColumn =
-      filters.sortBy === "ended_at"
-        ? sessions.endedAt
-        : filters.sortBy === "status"
-          ? sessions.status
-          : sessions.startedAt;
-    const sortDir = filters.sortOrder === "asc" ? asc : desc;
-
-    // Message count subquery
+    // Subqueries for aggregated data
     const messageCountSq = db
       .select({
         sessionId: sessionMessages.sessionId,
@@ -87,7 +58,6 @@ export async function listSessions(orgId: string, filters: SessionFilters) {
       .groupBy(sessionMessages.sessionId)
       .as("msg_counts");
 
-    // Feedback summary subquery
     const feedbackSq = db
       .select({
         sessionId: sessionFeedback.sessionId,
@@ -97,7 +67,16 @@ export async function listSessions(orgId: string, filters: SessionFilters) {
       .groupBy(sessionFeedback.sessionId)
       .as("fb_counts");
 
-    // Build base query for data
+    // Apply hasFeedback filter (depends on feedbackSq)
+    if (filters.hasFeedback === true) {
+      conditions.push(gt(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
+    } else if (filters.hasFeedback === false) {
+      conditions.push(eq(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
+    }
+
+    const finalWhere = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Data query
     let dataQuery = tx
       .select({
         session: sessions,
@@ -115,16 +94,7 @@ export async function listSessions(orgId: string, filters: SessionFilters) {
       .leftJoin(messageCountSq, eq(sessions.id, messageCountSq.sessionId))
       .leftJoin(feedbackSq, eq(sessions.id, feedbackSq.sessionId));
 
-    // Apply hasFeedback filter
-    if (filters.hasFeedback === true) {
-      conditions.push(gt(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
-    } else if (filters.hasFeedback === false) {
-      conditions.push(eq(sql`coalesce(${feedbackSq.feedbackCount}, 0)`, 0));
-    }
-
-    const finalWhere = conditions.length > 0 ? and(...conditions) : undefined;
-
-    // Count query
+    // Count query (joins feedbackSq only when hasFeedback filter is used)
     const countQuery = tx
       .select({ total: count() })
       .from(sessions)
@@ -140,21 +110,17 @@ export async function listSessions(orgId: string, filters: SessionFilters) {
       countQuery,
     ]);
 
-    const data = items.map((row) => ({
-      ...row.session,
-      agent: { id: row.session.agentId, name: row.agentName ?? "Unknown" },
-      messageCount: Number(row.messageCount),
-      durationSeconds: computeDuration(
-        row.session.startedAt,
-        row.session.endedAt,
-      ),
-      feedbackSummary: {
-        hasFeedback: Number(row.feedbackCount) > 0,
-      },
-    }));
-
     return {
-      data,
+      data: items.map((row) => ({
+        ...row.session,
+        agent: { id: row.session.agentId, name: row.agentName ?? "Unknown" },
+        messageCount: Number(row.messageCount),
+        durationSeconds: computeDuration(
+          row.session.startedAt,
+          row.session.endedAt,
+        ),
+        feedbackSummary: { hasFeedback: Number(row.feedbackCount) > 0 },
+      })),
       pagination: buildPaginationMeta(page, pageSize, total),
     };
   });
@@ -212,7 +178,6 @@ export async function createSession(
   },
 ) {
   return forOrg(orgId, async (tx) => {
-    // Validate agent exists and belongs to org
     const [agent] = await tx
       .select({ id: agents.id })
       .from(agents)
@@ -252,7 +217,7 @@ export async function updateSession(
 ) {
   return forOrg(orgId, async (tx) => {
     const [existing] = await tx
-      .select()
+      .select({ id: sessions.id, status: sessions.status })
       .from(sessions)
       .where(and(eq(sessions.id, sessionId), eq(sessions.agentId, agentId)));
 
@@ -260,24 +225,14 @@ export async function updateSession(
       throw Errors.sessionNotFound(sessionId);
     }
 
-    // Check if session is already in a terminal state
-    if (
-      TERMINAL_STATUSES.includes(
-        existing.status as (typeof TERMINAL_STATUSES)[number],
-      )
-    ) {
+    if (isTerminal(existing.status)) {
       throw Errors.sessionAlreadyEnded(sessionId);
     }
 
     const updateData: Partial<typeof sessions.$inferInsert> = {};
 
     if (data.status) {
-      // Only allow transitions from active to terminal states
-      if (
-        !TERMINAL_STATUSES.includes(
-          data.status as (typeof TERMINAL_STATUSES)[number],
-        )
-      ) {
+      if (!isTerminal(data.status)) {
         throw Errors.validationError(
           `Invalid status transition. Allowed: ${TERMINAL_STATUSES.join(", ")}`,
         );
@@ -321,9 +276,8 @@ export async function addMessage(
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       return await forOrg(orgId, async (tx) => {
-        // Validate session exists and belongs to agent
         const [session] = await tx
-          .select()
+          .select({ id: sessions.id, status: sessions.status })
           .from(sessions)
           .where(
             and(eq(sessions.id, sessionId), eq(sessions.agentId, agentId)),
@@ -333,11 +287,7 @@ export async function addMessage(
           throw Errors.sessionNotFound(sessionId);
         }
 
-        if (
-          TERMINAL_STATUSES.includes(
-            session.status as (typeof TERMINAL_STATUSES)[number],
-          )
-        ) {
+        if (isTerminal(session.status)) {
           throw Errors.sessionAlreadyEnded(sessionId);
         }
 
@@ -348,7 +298,6 @@ export async function addMessage(
           .where(eq(sessionMessages.sessionId, sessionId));
 
         let nextSequence = (maxSeq?.max ?? 0) + 1;
-
         const createdMessages = [];
 
         // Insert the main message
@@ -404,6 +353,49 @@ export async function addMessage(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+function buildFilterConditions(filters: SessionFilters) {
+  const conditions = [];
+
+  if (filters.agentId) {
+    conditions.push(eq(sessions.agentId, filters.agentId));
+  }
+  if (filters.status) {
+    conditions.push(
+      eq(
+        sessions.status,
+        filters.status as (typeof sessions.status.enumValues)[number],
+      ),
+    );
+  }
+  if (filters.channelType) {
+    conditions.push(
+      eq(
+        sessions.channelType,
+        filters.channelType as (typeof sessions.channelType.enumValues)[number],
+      ),
+    );
+  }
+  if (filters.startedAfter) {
+    conditions.push(gte(sessions.startedAt, new Date(filters.startedAfter)));
+  }
+  if (filters.startedBefore) {
+    conditions.push(lte(sessions.startedAt, new Date(filters.startedBefore)));
+  }
+
+  return conditions;
+}
+
+function buildSort(filters: SessionFilters) {
+  const sortColumn =
+    filters.sortBy === "ended_at"
+      ? sessions.endedAt
+      : filters.sortBy === "status"
+        ? sessions.status
+        : sessions.startedAt;
+  const sortDir = filters.sortOrder === "asc" ? asc : desc;
+  return { sortDir, sortColumn };
+}
 
 function computeDuration(startedAt: Date, endedAt: Date | null): number | null {
   if (!endedAt) return null;

--- a/modelguide-api/tests/integration/sessions.test.ts
+++ b/modelguide-api/tests/integration/sessions.test.ts
@@ -6,7 +6,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import app from "@/app";
 import { forApp } from "@db/rls";
-import { sessions } from "@db/schema";
+import { sessionFeedback, sessions } from "@db/schema";
 import { eq } from "drizzle-orm";
 import {
   type TestSeed,
@@ -664,5 +664,248 @@ describe("RLS isolation", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// PATCH /api/sessions/:id - Additional update tests
+// ============================================================================
+
+describe("PATCH /api/sessions/:id (additional)", () => {
+  test("updates status from active to abandoned (200)", async () => {
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "web",
+        userIdentifier: "abandon-test@test.com",
+      }),
+    });
+    const created = await createRes.json();
+    createdSessionIds.push(created.id);
+
+    const response = await request(`/api/sessions/${created.id}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "abandoned" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("abandoned");
+    expect(body.endedAt).not.toBeNull();
+  });
+
+  test("returns 404 for non-existent session", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const response = await request(`/api/sessions/${fakeId}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// POST /api/sessions/:id/messages - Additional message tests
+// ============================================================================
+
+describe("POST /api/sessions/:id/messages (additional)", () => {
+  test("creates message with audioUrl (201)", async () => {
+    const createRes = await request("/api/sessions", {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        channelType: "voice",
+        userIdentifier: "+4444444444",
+      }),
+    });
+    const created = await createRes.json();
+    createdSessionIds.push(created.id);
+
+    const response = await request(`/api/sessions/${created.id}/messages`, {
+      method: "POST",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({
+        role: "user",
+        content: "Voice message",
+        audioUrl: "https://storage.example.com/recordings/abc123.mp3",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.data[0].audioUrl).toBe(
+      "https://storage.example.com/recordings/abc123.mp3",
+    );
+    expect(body.data[0].content).toBe("Voice message");
+  });
+});
+
+// ============================================================================
+// GET /api/sessions - Filtering, sorting, pagination
+// ============================================================================
+
+describe("GET /api/sessions (filtering & sorting)", () => {
+  /** IDs of sessions created specifically for filter tests */
+  const filterSessionIds: string[] = [];
+
+  beforeAll(async () => {
+    // Create several sessions with different channels to test filters
+    for (const channel of ["web", "sms", "sms"]) {
+      const res = await request("/api/sessions", {
+        method: "POST",
+        headers: pizzaAgentHeaders,
+        body: JSON.stringify({
+          channelType: channel,
+          userIdentifier: `filter-${channel}-${Date.now()}@test.com`,
+        }),
+      });
+      const body = await res.json();
+      filterSessionIds.push(body.id);
+      createdSessionIds.push(body.id);
+    }
+
+    // Complete one session so we can test date-range and status filters
+    await request(`/api/sessions/${filterSessionIds[0]}`, {
+      method: "PATCH",
+      headers: pizzaAgentHeaders,
+      body: JSON.stringify({ status: "completed" }),
+    });
+
+    // Add feedback to the completed session so we can test hasFeedback
+    await forApp(async (tx) => {
+      await tx.insert(sessionFeedback).values({
+        sessionId: filterSessionIds[0],
+        rating: 2,
+        feedbackSource: "customer",
+        userIdentifier: "filter-tester",
+      });
+    });
+  });
+
+  test("filters by startedAfter (200)", async () => {
+    // Use a date far in the past — should return all sessions
+    const response = await request(
+      "/api/sessions?startedAfter=2020-01-01T00:00:00Z",
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("filters by startedBefore (200)", async () => {
+    // Use a date far in the past — should return zero sessions
+    const response = await request(
+      "/api/sessions?startedBefore=2020-01-01T00:00:00Z",
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.length).toBe(0);
+  });
+
+  test("filters by hasFeedback=true (200)", async () => {
+    const response = await request("/api/sessions?hasFeedback=true", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    for (const session of body.data) {
+      expect(session.feedbackSummary.hasFeedback).toBe(true);
+    }
+  });
+
+  test("filters by hasFeedback=false (200)", async () => {
+    const response = await request("/api/sessions?hasFeedback=false", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    for (const session of body.data) {
+      expect(session.feedbackSummary.hasFeedback).toBe(false);
+    }
+  });
+
+  test("sorts by started_at ascending (200)", async () => {
+    const response = await request(
+      "/api/sessions?sortBy=started_at&sortOrder=asc",
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    for (let i = 1; i < body.data.length; i++) {
+      expect(new Date(body.data[i].startedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(body.data[i - 1].startedAt).getTime(),
+      );
+    }
+  });
+
+  test("sorts by status (200)", async () => {
+    const response = await request(
+      "/api/sessions?sortBy=status&sortOrder=asc",
+      { headers: pizzaAdminHeaders },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("paginates with pageSize=1 and returns correct totalPages (200)", async () => {
+    const response = await request("/api/sessions?page=1&pageSize=1", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data.length).toBe(1);
+    expect(body.pagination.pageSize).toBe(1);
+    expect(body.pagination.totalItems).toBeGreaterThan(1);
+    expect(body.pagination.totalPages).toBeGreaterThan(1);
+    expect(body.pagination.hasNextPage).toBe(true);
+    expect(body.pagination.hasPreviousPage).toBe(false);
+  });
+
+  test("returns page 2 results (200)", async () => {
+    const response = await request("/api/sessions?page=2&pageSize=1", {
+      headers: pizzaAdminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.data.length).toBe(1);
+    expect(body.pagination.page).toBe(2);
+    expect(body.pagination.hasPreviousPage).toBe(true);
+  });
+
+  test("page 1 and page 2 return different sessions (200)", async () => {
+    const [res1, res2] = await Promise.all([
+      request("/api/sessions?page=1&pageSize=1", {
+        headers: pizzaAdminHeaders,
+      }),
+      request("/api/sessions?page=2&pageSize=1", {
+        headers: pizzaAdminHeaders,
+      }),
+    ]);
+
+    const body1 = await res1.json();
+    const body2 = await res2.json();
+
+    expect(body1.data[0].id).not.toBe(body2.data[0].id);
   });
 });


### PR DESCRIPTION
## Summary

- **Service readability** — Extracted `isTerminal()`, `buildFilterConditions()`, and `buildSort()` helpers from `sessions.service.ts` to reduce `listSessions` complexity and eliminate 3 repeated `TERMINAL_STATUSES.includes(... as ...)` casts
- **Narrower SELECTs** — `updateSession` and `addMessage` existence checks now select `(id, status)` instead of all columns
- **12 new integration tests** covering previously untested paths:
  - `hasFeedback=true` / `hasFeedback=false` filters
  - `startedAfter` / `startedBefore` date-range filters
  - Sort by `started_at` ascending and by `status`
  - Pagination: `pageSize=1` returns correct `totalPages`, page 2 returns different results
  - `active → abandoned` status transition
  - `PATCH` non-existent session returns 404
  - `audioUrl` field on messages

## Test plan

- [x] `make api-test-integration` — 250 tests pass (625 assertions)
- [x] `make api-typecheck` — passes
- [x] `bun run lint:check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)