### PR TITLE
feat: external resource links from tool calls in session detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bun.lockb
 # Drizzle
 drizzle/meta/
 
+# Manual test payloads
+**/tests/manual/payload*.json
+
 # Claude Code
 .claude/settings.local.json
 .claude/local/

--- a/modelguide-api/drizzle/0015_add-session-links.sql
+++ b/modelguide-api/drizzle/0015_add-session-links.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "session_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"session_id" uuid NOT NULL,
+	"url" varchar(2048) NOT NULL,
+	"title" varchar(255),
+	"connector_slug" varchar(100),
+	"resource_type" varchar(100),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "session_links" ADD CONSTRAINT "session_links_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "session_links_session_url_unique" ON "session_links" USING btree ("session_id","url");
+--> statement-breakpoint
+CREATE INDEX "session_links_session_idx" ON "session_links" USING btree ("session_id");

--- a/modelguide-api/drizzle/meta/_journal.json
+++ b/modelguide-api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1770723300000,
       "tag": "0014_add-webhook-secret-type",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1770900000000,
+      "tag": "0015_add-session-links",
+      "breakpoints": true
     }
   ]
 }

--- a/modelguide-api/src/db/schema/core.ts
+++ b/modelguide-api/src/db/schema/core.ts
@@ -541,6 +541,42 @@ export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   }),
   messages: many(sessionMessages),
   feedback: many(sessionFeedback),
