### PR TITLE
feat(api): add manual MCP order lookup test and extract shared helpers

### DIFF
--- a/modelguide-api/tests/manual/.env.example
+++ b/modelguide-api/tests/manual/.env.example
@@ -3,3 +3,7 @@ MG_AGENT_ID=your-agent-uuid
 MG_API_KEY=mgk_your_api_key
 MG_CONNECTOR_SLUG=your_zendesk_connector_slug
 MG_POSTCALL_PAYLOAD=
+
+# mcp-order-lookup.ts
+MG_ORDER_EMAIL=customer@example.com
+MG_ORDER_DISPLAY_ID=1001

--- a/modelguide-api/tests/manual/mcp-helpers.ts
+++ b/modelguide-api/tests/manual/mcp-helpers.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared helpers for manual MCP test scripts.
+ */
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+export async function loadEnv(dir: string): Promise<void> {
+  const envPath = resolve(dir, ".env");
+  await Bun.file(envPath)
+    .text()
+    .then((text) => {
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const idx = trimmed.indexOf("=");
+        if (idx === -1) continue;
+        const key = trimmed.slice(0, idx).trim();
+        const val = trimmed.slice(idx + 1).trim();
+        if (!process.env[key]) process.env[key] = val;
+      }
+    })
+    .catch(() => {
+      console.warn("No .env found at", envPath, "— using exported env vars");
+    });
+}
+
+export function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`Missing env var: ${name}`);
+    process.exit(1);
+  }
+  return val;
+}
+
+// ---------------------------------------------------------------------------
+// REST + MCP client
+// ---------------------------------------------------------------------------
+
+export interface McpTestContext {
+  baseUrl: string;
+  agentId: string;
+  apiKey: string;
+  connectorSlug: string;
+  client: Client;
+  sessionId: string;
+  /** Convenience: prefixed tool name */
+  toolName(tool: string): string;
+  /** Authenticated REST request against the API */
+  request(path: string, options?: RequestInit): Promise<Response>;
+  /** Close session + disconnect MCP client */
+  cleanup(): Promise<void>;
+}
+
+interface SetupOptions {
+  /** Session user identifier (phone, email, etc.) */
+  userIdentifier?: string;
+  channelType?: string;
+}
+
+export async function setupMcpTest(
+  opts: SetupOptions = {},
+): Promise<McpTestContext> {
+  const baseUrl = requireEnv("MG_BASE_URL");
+  const agentId = requireEnv("MG_AGENT_ID");
+  const apiKey = requireEnv("MG_API_KEY");
+  const connectorSlug = requireEnv("MG_CONNECTOR_SLUG");
+
+  const request = (path: string, options?: RequestInit) =>
+    fetch(`${baseUrl}${path}`, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    });
+
+  // Create session
+  console.log("=== Creating session ===");
+  const sessionRes = await request("/api/sessions", {
+    method: "POST",
+    body: JSON.stringify({
+      channelType: opts.channelType ?? "voice",
+      userIdentifier: opts.userIdentifier ?? "+1234567890",
+    }),
+  });
+
+  if (!sessionRes.ok) {
+    console.error(
+      "Failed to create session:",
+      sessionRes.status,
+      await sessionRes.text(),
+    );
+    process.exit(1);
+  }
+
+  const session = (await sessionRes.json()) as { id: string };
+  console.log("Session created:", session.id);
+
+  // Connect MCP
+  console.log("\n=== Connecting MCP client ===");
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${baseUrl}/mcp/${agentId}`),
+    { requestInit: { headers: { Authorization: `Bearer ${apiKey}` } } },
+  );
+
+  const client = new Client({ name: "manual-test", version: "1.0.0" });
+  await client.connect(transport);
+  console.log("MCP connected");
+
+  // List tools
+  console.log("\n=== Listing tools ===");
+  const { tools } = await client.listTools();
+  console.log(
+    "Available tools:",
+    tools.map((t) => t.name),
+  );
+
+  return {
+    baseUrl,
+    agentId,
+    apiKey,
+    connectorSlug,
+    client,
+    sessionId: session.id,
+    toolName: (tool) => `${connectorSlug}_${tool}`,
+    request,
+    async cleanup() {
+      console.log("\n=== Closing session ===");
+      const closeRes = await request(`/api/sessions/${session.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "completed" }),
+      });
+      console.log("Session closed:", closeRes.status);
+      await client.close();
+    },
+  };
+}

--- a/modelguide-api/tests/manual/mcp-medusa-order-lookup.ts
+++ b/modelguide-api/tests/manual/mcp-medusa-order-lookup.ts
@@ -1,0 +1,41 @@
+/**
+ * Manual E2E test: create a session, then call the Medusa look_up_order tool via MCP.
+ *
+ * Extra env vars:
+ *   MG_ORDER_EMAIL       — customer email to look up
+ *   MG_ORDER_DISPLAY_ID  — order display ID (e.g. "1001")
+ *
+ * Usage:
+ *   bun run tests/manual/mcp-medusa-order-lookup.ts
+ */
+
+import { loadEnv, requireEnv, setupMcpTest } from "./mcp-helpers";
+
+await loadEnv(import.meta.dir);
+
+const orderEmail = requireEnv("MG_ORDER_EMAIL");
+const orderDisplayId = Number(requireEnv("MG_ORDER_DISPLAY_ID"));
+
+const ctx = await setupMcpTest({
+  connectorSlug: "acme-store",
+  userIdentifier: orderEmail,
+});
+const tool = ctx.toolName("look_up_order");
+
+console.log(`\n=== Calling ${tool} ===`);
+console.log(`  email: ${orderEmail}`);
+console.log(`  displayId: ${orderDisplayId}`);
+
+const result = await ctx.client.callTool({
+  name: tool,
+  arguments: {
+    session_id: ctx.sessionId,
+    email: orderEmail,
+    displayId: orderDisplayId,
+  },
+});
+
+console.log("\nResult:", JSON.stringify(result, null, 2));
+
+await ctx.cleanup();
+process.exit(0);

