### PR TITLE
fix(ui): update login page dev emails to match seed data

### DIFF
--- a/modelguide-ui/src/routes/login.tsx
+++ b/modelguide-ui/src/routes/login.tsx
@@ -47,17 +47,14 @@ function LoginPage() {
             </p>
             <div className="space-y-2 font-mono text-sm">
               <div className="flex items-center justify-between">
-                <span className="text-fg-primary">admin@pizza-palace.com</span>
+                <span className="text-fg-primary">delivered+admin-pizza-palace@resend.dev</span>
                 <span className="text-fg-muted">admin</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-fg-primary">support@pizza-palace.com</span>
+                <span className="text-fg-primary">delivered+support-pizza-palace@resend.dev</span>
                 <span className="text-fg-muted">support</span>
               </div>
             </div>
-            <p className="mt-3 text-xs text-fg-muted">
-              Magic link token prints to the API server console
-            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Updated dev account emails on the login page to match the actual seed data (`delivered+admin-pizza-palace@resend.dev` and `delivered+support-pizza-palace@resend.dev`)
- Removed the hardcoded "Magic link token prints to the API server console" hint

## Test plan
- [ ] Verify login page shows the correct seed emails
- [ ] Confirm magic link flow works with the displayed emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)