### PR TITLE
fix(ci): drop drizzle schema during db reset

### DIFF
--- a/scripts/railway-db-reset.sh
+++ b/scripts/railway-db-reset.sh
@@ -21,8 +21,8 @@ if [ -t 0 ] && [ "${CI:-}" != "true" ]; then
   [ "$confirm" = "yes" ] || { echo "Aborted."; exit 1; }
 fi
 
-echo "==> Dropping and recreating public schema..."
-psql "$DATABASE_MIGRATION_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+echo "==> Dropping and recreating schemas..."
+psql "$DATABASE_MIGRATION_URL" -c "DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
 echo "==> Ensuring modelguide_app role exists..."
 psql "$DATABASE_MIGRATION_URL" -v app_password="$DATABASE_APP_PASSWORD" -f scripts/railway-db-init.sql 2>/dev/null || true


### PR DESCRIPTION
## Summary

- The db reset script only dropped the `public` schema, but the `drizzle` schema (containing `__drizzle_migrations` journal) survived
- This caused `drizzle-kit migrate` to think all migrations were already applied and skip them, leaving tables like `connectors_catalog` missing
- Now drops both `drizzle` and `public` schemas so migrations run fresh

## Test plan

- [ ] Run the "Reset & Seed Database" workflow and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)