### PR TITLE
feat(db): add post-seed verification with row count checks

### DIFF
--- a/modelguide-api/src/db/seed/index.ts
+++ b/modelguide-api/src/db/seed/index.ts
@@ -101,12 +101,13 @@ async function seedAll(db: SeedDb) {
   }
 }
 
-const EXPECTED_COUNTS: Record<string, number> = {
+const MIN_ROW_COUNTS: Record<string, number> = {
   organizations: 3,
-  users: 9, // minimum: 3 per org
+  users: 9, // 3 per org
   agents: 6,
   connectors: 6,
-  sessions: 300, // at least 300 generated per org, plus handwritten
+  connector_tools: 1,
+  sessions: 300, // ~300 generated per org, plus handwritten
   session_messages: 100,
   session_feedback: 50,
 };
@@ -114,26 +115,26 @@ const EXPECTED_COUNTS: Record<string, number> = {
 async function verifySeed(db: SeedDb): Promise<boolean> {
   console.log("\nVerifying seed data...");
 
-  const rows = await db.execute<{ tbl: string; count: number }>(sql`
-    SELECT 'organizations' AS tbl, count(*)::int AS count FROM organizations
-    UNION ALL SELECT 'users', count(*)::int FROM users
-    UNION ALL SELECT 'agents', count(*)::int FROM agents
-    UNION ALL SELECT 'connectors', count(*)::int FROM connectors
-    UNION ALL SELECT 'connector_tools', count(*)::int FROM connector_tools
-    UNION ALL SELECT 'sessions', count(*)::int FROM sessions
-    UNION ALL SELECT 'session_messages', count(*)::int FROM session_messages
-    UNION ALL SELECT 'session_feedback', count(*)::int FROM session_feedback
-  `);
+  const tables = Object.keys(MIN_ROW_COUNTS);
+  const counts: Record<string, number> = {};
+
+  for (const tbl of tables) {
+    const [row] = await db.execute<{ count: number }>(
+      sql`SELECT count(*)::int AS count FROM ${sql.identifier(tbl)}`,
+    );
+    counts[tbl] = row.count;
+  }
 
   let ok = true;
-  const widest = Math.max(...rows.map((r) => r.tbl.length));
+  const widest = Math.max(...tables.map((t) => t.length));
 
-  for (const { tbl, count } of rows) {
-    const expected = EXPECTED_COUNTS[tbl];
-    const fail = expected !== undefined && count < expected;
+  for (const tbl of tables) {
+    const count = counts[tbl];
+    const min = MIN_ROW_COUNTS[tbl];
+    const fail = count < min;
     const marker = fail ? "FAIL" : " ok ";
     console.log(
-      `  [${marker}] ${tbl.padEnd(widest)}  ${count}${fail ? `  (expected >= ${expected})` : ""}`,
+      `  [${marker}] ${tbl.padEnd(widest)}  ${count}${fail ? `  (expected >= ${min})` : ""}`,
     );
     if (fail) ok = false;
   }


### PR DESCRIPTION
## Summary
- Extracts the seed verification feature from #93 into its own PR (that PR was mixing UI tooltip changes with DB seed logic)
- After seeding, queries key tables and compares row counts against expected minimums
- Prints a pass/fail summary and sets a non-zero exit code when any table falls short

## Test plan
- [ ] Run `make db-seed` and verify the new verification summary prints after seeding
- [ ] Confirm exit code is 0 on a successful seed
- [ ] Verify type check passes (`make api-typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)