### PR TITLE
docs: add DATABASE_MIGRATION_URL to .env.example

### DIFF
--- a/modelguide-api/.env.example
+++ b/modelguide-api/.env.example
@@ -1,6 +1,7 @@
 PORT=3000
 NODE_ENV=development
 DATABASE_URL=postgresql://modelguide_app:modelguide_app@localhost:5434/modelguide
+DATABASE_MIGRATION_URL=postgresql://modelguide:modelguide@localhost:5434/modelguide
 MCP_SERVER_NAME=ModelGuide MCP
 MCP_SERVER_VERSION=1.0.0
 


### PR DESCRIPTION
## Summary

- Add `DATABASE_MIGRATION_URL` to `.env.example` so the migration user (`modelguide`, with DDL privileges) is documented alongside the RLS app user (`modelguide_app`)

## Test plan

- [ ] Verify `make db-migrate` works with the migration URL
- [ ] Verify `make api-dev` works with the app URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)