### PR TITLE
fix(connectors): use Basic auth for Medusa Admin API keys

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/medusa/client.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/client.ts
@@ -45,7 +45,7 @@ export function createMedusaAdminFetcher(
     {
       "Content-Type": "application/json",
       Accept: "application/json",
-      Authorization: `Bearer ${secretApiKey}`,
+      Authorization: `Basic ${btoa(`${secretApiKey}:`)}`,
     },
     "Medusa Admin",
   );

--- a/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
@@ -134,15 +134,6 @@ interface MedusaOrderItem {
   title: string;
   quantity: number;
   unit_price: number;
-  variant?: {
-    id: string;
-    title: string;
-    sku: string | null;
-    product?: {
-      id: string;
-      title: string;
-    };
-  };
 }
 
 interface MedusaOrderDetail {
@@ -190,7 +181,7 @@ export const lookUpOrder = withMedusaAdmin(async (fetcher, ctx) => {
       };
     }
     const { orders, count } = await fetcher<{
-      orders: { id: string; display_id: number }[];
+      orders: MedusaOrderDetail[];
       count: number;
     }>("/admin/orders", {
       params: {
@@ -198,22 +189,14 @@ export const lookUpOrder = withMedusaAdmin(async (fetcher, ctx) => {
         limit: PAGE_SIZE,
         offset,
         order: "-created_at",
+        fields:
+          "id,display_id,status,total,currency_code,summary,version,metadata,created_at,updated_at,*items",
       },
     });
 
     const match = orders?.find((o) => o.display_id === displayId);
     if (match) {
-      // Step 3: Fetch full order with items
-      const { order } = await fetcher<{ order: MedusaOrderDetail }>(
-        `/admin/orders/${match.id}`,
-        {
-          params: {
-            fields:
-              "id,display_id,status,total,currency_code,summary,version,metadata,created_at,updated_at,*items,*items.variant,*items.variant.product",
-          },
-        },
-      );
-      return { success: true, data: order };
+      return { success: true, data: match };
     }
 
     offset += PAGE_SIZE;

--- a/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
+++ b/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
@@ -334,37 +334,31 @@ describe("lookUpOrder (Admin API)", () => {
   // ----------------------------------------------------------------
   // Happy path
   // ----------------------------------------------------------------
-  test("finds order on first page and fetches detail with items", async () => {
+  test("finds order on first page with items included", async () => {
     mockFetchSequence([
       { status: 200, body: { customers: [{ id: "cust_1" }] } },
       {
         status: 200,
         body: {
           orders: [
-            { id: "order_aaa", display_id: 1001 },
+            {
+              id: "order_aaa",
+              display_id: 1001,
+              status: "completed",
+              total: 4500,
+              currency_code: "usd",
+              items: [
+                {
+                  id: "item_1",
+                  title: "Margherita",
+                  quantity: 2,
+                  unit_price: 1500,
+                },
+              ],
+            },
             { id: "order_bbb", display_id: 1002 },
           ],
           count: 2,
-        },
-      },
-      {
-        status: 200,
-        body: {
-          order: {
-            id: "order_aaa",
-            display_id: 1001,
-            status: "completed",
-            total: 4500,
-            currency_code: "usd",
-            items: [
-              {
-                id: "item_1",
-                title: "Margherita",
-                quantity: 2,
-                unit_price: 1500,
-              },
-            ],
-          },
         },
       },
     ]);
@@ -382,10 +376,10 @@ describe("lookUpOrder (Admin API)", () => {
       items: [{ id: "item_1", title: "Margherita", quantity: 2 }],
     });
 
-    // Verify auth header uses Bearer token (not publishable key)
+    // Verify auth header uses Basic auth (not publishable key)
     const [, customerOpts] = fetchMock.mock.calls[0];
     expect(customerOpts.headers.Authorization).toBe(
-      "Bearer sk_admin_token_123",
+      `Basic ${btoa("sk_admin_token_123:")}`,
     );
     expect(customerOpts.headers["x-publishable-api-key"]).toBeUndefined();
 
@@ -397,12 +391,11 @@ describe("lookUpOrder (Admin API)", () => {
     const [ordersUrl] = fetchMock.mock.calls[1];
     expect(ordersUrl).toContain("/admin/orders");
     expect(ordersUrl).toContain("customer_id=cust_1");
+    expect(ordersUrl).toContain("fields=");
+    expect(ordersUrl).toContain("*items");
 
-    // Verify detail fetch with fields param
-    const [detailUrl] = fetchMock.mock.calls[2];
-    expect(detailUrl).toContain("/admin/orders/order_aaa");
-    expect(detailUrl).toContain("fields=");
-    expect(detailUrl).toContain("*items");
+    // Only 2 fetches: customers + orders (no separate detail call)
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   // ----------------------------------------------------------------
@@ -422,21 +415,15 @@ describe("lookUpOrder (Admin API)", () => {
         status: 200,
         body: {
           orders: [
-            { id: "order_p2_0", display_id: 1099 },
+            {
+              id: "order_p2_0",
+              display_id: 1099,
+              status: "pending",
+              items: [],
+            },
             { id: "order_p2_1", display_id: 1100 },
           ],
           count: 55,
-        },
-      },
-      {
-        status: 200,
-        body: {
-          order: {
-            id: "order_p2_0",
-            display_id: 1099,
-            status: "pending",
-            items: [],
-          },
         },
       },
     ]);
@@ -447,7 +434,7 @@ describe("lookUpOrder (Admin API)", () => {
 
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({ id: "order_p2_0", display_id: 1099 });
-    expect(fetchMock).toHaveBeenCalledTimes(4); // customers + page1 + page2 + detail
+    expect(fetchMock).toHaveBeenCalledTimes(3); // customers + page1 + page2
 
     // Verify second orders call has correct offset
     const [page2Url] = fetchMock.mock.calls[2];
@@ -530,19 +517,15 @@ describe("lookUpOrder (Admin API)", () => {
       {
         status: 200,
         body: {
-          orders: [{ id: "order_match", display_id: 42 }],
+          orders: [
+            {
+              id: "order_match",
+              display_id: 42,
+              status: "completed",
+              items: [],
+            },
+          ],
           count: 1,
-        },
-      },
-      {
-        status: 200,
-        body: {
-          order: {
-            id: "order_match",
-            display_id: 42,
-            status: "completed",
-            items: [],
-          },
         },
       },
     ]);
@@ -648,18 +631,11 @@ describe("lookUpOrder (Admin API)", () => {
   });
 
   // ----------------------------------------------------------------
-  // API error on order detail fetch (step 3)
+  // API error on orders fetch
   // ----------------------------------------------------------------
-  test("returns error when order detail fetch fails", async () => {
+  test("returns error when orders fetch fails with 502", async () => {
     mockFetchSequence([
       { status: 200, body: { customers: [{ id: "cust_1" }] } },
-      {
-        status: 200,
-        body: {
-          orders: [{ id: "order_aaa", display_id: 1001 }],
-          count: 1,
-        },
-      },
       { status: 502, body: "Bad Gateway" },
     ]);
 


### PR DESCRIPTION
## Summary

Medusa Admin API expects static API keys via HTTP Basic auth (`Authorization: Basic {base64(key:)}`), not Bearer tokens. This fixes the auth header and also eliminates a redundant order detail fetch by requesting item fields directly in the orders list call.

## Changes

- `client.ts`: `Authorization: Bearer` → `Authorization: Basic` with base64-encoded key
- `handlers.ts`: Moved `fields` param (with `*items`) into `/admin/orders` list call, removed separate `/admin/orders/:id` detail fetch, removed unused `variant` fields from `MedusaOrderItem`
- `medusa-handlers.test.ts`: Updated auth assertions, reduced expected fetch counts, adjusted mock response shapes

## How to Test

1. Run `make api-test-unit` — all 235 tests should pass
2. If you have a Medusa instance with an Admin API key, configure a connector and verify `lookUpOrder` works with the corrected Basic auth header

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Scoped to one concern