+  links: many(sessionLinks),
+}));
+
+// ============================================================================
+// Session Links (external resource URLs from tool calls)
+// ============================================================================
+
+export const sessionLinks = pgTable(
+  "session_links",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    url: varchar("url", { length: 2048 }).notNull(),
+    title: varchar("title", { length: 255 }),
+    connectorSlug: varchar("connector_slug", { length: 100 }),
+    resourceType: varchar("resource_type", { length: 100 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("session_links_session_url_unique").on(
+      table.sessionId,
+      table.url,
+    ),
+    index("session_links_session_idx").on(table.sessionId),
+  ],
+);
+
+export const sessionLinksRelations = relations(sessionLinks, ({ one }) => ({
+  session: one(sessions, {
+    fields: [sessionLinks.sessionId],
+    references: [sessions.id],
+  }),
 }));
 
 // ============================================================================

--- a/modelguide-api/src/db/schema/index.ts
+++ b/modelguide-api/src/db/schema/index.ts
@@ -14,6 +14,7 @@ import type {
   secrets,
   securityTokens,
   sessionFeedback,
+  sessionLinks,
   sessionMessages,
   sessions,
   users,
@@ -62,3 +63,6 @@ export type NewSessionMessage = InferInsertModel<typeof sessionMessages>;
 
 export type SessionFeedback = InferSelectModel<typeof sessionFeedback>;
 export type NewSessionFeedback = InferInsertModel<typeof sessionFeedback>;
+
+export type SessionLink = InferSelectModel<typeof sessionLinks>;
+export type NewSessionLink = InferInsertModel<typeof sessionLinks>;

--- a/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
@@ -119,7 +119,14 @@ export const getOrder = withMedusa(async (fetcher, ctx) => {
   const data = await fetcher<Record<string, unknown>>(
     `/store/orders/${orderId}`,
   );
-  return { success: true, data };
+  const baseUrl = ctx.config.baseUrl?.replace(/\/$/, "");
+  return {
+    success: true,
+    data,
+    ...(baseUrl && {
+      url: `${baseUrl}/app/orders/${orderId}`,
+    }),
+  };
 });
 
 // ---------------------------------------------------------------------------
@@ -196,7 +203,14 @@ export const lookUpOrder = withMedusaAdmin(async (fetcher, ctx) => {
 
     const match = orders?.find((o) => o.display_id === displayId);
     if (match) {
-      return { success: true, data: match };
+      const baseUrl = ctx.config.baseUrl?.replace(/\/$/, "");
+      return {
+        success: true,
+        data: match,
+        ...(baseUrl && {
+          url: `${baseUrl}/app/orders/${match.id}`,
+        }),
+      };
     }
 
     offset += PAGE_SIZE;

--- a/modelguide-api/src/features/connectors/catalog/types.ts
+++ b/modelguide-api/src/features/connectors/catalog/types.ts
@@ -16,6 +16,7 @@ export interface ToolExecutionResult {
   success: boolean;
   data?: Record<string, unknown>;
   error?: string;
+  url?: string;
 }
 
 export interface ConnectorToolDefinition {

--- a/modelguide-api/src/features/connectors/catalog/zendesk/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/zendesk/handlers.ts
@@ -39,7 +39,11 @@ export const getTicket = withZendesk(async (fetcher, ctx) => {
   const data = await fetcher<Record<string, unknown>>(
     `/tickets/${ticketId}.json`,
   );
-  return { success: true, data };
+  return {
+    success: true,
+    data,
+    url: `https://${ctx.config.subdomain}.zendesk.com/agent/tickets/${ticketId}`,
+  };
 });
 
 export const createTicket = withZendesk(async (fetcher, ctx) => {
@@ -81,7 +85,14 @@ export const createTicket = withZendesk(async (fetcher, ctx) => {
     method: "POST",
     body: { ticket },
   });
-  return { success: true, data };
+  const newTicketId = (data as { ticket?: { id?: number } })?.ticket?.id;
+  return {
+    success: true,
+    data,
+    ...(newTicketId && {
+      url: `https://${ctx.config.subdomain}.zendesk.com/agent/tickets/${newTicketId}`,
+    }),
+  };
 });
 
 export const updateTicket = withZendesk(async (fetcher, ctx) => {
@@ -112,7 +123,11 @@ export const updateTicket = withZendesk(async (fetcher, ctx) => {
       body: { ticket },
     },
   );
-  return { success: true, data };
+  return {
+    success: true,
+    data,
+    url: `https://${ctx.config.subdomain}.zendesk.com/agent/tickets/${ticketId}`,
+  };
 });
 
 export const addComment = withZendesk(async (fetcher, ctx) => {
@@ -138,7 +153,11 @@ export const addComment = withZendesk(async (fetcher, ctx) => {
       },
     },
   );
-  return { success: true, data };
+  return {
+    success: true,
+    data,
+    url: `https://${ctx.config.subdomain}.zendesk.com/agent/tickets/${ticketId}`,
+  };
 });
 
 export const searchTickets = withZendesk(async (fetcher, ctx) => {

--- a/modelguide-api/src/features/sessions/link-extraction.ts
+++ b/modelguide-api/src/features/sessions/link-extraction.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared utilities for extracting external resource links from tool call outputs.
+ * Used by both the MCP addMessages path and the ElevenLabs post-call webhook.
+ */
+
+export interface ExtractedLink {
+  url: string;
+  title: string | null;
+  connectorSlug: string | null;
+  resourceType: string | null;
+}
+
+interface ToolOutputWithUrl {
+  url?: unknown;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract external links from a list of tool call outputs.
+ */
+export function extractLinks(
+  toolCalls: { toolName: string; toolOutput: ToolOutputWithUrl | null }[],
+): ExtractedLink[] {
+  const links: ExtractedLink[] = [];
+  const seen = new Set<string>();
+
+  for (const tc of toolCalls) {
+    if (!tc.toolOutput) continue;
+
+    const url = tc.toolOutput.url;
+    if (!url || typeof url !== "string" || seen.has(url)) continue;
+    seen.add(url);
+
+    const parts = tc.toolName.split("_");
+    const connectorSlug = parts[0] || null;
+    const resourceType = deriveResourceType(parts.slice(1));
+    const title = deriveTitle(
+      tc.toolOutput.data as Record<string, unknown> | undefined,
+      resourceType,
+    );
+
+    links.push({ url, title, connectorSlug, resourceType });
+  }
+
+  return links;
+}
+
+/**
+ * Derive resource type from the action parts of a tool name.
+ * e.g. ["get", "ticket"] → "ticket", ["look", "up", "order"] → "order"
+ */
+function deriveResourceType(parts: string[]): string | null {
+  const verbs = [
+    "get",
+    "create",
+    "update",
+    "add",
+    "list",
+    "search",
+    "look",
+    "up",
+  ];
+  const nouns = parts.filter((p) => !verbs.includes(p));
+  return nouns[nouns.length - 1] ?? parts[parts.length - 1] ?? null;
+}
+
+/**
+ * Derive a human-readable title from tool output data.
+ */
+function deriveTitle(
+  data: Record<string, unknown> | undefined,
+  resourceType: string | null,
+): string | null {
+  if (!data) return null;
+
+  // Zendesk: { ticket: { id, subject } }, Medusa: { id, display_id }
+  const nested = (data.ticket ?? data.order ?? data) as Record<string, unknown>;
+  const subject = nested.subject as string | undefined;
+  const displayId = nested.display_id as number | undefined;
+  const id = nested.id as string | number | undefined;
+
+  if (subject && id) return `${subject} (#${id})`;
+  if (displayId) {
+    const label =
+      resourceType === "order" ? "Order" : (resourceType ?? "Resource");
+    return `${label} #${displayId}`;
+  }
+  if (subject) return subject;
+  if (id) return `#${id}`;
+  return null;
+}

--- a/modelguide-api/src/features/sessions/sessions.routes.ts
+++ b/modelguide-api/src/features/sessions/sessions.routes.ts
@@ -2,7 +2,12 @@
  * Session management routes
  */
 
-import type { Session, SessionFeedback, SessionMessage } from "@db/schema";
+import type {
+  Session,
+  SessionFeedback,
+  SessionLink,
+  SessionMessage,
+} from "@db/schema";
 import {
   feedbackResponseSchema,
   formatFeedback,
@@ -81,6 +86,15 @@ const messageResponseSchema = z.object({
   occurredAt: z.string().nullable(),
 });
 
+const sessionLinkSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string(),
+  title: z.string().nullable(),
+  connectorSlug: z.string().nullable(),
+  resourceType: z.string().nullable(),
+  createdAt: z.string(),
+});
+
 const sessionDetailSchema = z.object({
   id: z.string().uuid(),
   organizationId: z.string().uuid(),
@@ -97,6 +111,7 @@ const sessionDetailSchema = z.object({
   durationSeconds: z.number().nullable(),
   messages: z.array(messageResponseSchema),
   feedback: z.array(feedbackResponseSchema),
+  links: z.array(sessionLinkSchema),
 });
 
 const createSessionSchema = z.object({
@@ -235,6 +250,7 @@ function formatSessionDetail(
     durationSeconds: number | null;
     messages: SessionMessage[];
     feedback: SessionFeedback[];
+    links: SessionLink[];
   },
 ) {
   return {
@@ -253,6 +269,18 @@ function formatSessionDetail(
     durationSeconds: session.durationSeconds,
     messages: session.messages.map(formatMessage),
     feedback: session.feedback.map(formatFeedback),
+    links: session.links.map(formatLink),
+  };
+}
+
+function formatLink(link: SessionLink) {
+  return {
+    id: link.id,
+    url: link.url,
+    title: link.title,
+    connectorSlug: link.connectorSlug,
+    resourceType: link.resourceType,
+    createdAt: link.createdAt.toISOString(),
   };
 }
 

--- a/modelguide-api/src/features/sessions/sessions.service.ts
+++ b/modelguide-api/src/features/sessions/sessions.service.ts
@@ -4,7 +4,14 @@
 
 import { db } from "@db/client";
 import { forOrg } from "@db/rls";
-import { agents, sessionFeedback, sessionMessages, sessions } from "@db/schema";
+import {
+  agents,
+  sessionFeedback,
+  sessionLinks,
+  sessionMessages,
+  sessions,
+} from "@db/schema";
+import { extractLinks } from "@features/sessions/link-extraction";
 import { Errors } from "@lib/errors";
 import {
   type PaginationParams,
@@ -157,7 +164,7 @@ export async function getSessionById(orgId: string, sessionId: string) {
       throw Errors.sessionNotFound(sessionId);
     }
 
-    const [messages, feedback] = await Promise.all([
+    const [messages, feedback, links] = await Promise.all([
       tx
         .select()
         .from(sessionMessages)
@@ -168,6 +175,11 @@ export async function getSessionById(orgId: string, sessionId: string) {
         .from(sessionFeedback)
         .where(eq(sessionFeedback.sessionId, sessionId))
         .orderBy(asc(sessionFeedback.createdAt)),
+      tx
+        .select()
+        .from(sessionLinks)
+        .where(eq(sessionLinks.sessionId, sessionId))
+        .orderBy(asc(sessionLinks.createdAt)),
     ]);
 
     return {
@@ -179,6 +191,7 @@ export async function getSessionById(orgId: string, sessionId: string) {
       ),
       messages,
       feedback,
+      links,
     };
   });
 }
@@ -333,7 +346,28 @@ export async function addMessages(
       }
     }
 
-    return tx.insert(sessionMessages).values(rows).returning();
+    const inserted = await tx.insert(sessionMessages).values(rows).returning();
+
+    // Extract external links from tool call outputs
+    const toolCallsWithOutput = messages
+      .flatMap((msg) => msg.toolCalls ?? [])
+      .filter((tc) => tc.toolOutput)
+      .map((tc) => ({
+        toolName: tc.toolName,
+        toolOutput: tc.toolOutput as Record<string, unknown>,
+      }));
+
+    const extracted = extractLinks(toolCallsWithOutput);
+    if (extracted.length > 0) {
+      await tx
+        .insert(sessionLinks)
+        .values(extracted.map((l) => ({ ...l, sessionId })))
+        .onConflictDoNothing({
+          target: [sessionLinks.sessionId, sessionLinks.url],
+        });
+    }
+
+    return inserted;
   });
 }
 

--- a/modelguide-api/src/features/webhooks/elevenlabs.routes.ts
+++ b/modelguide-api/src/features/webhooks/elevenlabs.routes.ts
@@ -9,12 +9,13 @@
 
 import { env } from "@/env";
 import { db } from "@db/client";
-import { agents, sessionMessages, sessions } from "@db/schema";
+import { agents, sessionLinks, sessionMessages, sessions } from "@db/schema";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 
 import { getAgentSecretByType } from "@features/secrets";
+import { extractLinks } from "@features/sessions/link-extraction";
 import { convertPostCallToSession } from "./elevenlabs.converter";
 import { postCallTranscriptionPayloadSchema } from "./elevenlabs.schemas";
 
@@ -149,7 +150,13 @@ app.post("/:agentId/post-call", async (c) => {
     return c.json({ received: true, session_id: existingByExternalId.id });
   }
 
-  // 6. Store session + messages in a transaction
+  // 6. Extract links from tool outputs
+  const toolMessages = converted.messages
+    .filter((m) => m.role === "tool" && m.toolOutput)
+    .map((m) => ({ toolName: m.toolName ?? "", toolOutput: m.toolOutput }));
+  const linkRows = extractLinks(toolMessages);
+
+  // 7. Store session + messages + links in a transaction
   let sessionId: string;
 
   try {
@@ -163,6 +170,17 @@ app.post("/:agentId/post-call", async (c) => {
               ...msg,
             })),
           );
+        }
+
+        if (linkRows.length > 0) {
+          await tx
+            .insert(sessionLinks)
+            .values(
+              linkRows.map((l) => ({ ...l, sessionId: existingSessionId })),
+            )
+            .onConflictDoNothing({
+              target: [sessionLinks.sessionId, sessionLinks.url],
+            });
         }
 
         const [updated] = await tx
@@ -201,6 +219,15 @@ app.post("/:agentId/post-call", async (c) => {
             ...msg,
           })),
         );
+      }
+
+      if (linkRows.length > 0) {
+        await tx
+          .insert(sessionLinks)
+          .values(linkRows.map((l) => ({ ...l, sessionId: session.id })))
+          .onConflictDoNothing({
+            target: [sessionLinks.sessionId, sessionLinks.url],
+          });
       }
 
       return session.id;

--- a/modelguide-api/tests/manual/.env.example
+++ b/modelguide-api/tests/manual/.env.example
@@ -2,3 +2,4 @@ MG_BASE_URL=http://localhost:3000
 MG_AGENT_ID=your-agent-uuid
 MG_API_KEY=mgk_your_api_key
 MG_CONNECTOR_SLUG=your_zendesk_connector_slug
+MG_POSTCALL_PAYLOAD=

--- a/modelguide-api/tests/manual/replay-post-call.ts
+++ b/modelguide-api/tests/manual/replay-post-call.ts
@@ -1,0 +1,112 @@
+/**
+ * Manual test: replay a saved ElevenLabs post-call webhook payload.
+ *
+ * The webhook route dumps payloads to /tmp/elevenlabs-post-call-*.json
+ * in development mode. This script replays one of those files against
+ * the local webhook endpoint with HMAC verification skipped.
+ *
+ * Required env vars:
+ *   MG_BASE_URL   — e.g. http://localhost:3000
+ *   MG_AGENT_ID   — agent UUID
+ *
+ * Usage:
+ *   bun run tests/manual/replay-post-call.ts <path-to-payload.json>
+ *
+ *   # or replay the latest dump automatically:
+ *   bun run tests/manual/replay-post-call.ts --latest
+ */
+
+import { readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Load .env from tests/manual/.env
+const envPath = resolve(import.meta.dir, ".env");
+await Bun.file(envPath)
+  .text()
+  .then((text) => {
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx === -1) continue;
+      const key = trimmed.slice(0, idx).trim();
+      const val = trimmed.slice(idx + 1).trim();
+      if (!process.env[key]) process.env[key] = val;
+    }
+  })
+  .catch(() => {
+    console.warn(
+      "No tests/manual/.env found, falling back to exported env vars",
+    );
+  });
+
+const BASE_URL = requireEnv("MG_BASE_URL");
+const AGENT_ID = requireEnv("MG_AGENT_ID");
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`Missing env var: ${name}`);
+    process.exit(1);
+  }
+  return val;
+}
+
+// Resolve payload file path: CLI arg > env var > latest tmp dump
+let payloadPath = process.argv[2];
+
+if (!payloadPath || payloadPath === "--latest") {
+  const payloadFromEnv = process.env.MG_POSTCALL_PAYLOAD;
+
+  if (payloadFromEnv) {
+    payloadPath = resolve(payloadFromEnv);
+    console.log(`Using payload from MG_POSTCALL_PAYLOAD: ${payloadPath}`);
+  } else {
+    // Find the latest dump in /tmp
+    const prefix = `elevenlabs-post-call-${AGENT_ID}-`;
+    const files = readdirSync(tmpdir())
+      .filter((f) => f.startsWith(prefix) && f.endsWith(".json"))
+      .sort()
+      .reverse();
+
+    if (files.length === 0) {
+      console.error(
+        `No payload dumps found in ${tmpdir()} for agent ${AGENT_ID}.\nSet MG_POSTCALL_PAYLOAD in .env or ensure the API has received a webhook in dev mode.`,
+      );
+      process.exit(1);
+    }
+
+    payloadPath = join(tmpdir(), files[0]);
+    console.log(`Using latest dump: ${payloadPath}`);
+  }
+} else {
+  payloadPath = resolve(payloadPath);
+}
+
+// Read payload
+const rawBody = await Bun.file(payloadPath).text();
+console.log(`Payload size: ${rawBody.length} bytes`);
+
+// Send to webhook endpoint with HMAC skip header
+const url = `${BASE_URL}/webhooks/elevenlabs/${AGENT_ID}/post-call`;
+console.log(`\n=== POST ${url} ===`);
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-skip-hmac": "true",
+  },
+  body: rawBody,
+});
+
+const body = await res.text();
+console.log(`Status: ${res.status}`);
+try {
+  console.log("Response:", JSON.stringify(JSON.parse(body), null, 2));
+} catch {
+  console.log("Response:", body);
+}
+
+process.exit(res.ok ? 0 : 1);

