### PR TITLE
feat(medusa): add inventory stock data and fix order lookup fields

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
@@ -21,6 +21,7 @@ export const listProducts = withMedusa(async (fetcher, ctx) => {
       limit: input.limit ?? 20,
       offset: input.offset ?? 0,
       q: input.query,
+      fields: "+variants.inventory_quantity",
     },
   });
   return { success: true, data };
@@ -30,6 +31,11 @@ export const getProduct = withMedusa(async (fetcher, ctx) => {
   const { productId } = ctx.input as { productId: string };
   const data = await fetcher<Record<string, unknown>>(
     `/store/products/${productId}`,
+    {
+      params: {
+        fields: "+variants.inventory_quantity",
+      },
+    },
   );
   return { success: true, data };
 });
@@ -255,11 +261,17 @@ function dashboardUrl(
 }
 
 /** Medusa Admin API response types for order detail. */
+interface MedusaOrderItemVariant {
+  id: string;
+  title: string;
+}
+
 interface MedusaOrderItem {
   id: string;
   title: string;
   quantity: number;
   unit_price: number;
+  variant?: MedusaOrderItemVariant;
 }
 
 interface MedusaOrderDetail {
@@ -268,8 +280,8 @@ interface MedusaOrderDetail {
   status: string;
   total: number;
   currency_code: string;
+  email: string;
   summary: Record<string, unknown>;
-  version: number;
   metadata: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
@@ -313,7 +325,7 @@ export const lookUpOrder = withMedusaAdmin(async (fetcher, ctx) => {
         offset,
         order: "-created_at",
         fields:
-          "id,display_id,status,total,currency_code,summary,version,metadata,created_at,updated_at,*items",
+          "id,display_id,status,total,currency_code,email,summary,metadata,created_at,updated_at,*items,*items.variant,shipping_address.first_name,shipping_address.last_name,shipping_address.address_1,shipping_address.address_2,shipping_address.city,shipping_address.postal_code,shipping_address.country_code,shipping_address.phone",
       },
     });
 
@@ -375,7 +387,7 @@ export const lookUpOrderHistory = withMedusaAdmin(async (fetcher, ctx) => {
       offset,
       order: "-created_at",
       fields:
-        "id,display_id,status,currency_code,email,created_at,updated_at,*items,*shipping_address,*summary",
+        "id,display_id,status,total,currency_code,email,metadata,created_at,updated_at,*items,*items.variant,shipping_address.first_name,shipping_address.last_name,shipping_address.address_1,shipping_address.address_2,shipping_address.city,shipping_address.postal_code,shipping_address.country_code,shipping_address.phone,*summary",
     },
   });
 

