### PR TITLE
chore(ui): add @tanstack/router-cli to devDependencies

### DIFF
--- a/modelguide-ui/package-lock.json
+++ b/modelguide-ui/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/router-cli": "^1.164.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
@@ -2868,6 +2869,132 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-cli": {
+      "version": "1.164.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-cli/-/router-cli-1.164.0.tgz",
+      "integrity": "sha512-O7Cdp56ojM5PbDZ50pZhwqBTvNa9/IQJknkljnkSDbPFoGHs/7/74Se0xN7YeQjRQvFeEJ1T/DGFVjEC73fV4A==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/router-generator": "1.164.0",
+        "chokidar": "^3.6.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "tsr": "bin/tsr.cjs"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/history": {
+      "version": "1.161.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.4.tgz",
+      "integrity": "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/router-core": {
+      "version": "1.163.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.163.3.tgz",
+      "integrity": "sha512-jPptiGq/w3nuPzcMC7RNa79aU+b6OjaDzWJnBcV2UAwL4ThJamRS4h42TdhJE+oF5yH9IEnCOGQdfnbw45LbfA==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/history": "1.161.4",
+        "@tanstack/store": "^0.9.1",
+        "cookie-es": "^2.0.0",
+        "seroval": "^1.4.2",
+        "seroval-plugins": "^1.4.2",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/router-generator": {
+      "version": "1.164.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.164.0.tgz",
+      "integrity": "sha512-Uiyj+RtW0kdeqEd8NEd3Np1Z2nhJ2xgLS8U+5mTvFrm/s3xkM2LYjJHoLzc6am7sKPDsmeF9a4/NYq3R7ZJP0Q==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/router-core": "1.163.3",
+        "@tanstack/router-utils": "1.161.4",
+        "@tanstack/virtual-file-routes": "1.161.4",
+        "prettier": "^3.5.0",
+        "recast": "^0.23.11",
+        "source-map": "^0.7.4",
+        "tsx": "^4.19.2",
+        "zod": "^3.24.2"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/router-utils": {
+      "version": "1.161.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-utils/-/router-utils-1.161.4.tgz",
+      "integrity": "sha512-r8TpjyIZoqrXXaf2DDyjd44gjGBoyE+/oEaaH68yLI9ySPO1gUWmQENZ1MZnmBnpUGN24NOZxdjDLc8npK0SAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.28.5",
+        "@babel/generator": "^7.28.5",
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "ansis": "^4.1.0",
+        "babel-dead-code-elimination": "^1.0.12",
+        "diff": "^8.0.2",
+        "pathe": "^2.0.3",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/store": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.1.tgz",
+      "integrity": "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/virtual-file-routes": {
+      "version": "1.161.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.161.4.tgz",
+      "integrity": "sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/router-core": {

--- a/modelguide-ui/package.json
+++ b/modelguide-ui/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/router-cli": "^1.164.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",


### PR DESCRIPTION
## Summary
- Add `@tanstack/router-cli` to devDependencies so `npx` resolves it instantly from `node_modules` instead of re-downloading on every `npm run typecheck`

## Result
UI typecheck in pre-push hooks went from ~minutes to ~2.5 seconds.

## Test plan
- [x] `npm run typecheck` in `modelguide-ui/` completes in seconds
- [x] Pre-push lefthook hooks pass (both api-typecheck and ui-typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)