### PR TITLE
feat(connectors): add optional email field to Medusa createCart tool

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
@@ -38,10 +38,12 @@ export const createCart = withMedusa(async (fetcher, ctx) => {
   const input = ctx.input as {
     regionId?: string;
     currencyCode?: string;
+    email?: string;
   };
   const body: Record<string, unknown> = {};
   if (input.regionId) body.region_id = input.regionId;
   if (input.currencyCode) body.currency_code = input.currencyCode;
+  if (input.email) body.email = input.email;
 
   const data = await fetcher<Record<string, unknown>>("/store/carts", {
     method: "POST",

--- a/modelguide-api/src/features/connectors/catalog/medusa/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/index.ts
@@ -86,6 +86,10 @@ const tools: ConnectorToolDefinition[] = [
             type: "string",
             description: "Currency code (e.g., usd, eur)",
           },
+          email: {
+            type: "string",
+            description: "Customer email address for the cart",
+          },
         },
         required: [],
       },

--- a/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
+++ b/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
@@ -141,10 +141,14 @@ describe("Medusa handlers", () => {
   // Create Cart
   // ----------------------------------------------------------------
   describe("createCart", () => {
-    test("calls POST /store/carts", async () => {
+    test("calls POST /store/carts with all optional fields", async () => {
       mockFetchSuccess({ cart: { id: "cart_abc" } });
       const result = await createCart(
-        makeCtx({ regionId: "reg_us", currencyCode: "usd" }),
+        makeCtx({
+          regionId: "reg_us",
+          currencyCode: "usd",
+          email: "customer@example.com",
+        }),
       );
       expect(result.success).toBe(true);
 
@@ -154,6 +158,7 @@ describe("Medusa handlers", () => {
       const body = JSON.parse(opts.body);
       expect(body.region_id).toBe("reg_us");
       expect(body.currency_code).toBe("usd");
+      expect(body.email).toBe("customer@example.com");
     });
 
     test("sends empty body when no params", async () => {
@@ -163,6 +168,17 @@ describe("Medusa handlers", () => {
       const [, opts] = fetchMock.mock.calls[0];
       const body = JSON.parse(opts.body);
       expect(body).toEqual({});
+    });
+
+    test("omits email from body when not provided", async () => {
+      mockFetchSuccess({ cart: { id: "cart_abc" } });
+      await createCart(makeCtx({ regionId: "reg_us", currencyCode: "usd" }));
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.region_id).toBe("reg_us");
+      expect(body.currency_code).toBe("usd");
+      expect(body).not.toHaveProperty("email");
     });
   });
 


### PR DESCRIPTION
## Summary

Add support for an optional `email` field on the Medusa `createCart` tool so AI agents can associate a customer email with the cart at creation time. This enables order confirmation emails and customer association without a separate update step.

## Changes

- feat(connectors): add optional email field to Medusa createCart tool

## How to Test

1. Start the API dev server
2. Connect an AI agent via MCP and call the `createCart` tool with `{ "email": "customer@example.com", "regionId": "reg_us" }`
3. Verify the cart is created with the email attached
4. Call `createCart` without `email` and verify it still works (backward compatible)

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Unit tests pass (278/278, including 2 new createCart tests)
- [x] UI lint, typecheck, and tests pass
- [x] Scoped to one concern