--- a/modelguide-ui/src/features/sessions/components/session-detail.tsx
+++ b/modelguide-ui/src/features/sessions/components/session-detail.tsx
@@ -1,3 +1,5 @@
+import type { LucideIcon } from 'lucide-react'
+import { ExternalLink, Link, Package, Ticket } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
@@ -5,7 +7,11 @@ import { RatingBadge } from '~/components/ui/rating-badge'
 import { Tooltip } from '~/components/ui/tooltip'
 import { channelConfig } from '~/lib/channel-config'
 import { formatDate, formatDuration } from '~/lib/utils'
-import type { SessionDetail as SessionDetailType, SessionStatus } from '~/schemas/sessions'
+import type {
+  SessionDetail as SessionDetailType,
+  SessionLink,
+  SessionStatus,
+} from '~/schemas/sessions'
 import { Transcript } from './transcript'
 
 const statusVariants: Record<SessionStatus, 'active' | 'completed' | 'abandoned'> = {
@@ -161,6 +167,22 @@ export function SessionDetail({ session, onRate }: SessionDetailProps) {
         </CardContent>
       </Card>
 
+      {/* External Resources */}
+      {session.links && session.links.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>External Resources</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {session.links.map((link) => (
+                <ExternalLinkRow key={link.id} link={link} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Transcript */}
       <Card>
         <CardHeader>
@@ -207,6 +229,29 @@ export function SessionDetail({ session, onRate }: SessionDetailProps) {
   )
 }
 
+const resourceIcons: Record<string, LucideIcon> = {
+  ticket: Ticket,
+  order: Package,
+}
+
+function ExternalLinkRow({ link }: { link: SessionLink }) {
+  const Icon = resourceIcons[link.resourceType ?? ''] ?? Link
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 rounded-lg border border-fg-subtle/10 bg-bg-subtle px-3 py-2 transition-colors hover:border-brand-500/30 hover:bg-bg-subtle/80"
+    >
+      <Icon className="h-4 w-4 shrink-0 text-fg-muted" />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium text-fg-primary">
+        {link.title ?? link.url}
+      </span>
+      {link.connectorSlug && <Badge variant="default">{link.connectorSlug}</Badge>}
+      <ExternalLink className="h-4 w-4 shrink-0 text-fg-muted" />
+    </a>
+  )
+}
 function InfoItem({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div>

--- a/modelguide-ui/src/schemas/sessions.ts
+++ b/modelguide-ui/src/schemas/sessions.ts
@@ -77,10 +77,22 @@ export const sessionListItemSchema = z.object({
 
 export type SessionListItem = z.infer<typeof sessionListItemSchema>
 
-// Detail endpoint — includes messages + feedback
+export const sessionLinkSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string().nullable(),
+  connectorSlug: z.string().nullable(),
+  resourceType: z.string().nullable(),
+  createdAt: z.string(),
+})
+
+export type SessionLink = z.infer<typeof sessionLinkSchema>
+
+// Detail endpoint — includes messages + feedback + links
 export const sessionDetailSchema = sessionListItemSchema.extend({
   messages: z.array(sessionMessageSchema),
   feedback: z.array(sessionFeedbackSchema),
+  links: z.array(sessionLinkSchema).optional().default([]),
 })
 
 export type SessionDetail = z.infer<typeof sessionDetailSchema>


### PR DESCRIPTION
## Summary
- Connectors (Zendesk, Medusa) now return a `url` field in tool results pointing to the resource in the external system
- URLs are extracted when messages are stored (both MCP and post-call webhook paths) and persisted in a new `session_links` table
- Session detail API includes links in its response, and the UI renders them in an External Resources card with Lucide icons

## Test plan
- [ ] Replay ElevenLabs post-call webhook with tool calls containing URLs → verify `session_links` rows created
- [ ] `GET /sessions/{id}` → verify `links` array in response
- [ ] UI: open session detail → verify External Resources card with clickable links
- [ ] Verify deduplication: replaying same payload doesn't create duplicate links

🤖 Generated with [Claude Code](https://claude.com/claude-code)