### PR TITLE
fix(ci): allow claude[bot] to trigger code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'claude[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Add `allowed_bots: 'claude[bot]'` to the Claude Code Review workflow so PRs opened by the Claude bot don't fail with "non-human actor" error

Fixes CI failure on #101.

## Test plan

- [ ] Merge this PR, then re-run CI on #101 — `claude-review` check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)