### PR TITLE
docs(decisions): add ADR-003 to index table in decisions/README.md

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,3 +4,4 @@
 |-----|-------|--------|
 | [001](001-refresh-token-rotation.md) | Refresh Token Rotation | Accepted |
 | [002](002-magic-link-authentication.md) | Magic Link Authentication & Session Lifecycle | Accepted |
+| [003](003-medusa-payment-auto-init.md) | Auto-Initiate Payment Session on Cart Completion (Medusa) | Accepted |


### PR DESCRIPTION
## Summary

PR #102 (ADR-003 for Medusa payment auto-init) was merged without updating the ADR index table in `docs/decisions/README.md`. This PR adds the missing row.

## Changes

- docs(decisions): add ADR-003 to index table in decisions/README.md

## How to Test

1. Open `docs/decisions/README.md`
2. Confirm the table has 3 rows (ADR-001, ADR-002, ADR-003)
3. Confirm the ADR-003 link resolves to `003-medusa-payment-auto-init.md`

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass
- [x] Scoped to one concern