### PR TITLE
fix(readme): use GitHub native CI badge for private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=for-the-badge" alt="MIT License" /></a>&nbsp;
-  <a href="https://github.com/modelguide/modelguide/actions"><img src="https://img.shields.io/github/actions/workflow/status/modelguide/modelguide/ci.yml?style=for-the-badge&label=CI" alt="CI Status" /></a>
+  <a href="https://github.com/modelguide/modelguide/actions/workflows/ci.yml"><img src="https://github.com/modelguide/modelguide/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Replace shields.io CI badge with GitHub's native workflow badge. Shields.io can't access private repos, causing "repo or workflow not found" error. GitHub's own badge works for both private and public repos.

## Changes

- `README.md`: `img.shields.io/github/actions/...` → `github.com/.../actions/workflows/ci.yml/badge.svg`

## How to Test

1. View README on GitHub — CI badge should show passing status instead of error

## Verification

- [x] Type check passes
- [x] Lint passes