--- a/modelguide-api/tests/manual/mcp-zendesk-ticket.ts
+++ b/modelguide-api/tests/manual/mcp-zendesk-ticket.ts
@@ -1,123 +1,22 @@
 /**
  * Manual E2E test: create a session, then call the Zendesk create_ticket tool via MCP.
  *
- * Required env vars:
- *   MG_BASE_URL        — e.g. http://localhost:3000
- *   MG_AGENT_ID        — agent UUID
- *   MG_API_KEY         — mgk_... API key
- *   MG_CONNECTOR_SLUG  — Zendesk connector slug (e.g. "acme_zendesk")
- *
- * Setup:
- *   cp tests/manual/.env.example tests/manual/.env
- *   # fill in values in tests/manual/.env
- *
  * Usage:
  *   bun run tests/manual/mcp-zendesk-ticket.ts
  */
 
-import { resolve } from "node:path";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { loadEnv, setupMcpTest } from "./mcp-helpers";
 
-// Load .env from tests/manual/.env
-const envPath = resolve(import.meta.dir, ".env");
-await Bun.file(envPath)
-  .text()
-  .then((text) => {
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const idx = trimmed.indexOf("=");
-      if (idx === -1) continue;
-      const key = trimmed.slice(0, idx).trim();
-      const val = trimmed.slice(idx + 1).trim();
-      if (!process.env[key]) process.env[key] = val;
-    }
-  })
-  .catch(() => {
-    console.warn(
-      "No tests/manual/.env found, falling back to exported env vars",
-    );
-  });
+await loadEnv(import.meta.dir);
 
-const BASE_URL = requireEnv("MG_BASE_URL");
-const AGENT_ID = requireEnv("MG_AGENT_ID");
-const API_KEY = requireEnv("MG_API_KEY");
-const CONNECTOR_SLUG = requireEnv("MG_CONNECTOR_SLUG");
+const ctx = await setupMcpTest();
+const tool = ctx.toolName("create_ticket");
 
-function requireEnv(name: string): string {
-  const val = process.env[name];
-  if (!val) {
-    console.error(`Missing env var: ${name}`);
-    process.exit(1);
-  }
-  return val;
-}
-
-async function request(path: string, options?: RequestInit): Promise<Response> {
-  return fetch(`${BASE_URL}${path}`, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-}
-
-// Step 1: Create a session via REST
-console.log("=== Creating session ===");
-const sessionRes = await request("/api/sessions", {
-  method: "POST",
-  body: JSON.stringify({
-    channelType: "voice",
-    userIdentifier: "+1234567890",
-  }),
-});
-
-if (!sessionRes.ok) {
-  console.error(
-    "Failed to create session:",
-    sessionRes.status,
-    await sessionRes.text(),
-  );
-  process.exit(1);
-}
-
-const session = (await sessionRes.json()) as { id: string };
-console.log("Session created:", session.id);
-
-// Step 2: Connect MCP client
-console.log("\n=== Connecting MCP client ===");
-const transport = new StreamableHTTPClientTransport(
-  new URL(`${BASE_URL}/mcp/${AGENT_ID}`),
-  {
-    requestInit: {
-      headers: { Authorization: `Bearer ${API_KEY}` },
-    },
-  },
-);
-
-const client = new Client({ name: "manual-test", version: "1.0.0" });
-await client.connect(transport);
-console.log("MCP connected");
-
-// Step 3: List tools
-console.log("\n=== Listing tools ===");
-const { tools } = await client.listTools();
-console.log(
-  "Available tools:",
-  tools.map((t) => t.name),
-);
-
-// Step 4: Call create_ticket
-const toolName = `${CONNECTOR_SLUG}_create_ticket`;
-console.log(`\n=== Calling ${toolName} ===`);
-
-const result = await client.callTool({
-  name: toolName,
+console.log(`\n=== Calling ${tool} ===`);
+const result = await ctx.client.callTool({
+  name: tool,
   arguments: {
-    session_id: session.id,
+    session_id: ctx.sessionId,
     subject: "Test ticket from MCP",
     description: "This is a test ticket created via ModelGuide MCP endpoint.",
     body: "This is a test ticket created via ModelGuide MCP endpoint.",
@@ -129,13 +28,5 @@ const result = await client.callTool({
 
 console.log("\nResult:", JSON.stringify(result, null, 2));
 
-// Cleanup: close session
-console.log("\n=== Closing session ===");
-const closeRes = await request(`/api/sessions/${session.id}`, {
-  method: "PATCH",
-  body: JSON.stringify({ status: "completed" }),
-});
-console.log("Session closed:", closeRes.status);
-
-await client.close();
+await ctx.cleanup();
 process.exit(0);


### PR DESCRIPTION
## Summary
- Extract shared MCP test utilities (`mcp-helpers.ts`): env loading, session lifecycle, client connection, cleanup
- Refactor existing Zendesk ticket test to use shared helpers (142 → 33 lines)
- Add new Medusa `look_up_order` manual E2E test
- Update `.env.example` with order-specific vars

## Test plan
- [ ] `bun run tests/manual/mcp-order-lookup.ts` against a running Medusa instance
- [ ] `bun run tests/manual/mcp-zendesk-ticket.ts` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)