--- a/modelguide-api/src/features/connectors/catalog/medusa/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/index.ts
@@ -24,7 +24,7 @@ const tools: ConnectorToolDefinition[] = [
     catalog: {
       name: "List Products",
       description:
-        "Search the store catalog for products by name, brand, or category",
+        "Search the store catalog for products by name, brand, or category. Returns variant-level stock availability.",
       inputSchema: {
         type: "object",
         properties: {
@@ -56,7 +56,7 @@ const tools: ConnectorToolDefinition[] = [
     catalog: {
       name: "Get Product",
       description:
-        "Get product details (price, description, variants). Use a product ID returned by search.",
+        "Get product details (price, description, variants, inventory quantity). Use a product ID returned by search.",
       inputSchema: {
         type: "object",
         properties: {

--- a/modelguide-api/tests/manual/.env.example
+++ b/modelguide-api/tests/manual/.env.example
@@ -7,3 +7,6 @@ MG_POSTCALL_PAYLOAD=
 # mcp-order-lookup.ts
 MG_ORDER_EMAIL=customer@example.com
 MG_ORDER_DISPLAY_ID=1001
+
+# mcp-medusa-products.ts
+MG_PRODUCT_QUERY=olaplex

--- a/modelguide-api/tests/manual/mcp-medusa-products.ts
+++ b/modelguide-api/tests/manual/mcp-medusa-products.ts
@@ -1,0 +1,61 @@
+/**
+ * Manual E2E test: create a session, then call list_products and get_product
+ * via MCP to verify inventory data is returned.
+ *
+ * Extra env vars:
+ *   MG_PRODUCT_QUERY — search term (default: "olaplex")
+ *
+ * Usage:
+ *   bun run tests/manual/mcp-medusa-products.ts
+ */
+
+import { loadEnv, setupMcpTest } from "./mcp-helpers";
+
+await loadEnv(import.meta.dir);
+
+const query = process.env.MG_PRODUCT_QUERY ?? "olaplex";
+
+const ctx = await setupMcpTest();
+
+// 1. List products
+const listTool = ctx.toolName("list_products");
+console.log(`\n=== Calling ${listTool} ===`);
+console.log(`  query: ${query}`);
+
+const listResult = await ctx.client.callTool({
+  name: listTool,
+  arguments: {
+    session_id: ctx.sessionId,
+    query,
+    limit: 5,
+  },
+});
+
+console.log("\nlist_products result:", JSON.stringify(listResult, null, 2));
+
+// 2. Get first product details
+const content = listResult.content as { type: string; text: string }[];
+const text = content?.find((c) => c.type === "text")?.text;
+const parsed = text ? JSON.parse(text) : null;
+const firstProduct = parsed?.data?.products?.[0];
+
+if (firstProduct) {
+  const getTool = ctx.toolName("get_product");
+  console.log(`\n=== Calling ${getTool} ===`);
+  console.log(`  productId: ${firstProduct.id}`);
+
+  const getResult = await ctx.client.callTool({
+    name: getTool,
+    arguments: {
+      session_id: ctx.sessionId,
+      productId: firstProduct.id,
+    },
+  });
+
+  console.log("\nget_product result:", JSON.stringify(getResult, null, 2));
+} else {
+  console.log("\nNo products found — skipping get_product");
+}
+
+await ctx.cleanup();
+process.exit(0);

--- a/modelguide-api/tests/manual/test-medusa-inventory.ts
+++ b/modelguide-api/tests/manual/test-medusa-inventory.ts
@@ -1,0 +1,98 @@
+/**
+ * Quick test: call Medusa Store API directly to verify inventory_quantity
+ * is returned when using the +variants.inventory_quantity fields param.
+ *
+ * Env vars (or create tests/manual/.env):
+ *   MEDUSA_BASE_URL       — e.g. https://your-medusa.example.com
+ *   MEDUSA_PUBLISHABLE_KEY — pk_xxx
+ *   MEDUSA_PRODUCT_QUERY  — search term (default: "olaplex")
+ *
+ * Usage:
+ *   bun run tests/manual/test-medusa-inventory.ts
+ */
+
+import { loadEnv } from "./mcp-helpers";
+
+await loadEnv(import.meta.dir);
+
+const baseUrl = process.env.MEDUSA_BASE_URL;
+const publishableKey = process.env.MEDUSA_PUBLISHABLE_KEY;
+const query = process.env.MEDUSA_PRODUCT_QUERY ?? "olaplex";
+
+if (!baseUrl || !publishableKey) {
+  console.error(
+    "Set MEDUSA_BASE_URL and MEDUSA_PUBLISHABLE_KEY in tests/manual/.env",
+  );
+  process.exit(1);
+}
+
+const headers = { "x-publishable-api-key": publishableKey };
+
+// 1. List products WITH inventory field
+console.log("=== list_products (with +variants.inventory_quantity) ===");
+const listUrl = `${baseUrl}/store/products?q=${query}&limit=3&fields=%2Bvariants.inventory_quantity`;
+const listRes = await fetch(listUrl, { headers });
+const listData = (await listRes.json()) as {
+  products: {
+    id: string;
+    title: string;
+    variants: { id: string; title: string; inventory_quantity?: number }[];
+  }[];
+};
+
+for (const p of listData.products ?? []) {
+  console.log(`\n  ${p.title} (${p.id})`);
+  for (const v of p.variants ?? []) {
+    const stock =
+      v.inventory_quantity !== undefined ? v.inventory_quantity : "NOT PRESENT";
+    console.log(
+      `    variant ${v.title ?? v.id}: inventory_quantity = ${stock}`,
+    );
+  }
+}
+
+if (!listData.products?.length) {
+  console.log("  No products found for query:", query);
+  process.exit(0);
+}
+
+// 2. Get single product WITH inventory field
+const productId = listData.products[0].id;
+console.log(
+  `\n=== get_product ${productId} (with +variants.inventory_quantity) ===`,
+);
+const getUrl = `${baseUrl}/store/products/${productId}?fields=%2Bvariants.inventory_quantity`;
+const getRes = await fetch(getUrl, { headers });
+const getData = (await getRes.json()) as {
+  product: {
+    id: string;
+    title: string;
+    variants: { id: string; title: string; inventory_quantity?: number }[];
+  };
+};
+
+const prod = getData.product;
+console.log(`\n  ${prod.title} (${prod.id})`);
+for (const v of prod.variants ?? []) {
+  const stock =
+    v.inventory_quantity !== undefined ? v.inventory_quantity : "NOT PRESENT";
+  console.log(`    variant ${v.title ?? v.id}: inventory_quantity = ${stock}`);
+}
+
+// 3. Compare: without the field
+console.log(`\n=== get_product ${productId} (WITHOUT inventory field) ===`);
+const bareRes = await fetch(`${baseUrl}/store/products/${productId}`, {
+  headers,
+});
+const bareData = (await bareRes.json()) as {
+  product: {
+    variants: { id: string; title: string; inventory_quantity?: number }[];
+  };
+};
+for (const v of bareData.product?.variants ?? []) {
+  const stock =
+    v.inventory_quantity !== undefined ? v.inventory_quantity : "NOT PRESENT";
+  console.log(`    variant ${v.title ?? v.id}: inventory_quantity = ${stock}`);
+}
+
+console.log("\nDone.");

--- a/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
+++ b/modelguide-api/tests/unit/connectors/medusa-handlers.test.ts
@@ -100,6 +100,7 @@ describe("Medusa handlers", () => {
       expect(url).toContain("/store/products");
       expect(url).toContain("limit=20");
       expect(url).toContain("offset=0");
+      expect(url).toContain("fields=%2Bvariants.inventory_quantity");
       expect(opts.method).toBe("GET");
     });
 
@@ -111,6 +112,7 @@ describe("Medusa handlers", () => {
       expect(url).toContain("q=shirt");
       expect(url).toContain("limit=5");
       expect(url).toContain("offset=10");
+      expect(url).toContain("fields=%2Bvariants.inventory_quantity");
     });
 
     test("includes publishable key header", async () => {
@@ -133,7 +135,8 @@ describe("Medusa handlers", () => {
       expect(result.success).toBe(true);
 
       const [url, opts] = fetchMock.mock.calls[0];
-      expect(url).toBe("https://api.test-store.com/store/products/prod_123");
+      expect(url).toContain("/store/products/prod_123");
+      expect(url).toContain("fields=%2Bvariants.inventory_quantity");
       expect(opts.method).toBe("GET");
     });
   });
@@ -1026,7 +1029,8 @@ describe("lookUpOrderHistory (Admin API)", () => {
     expect(url).toContain("offset=0");
     expect(url).toContain("order=-created_at");
     expect(url).toContain("*items");
-    expect(url).toContain("*shipping_address");
+    expect(url).toContain("*items.variant");
+    expect(url).toContain("shipping_address.first_name");
     expect(url).toContain("*summary");
 
     // Verify admin auth header


### PR DESCRIPTION
## Summary

- Pass `+variants.inventory_quantity` in the `fields` param on `list_products` and `get_product` Store API calls so AI agents can answer stock availability questions (e.g. "is this in stock?", "how many left?")
- Fix order lookup field selection: add `*items.variant` for variant-level detail, replace `*shipping_address` wildcard with individual `shipping_address.*` fields (Medusa v2 doesn't support wildcard on embedded objects), add missing `email`/`total`/`metadata` fields
- Update tool descriptions to mention stock availability and inventory quantity
- Add manual test scripts for product inventory verification

## Test plan

- [x] All 50 Medusa handler unit tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] Verified `inventory_quantity` returns correctly against live Medusa instance (products with `manage_inventory: true`)
- [ ] Deploy to Railway demo and verify via MCP tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)