### PR TITLE
docs: add CLA assistant badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>&nbsp;
-  <a href="https://github.com/modelguide/modelguide/actions/workflows/ci.yml"><img src="https://github.com/modelguide/modelguide/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" /></a>
+  <a href="https://github.com/modelguide/modelguide/actions/workflows/ci.yml"><img src="https://github.com/modelguide/modelguide/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" /></a>&nbsp;
+  <a href="https://cla-assistant.io/modelguide/modelguide"><img src="https://cla-assistant.io/readme/badge/modelguide/modelguide" alt="CLA assistant" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds the CLA assistant badge to the README badge row, next to the existing MIT License and CI Status badges.

Badge links to https://cla-assistant.io/modelguide/modelguide where contributors can view and sign the CLA.