### PR TITLE
feat(evals): add eval suites UI with bidirectional navigation and improved scoring

### DIFF
--- a/modelguide-api/src/db/seed/index.ts
+++ b/modelguide-api/src/db/seed/index.ts
@@ -13,6 +13,7 @@ import postgres from "postgres";
 import * as schema from "../schema";
 import { connectorsCatalog, sopTemplates } from "../schema";
 import { connectorsCatalogSeed } from "./connectors-catalog";
+import { seedCompileAgents } from "./seed-compile-agents";
 import { seedKnowledgeBase } from "./seed-knowledge-base";
 import { seedOrg } from "./seed-org";
 import { seedSopDefinitions } from "./seed-sop-defs";
@@ -96,7 +97,10 @@ async function seedAll(db: SeedDb) {
   // 5. Seed knowledge base guardrails (all orgs)
   await seedKnowledgeBase(db);
 
-  // 6. Verify data was actually persisted
+  // 6. Compile agents from assigned SOPs (requires steps 4 + 5)
+  await seedCompileAgents(db);
+
+  // 7. Verify data was actually persisted
   const ok = await verifySeed(db);
 
   // 7. Print summary

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -1,0 +1,220 @@
+/**
+ * Seed step: compile active SOPs for demo agents.
+ *
+ * Populates compiled_instructions, compiled_at, and compiled_from on agents
+ * that have an active SOP assigned. This is required for the eval suite runner
+ * which gates on compiled_instructions being non-null.
+ *
+ * Uses the real compiler pipeline so the seed prompt stays in sync with
+ * production output.
+ */
+
+import { compile } from "@features/compiler/core/compile";
+import type { CompilerInput } from "@features/compiler/core/types";
+import { eq } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type * as schema from "../schema";
+import {
+  agentKnowledgeBase,
+  agentSops,
+  agents,
+  connectorTools,
+  connectors,
+  knowledgeBase,
+  sopSteps,
+  sops,
+} from "../schema";
+
+type SeedDb = PostgresJsDatabase<typeof schema>;
+
+export async function seedCompileAgents(db: SeedDb): Promise<void> {
+  console.log("\n--- Compiling agents from assigned SOPs ---");
+
+  // Find all agent→SOP assignments
+  const assignments = await db
+    .select({
+      agentId: agentSops.agentId,
+      sopId: agentSops.sopId,
+    })
+    .from(agentSops);
+
+  if (assignments.length === 0) {
+    console.log("  No agent→SOP assignments found, skipping compilation");
+    return;
+  }
+
+  for (const { agentId, sopId } of assignments) {
+    // Load agent
+    const [agent] = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.id, agentId));
+    if (!agent) continue;
+
+    // Load SOP (only compile active SOPs)
+    const [sop] = await db.select().from(sops).where(eq(sops.id, sopId));
+    if (!sop || sop.status !== "active") continue;
+
+    // Load SOP steps
+    const steps = await db
+      .select()
+      .from(sopSteps)
+      .where(eq(sopSteps.sopId, sopId));
+
+    if (steps.length === 0) continue;
+
+    // Resolve connector tool names for steps
+    const toolIds = steps
+      .map((s) => s.connectorToolId)
+      .filter((id): id is string => id !== null);
+
+    const toolNameMap = new Map<
+      string,
+      { slug: string; connectorSlug: string }
+    >();
+    for (const toolId of toolIds) {
+      const [tool] = await db
+        .select({
+          id: connectorTools.id,
+          slug: connectorTools.slug,
+          connectorSlug: connectors.slug,
+        })
+        .from(connectorTools)
+        .innerJoin(connectors, eq(connectorTools.connectorId, connectors.id))
+        .where(eq(connectorTools.id, toolId));
+
+      if (tool) {
+        toolNameMap.set(toolId, {
+          slug: tool.slug,
+          connectorSlug: tool.connectorSlug,
+        });
+      }
+    }
+
+    // Load guardrails assigned to this agent
+    const kbAssignments = await db
+      .select({ knowledgeBaseId: agentKnowledgeBase.knowledgeBaseId })
+      .from(agentKnowledgeBase)
+      .where(eq(agentKnowledgeBase.agentId, agentId));
+
+    const guardrailRows = [];
+    for (const { knowledgeBaseId } of kbAssignments) {
+      const [kb] = await db
+        .select()
+        .from(knowledgeBase)
+        .where(eq(knowledgeBase.id, knowledgeBaseId));
+      if (kb && kb.type === "guardrail" && kb.isActive) {
+        guardrailRows.push(kb);
+      }
+    }
+
+    // Build compiler input
+    const trigger = ((sop.trigger as unknown) ?? {
+      type: "intent_detected",
+      config: { patterns: [] },
+    }) as Record<string, unknown>;
+    const metadata = (sop.metadata as Record<string, unknown>) ?? {
+      tags: [],
+    };
+
+    const sopResponse = {
+      id: sop.id,
+      name: sop.name,
+      slug: sop.slug,
+      description: sop.description,
+      status: sop.status as "active",
+      version: sop.version,
+      assignedAgents: [
+        {
+          id: agent.id,
+          name: agent.name,
+          modality: (agent.modality ?? "text") as "voice" | "text",
+        },
+      ],
+      sopTemplateId: sop.sopTemplateId,
+      template: null,
+      definition: {
+        schemaVersion: 1 as const,
+        trigger,
+        metadata,
+        steps: steps.map((s) => {
+          const toolInfo = s.connectorToolId
+            ? toolNameMap.get(s.connectorToolId)
+            : undefined;
+          return {
+            id: s.stepId,
+            order: s.order,
+            instruction: s.instruction,
+            required: s.required,
+            ...(s.notes ? { notes: s.notes } : {}),
+            ...(s.evalConfigId ? { evalConfigId: s.evalConfigId } : {}),
+            tool: toolInfo
+              ? {
+                  connectorToolId: s.connectorToolId!,
+                  resolvedName: `${toolInfo.connectorSlug}_${toolInfo.slug}`,
+                }
+              : undefined,
+          };
+        }),
+      },
+      createdBy: sop.createdBy,
+      createdAt: sop.createdAt.toISOString(),
+      updatedAt: sop.updatedAt?.toISOString() ?? null,
+    };
+
+    const guardrailResponses = guardrailRows.map((g) => ({
+      id: g.id,
+      type: g.type as "guardrail",
+      name: g.name,
+      slug: g.slug,
+      content: g.content,
+      description: g.description,
+      config: (g.config ?? {}) as Record<string, unknown>,
+      isActive: g.isActive,
+      assignedAgents: [],
+      createdBy: g.createdBy,
+      createdAt: g.createdAt.toISOString(),
+      updatedAt: g.updatedAt?.toISOString() ?? null,
+    }));
+
+    const compilerInput: CompilerInput = {
+      sops: [sopResponse as CompilerInput["sops"][number]],
+      guardrails: guardrailResponses,
+      agentConfig: {
+        id: agent.id,
+        name: agent.name,
+        model: "anthropic/claude-haiku-4-5-20251001",
+        description: agent.description ?? "AI customer support agent",
+      },
+    };
+
+    try {
+      const ir = compile(compilerInput);
+
+      await db
+        .update(agents)
+        .set({
+          compiledInstructions: ir.systemPrompt,
+          compiledAt: new Date(),
+          compiledFrom: {
+            sopId: sop.id,
+            sopName: sop.name,
+            guardrailIds: guardrailRows.map((g) => g.id),
+            toolCount: ir.tools.length,
+            stepCount: ir.sop.steps.length,
+          },
+        })
+        .where(eq(agents.id, agentId));
+
+      console.log(
+        `  Compiled ${agent.name} from SOP "${sop.name}" (${ir.systemPrompt.length} chars, ${ir.tools.length} tools)`,
+      );
+    } catch (err) {
+      console.warn(
+        `  Failed to compile ${agent.name}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  console.log("  Agent compilation seeded.");
+}

--- a/modelguide-api/src/features/evals/eval-suites.routes.ts
+++ b/modelguide-api/src/features/evals/eval-suites.routes.ts
@@ -150,6 +150,7 @@ function formatSuiteRun(r: SuiteRunDetail) {
   return {
     id: r.id,
     suiteId: r.suiteId,
+    sessionId: r.sessionId ?? null,
     promptSource: r.promptSource,
     passed: r.passed,
     triggeredBy: r.triggeredBy,
@@ -159,6 +160,7 @@ function formatSuiteRun(r: SuiteRunDetail) {
     metadata: r.metadata as Record<string, unknown> | null,
     testCaseResults: r.testCaseResults.map((tc) => ({
       testCaseId: tc.testCaseId,
+      testCaseName: tc.testCaseName ?? null,
       evalRunId: tc.evalRunId,
       passed: tc.passed,
       status: tc.status,
@@ -173,6 +175,7 @@ function formatSuiteRunSummary(
   return {
     id: r.id,
     suiteId: r.suiteId,
+    sessionId: r.sessionId ?? null,
     promptSource: r.promptSource,
     passed: r.passed,
     triggeredBy: r.triggeredBy,
@@ -182,6 +185,7 @@ function formatSuiteRunSummary(
     metadata: r.metadata as Record<string, unknown> | null,
     testCaseResults: r.testCaseResults.map((tc) => ({
       testCaseId: tc.testCaseId,
+      testCaseName: tc.testCaseName ?? null,
       evalRunId: tc.evalRunId,
       passed: tc.passed,
       status: tc.status,

--- a/modelguide-api/src/features/evals/eval-suites.service.ts
+++ b/modelguide-api/src/features/evals/eval-suites.service.ts
@@ -12,6 +12,7 @@ import {
   type EvalSuiteEvaluator,
   type EvalSuiteTestCase,
   agentKnowledgeBase,
+  agentSops,
   agents,
   connectorTools,
   connectors,
@@ -93,6 +94,17 @@ export async function initSuiteFromSop(
       .from(sops)
       .where(eq(sops.id, sopId));
     if (!sop) throw Errors.sopNotFound(sopId);
+
+    // 1c. Validate SOP is assigned to agent
+    const [assignment] = await tx
+      .select({ agentId: agentSops.agentId })
+      .from(agentSops)
+      .where(and(eq(agentSops.agentId, agentId), eq(agentSops.sopId, sopId)));
+    if (!assignment) {
+      throw Errors.validationError(
+        `SOP "${sop.name}" is not assigned to agent "${agent.name}"`,
+      );
+    }
 
     // 2. Check for existing suite (re-initialization)
     const [existingSuite] = await tx
@@ -275,11 +287,15 @@ export async function initSuiteFromSop(
         continue;
       }
 
+      const stepLabel = step.instruction
+        ? truncate(step.instruction, 80)
+        : `step ${step.order}`;
+
       await tx.insert(evalSuiteEvaluators).values({
         organizationId: orgId,
         testCaseId: testCase.id,
         evalConfigId: configId!,
-        name: `step:${step.order}:${evaluatorType}`,
+        name: `${stepLabel} (${evaluatorType})`,
         sopStepId: step.stepId,
         source: "auto",
         order: step.order,
@@ -294,7 +310,7 @@ export async function initSuiteFromSop(
         organizationId: orgId,
         testCaseId: testCase.id,
         evalConfigId: guardConfig.id,
-        name: `guardrail:${gi}`,
+        name: `${guardConfig.guardrailName} (guardrail)`,
         source: "auto",
         order: 1000 + gi,
         required: true,
@@ -359,7 +375,7 @@ async function loadGuardrailEvaluators(
   tx: Transaction,
   orgId: string,
   agentId: string,
-): Promise<Array<{ id: string }>> {
+): Promise<Array<{ id: string; guardrailName: string }>> {
   // Find guardrails assigned to this agent
   const kbAssignments = await tx
     .select({ knowledgeBaseId: agentKnowledgeBase.knowledgeBaseId })
@@ -384,7 +400,7 @@ async function loadGuardrailEvaluators(
   if (guardrails.length === 0) return [];
 
   // Create or find eval_configs for each guardrail
-  const configs: Array<{ id: string }> = [];
+  const configs: Array<{ id: string; guardrailName: string }> = [];
   for (const guardrail of guardrails) {
     // Check if a guardrail eval config already exists
     const configName = `guardrail:${guardrail.slug}`;
@@ -407,7 +423,7 @@ async function loadGuardrailEvaluators(
         .update(evalConfigs)
         .set({ config: guardrailConfig })
         .where(eq(evalConfigs.id, existing.id));
-      configs.push(existing);
+      configs.push({ ...existing, guardrailName: guardrail.name });
     } else {
       const [created] = await tx
         .insert(evalConfigs)
@@ -419,7 +435,7 @@ async function loadGuardrailEvaluators(
           config: guardrailConfig,
         })
         .returning({ id: evalConfigs.id });
-      configs.push(created);
+      configs.push({ ...created, guardrailName: guardrail.name });
     }
   }
 
@@ -524,7 +540,7 @@ export async function resolveAssertions(
     if (!cfg) {
       return {
         order: a.order,
-        name: `assertion:${a.order}:unknown`,
+        name: a.name || `assertion:${a.order}:unknown`,
         required: a.required,
         evaluator: {
           configId: a.evalConfigId,
@@ -546,7 +562,7 @@ export async function resolveAssertions(
 
     return {
       order: a.order,
-      name: `assertion:${a.order}:${truncate(cfg.evaluatorType, 40)}`,
+      name: a.name || `${truncate(cfg.evaluatorType, 40)}`,
       required: a.required,
       evaluator: {
         configId: cfg.id,
@@ -780,7 +796,9 @@ async function runTestCaseEval(
     const failedRequired = scoreRows.filter(
       (s) => s.required && (s.result === "fail" || s.result === "error"),
     );
-    const passed = failedRequired.length === 0;
+    const allSkipped = scoreRows.every((s) => s.result === "skip");
+    // If all evaluators were skipped, the result is inconclusive (null)
+    const passed = allSkipped ? null : failedRequired.length === 0;
     const durationMs = elapsedMs(evalStartTime);
 
     // Persist scores and update eval run
@@ -1043,6 +1061,13 @@ export async function getEvalSuiteRuns(
         .where(eq(evalSuiteRuns.suiteId, suiteId)),
     ]);
 
+    // Load test case names for this suite
+    const testCaseRows = await tx
+      .select({ id: evalSuiteTestCases.id, name: evalSuiteTestCases.name })
+      .from(evalSuiteTestCases)
+      .where(eq(evalSuiteTestCases.suiteId, suiteId));
+    const testCaseNameMap = new Map(testCaseRows.map((tc) => [tc.id, tc.name]));
+
     // For each run, load per-test-case eval results
     const enrichedRuns = await Promise.all(
       runs.map(async (run) => {
@@ -1076,6 +1101,9 @@ export async function getEvalSuiteRuns(
         const testCaseResults: TestCaseRunDetail[] = linkedEvalRuns.map(
           (er) => ({
             testCaseId: er.testCaseId,
+            testCaseName: er.testCaseId
+              ? (testCaseNameMap.get(er.testCaseId) ?? null)
+              : null,
             evalRunId: er.id,
             passed: er.passed,
             status: er.status,
@@ -1083,17 +1111,23 @@ export async function getEvalSuiteRuns(
           }),
         );
 
-        // Aggregate pass/fail at query time
+        // Aggregate pass/fail at query time (three-state: true/false/null)
         const completedRuns = linkedEvalRuns.filter(
           (r) => r.status === "completed",
         );
-        const allPassed =
+        const anyFailed = completedRuns.some((r) => r.passed === false);
+        const allInconclusive =
           completedRuns.length > 0 &&
-          completedRuns.every((r) => r.passed === true);
+          completedRuns.every((r) => r.passed == null);
+        const passed =
+          completedRuns.length === 0 || allInconclusive ? null : !anyFailed;
+
+        const sessionId = linkedEvalRuns[0]?.sessionId ?? null;
 
         return {
           ...run,
-          passed: completedRuns.length > 0 ? allPassed : null,
+          sessionId,
+          passed,
           testCaseResults,
         };
       }),
@@ -1122,6 +1156,13 @@ export async function getEvalSuiteRunById(
 
     if (!run) throw Errors.evalSuiteRunNotFound(runId);
 
+    // Load test case names
+    const testCaseRows = await tx
+      .select({ id: evalSuiteTestCases.id, name: evalSuiteTestCases.name })
+      .from(evalSuiteTestCases)
+      .where(eq(evalSuiteTestCases.suiteId, suiteId));
+    const testCaseNameMap = new Map(testCaseRows.map((tc) => [tc.id, tc.name]));
+
     // Load per-test-case results with scores
     const linkedEvalRuns = await tx
       .select()
@@ -1148,6 +1189,9 @@ export async function getEvalSuiteRunById(
 
     const testCaseResults: TestCaseRunDetail[] = linkedEvalRuns.map((er) => ({
       testCaseId: er.testCaseId,
+      testCaseName: er.testCaseId
+        ? (testCaseNameMap.get(er.testCaseId) ?? null)
+        : null,
       evalRunId: er.id,
       passed: er.passed,
       status: er.status,
@@ -1157,12 +1201,19 @@ export async function getEvalSuiteRunById(
     const completedRuns = linkedEvalRuns.filter(
       (r) => r.status === "completed",
     );
-    const allPassed =
-      completedRuns.length > 0 && completedRuns.every((r) => r.passed === true);
+    const anyFailed = completedRuns.some((r) => r.passed === false);
+    const allInconclusive =
+      completedRuns.length > 0 && completedRuns.every((r) => r.passed == null);
+    const passed =
+      completedRuns.length === 0 || allInconclusive ? null : !anyFailed;
+
+    // Derive sessionId from linked eval runs (all share the same session)
+    const sessionId = linkedEvalRuns[0]?.sessionId ?? null;
 
     return {
       ...run,
-      passed: completedRuns.length > 0 ? allPassed : null,
+      sessionId,
+      passed,
       testCaseResults,
     };
   });

--- a/modelguide-api/src/features/evals/eval-suites.types.ts
+++ b/modelguide-api/src/features/evals/eval-suites.types.ts
@@ -73,6 +73,7 @@ export interface SuiteRunResult {
 
 export interface TestCaseRunDetail {
   testCaseId: string | null;
+  testCaseName: string | null;
   evalRunId: string;
   passed: boolean | null;
   status: string;
@@ -80,6 +81,7 @@ export interface TestCaseRunDetail {
 }
 
 export type SuiteRunDetail = EvalSuiteRunRow & {
+  sessionId: string | null;
   passed: boolean | null;
   testCaseResults: TestCaseRunDetail[];
 };

--- a/modelguide-ui/src/components/layout/sidebar.tsx
+++ b/modelguide-ui/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@ import {
   Activity,
   Bot,
   ClipboardList,
+  FlaskConical,
   Key,
   LayoutDashboard,
   MessageSquare,
@@ -36,6 +37,7 @@ const adminNav: NavItem[] = [
   { label: 'Connectors', href: '/connectors', icon: <Plug className="h-4 w-4" /> },
   { label: 'SOPs', href: '/sops', icon: <ClipboardList className="h-4 w-4" /> },
   { label: 'Knowledge Base', href: '/knowledge-base', icon: <Shield className="h-4 w-4" /> },
+  { label: 'Eval Suites', href: '/evals', icon: <FlaskConical className="h-4 w-4" /> },
   { label: 'Secrets', href: '/secrets', icon: <Key className="h-4 w-4" />, roles: ['admin'] },
 ]
 

--- a/modelguide-ui/src/features/evals/components/init-suite-dialog.tsx
+++ b/modelguide-ui/src/features/evals/components/init-suite-dialog.tsx
@@ -1,0 +1,141 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate } from '@tanstack/react-router'
+import { ClipboardList } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogFooter } from '~/components/ui/dialog'
+import { Select } from '~/components/ui/select'
+import { api } from '~/lib/api'
+import type { Agent } from '~/schemas/agents'
+import type { EvalSuiteDetail } from '~/schemas/eval-suites'
+import type { SopSummary } from '~/schemas/sops'
+
+export interface InitSuiteDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function InitSuiteDialog({ open, onClose }: InitSuiteDialogProps) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const [agentId, setAgentId] = useState('')
+  const [sopId, setSopId] = useState('')
+
+  const { data: agentsData } = useQuery({
+    queryKey: ['agents'],
+    queryFn: () => api.get('agents').json<{ data: Agent[] }>(),
+    enabled: open,
+  })
+
+  const { data: sopsData } = useQuery({
+    queryKey: ['sops', { status: 'active', agentId: agentId || undefined }],
+    queryFn: () =>
+      api
+        .get('sops', {
+          searchParams: {
+            status: 'active',
+            pageSize: 50,
+            ...(agentId ? { agentId } : {}),
+          },
+        })
+        .json<{ data: SopSummary[] }>(),
+    enabled: open && agentId !== '',
+  })
+
+  const initMutation = useMutation({
+    mutationFn: () =>
+      api.post('eval-suites/init', { json: { agentId, sopId } }).json<EvalSuiteDetail>(),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['eval-suites'] })
+      navigate({ to: '/evals/suites/$suiteId', params: { suiteId: data.id } })
+      onClose()
+      setAgentId('')
+      setSopId('')
+    },
+  })
+
+  const agents = agentsData?.data ?? []
+  const sops = sopsData?.data ?? []
+  const agentSelected = agentId !== ''
+  const noSopsForAgent = agentSelected && sopsData != null && sops.length === 0
+  const canSubmit = agentId !== '' && sopId !== ''
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Create Eval Suite"
+      description="Create an eval suite from an agent and SOP pair. Test cases and assertions will be auto-generated from SOP steps."
+    >
+      <div className="space-y-4">
+        <Select
+          label="Agent"
+          value={agentId}
+          onChange={(e) => {
+            setAgentId(e.target.value)
+            setSopId('')
+          }}
+        >
+          <option value="">Select an agent…</option>
+          {agents.map((agent) => (
+            <option key={agent.id} value={agent.id}>
+              {agent.name}
+            </option>
+          ))}
+        </Select>
+
+        {noSopsForAgent ? (
+          <div className="rounded-lg border border-warning/20 bg-warning/5 px-4 py-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-warning">
+              <ClipboardList className="h-4 w-4 shrink-0" />
+              No active SOPs assigned to this agent
+            </div>
+            <p className="mt-1 text-xs text-fg-muted">
+              Assign an active SOP to this agent first, then come back to create an eval suite.
+            </p>
+            <Link
+              to="/agents/$id"
+              params={{ id: agentId }}
+              className="mt-2 inline-block text-xs font-medium text-brand-400 hover:text-brand-300"
+              onClick={onClose}
+            >
+              Go to agent settings &rarr;
+            </Link>
+          </div>
+        ) : (
+          <Select
+            label="SOP"
+            value={sopId}
+            onChange={(e) => setSopId(e.target.value)}
+            disabled={!agentId}
+          >
+            <option value="">{agentId ? 'Select an active SOP…' : 'Select an agent first'}</option>
+            {sops.map((sop) => (
+              <option key={sop.id} value={sop.id}>
+                {sop.name}
+              </option>
+            ))}
+          </Select>
+        )}
+
+        {initMutation.error ? (
+          <p className="text-xs text-error">Failed to create eval suite. Please try again.</p>
+        ) : null}
+      </div>
+
+      <DialogFooter>
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => initMutation.mutate()}
+          disabled={!canSubmit}
+          loading={initMutation.isPending}
+        >
+          Create Eval Suite
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/modelguide-ui/src/features/evals/components/run-results-card.test.tsx
+++ b/modelguide-ui/src/features/evals/components/run-results-card.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  makeEvalRunScore,
+  makeEvalSuiteTestCase,
+  makeTestCaseResult,
+} from '../../../../test/eval-suite-fixtures'
+import { RunResultsCard } from './run-results-card'
+
+describe('RunResultsCard', () => {
+  it('renders summary bar with pass count', () => {
+    const results = [
+      makeTestCaseResult({ testCaseId: 'tc-1', passed: true }),
+      makeTestCaseResult({ testCaseId: 'tc-2', passed: false }),
+      makeTestCaseResult({ testCaseId: 'tc-3', passed: true }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} />)
+
+    expect(screen.getByText('2/3 test cases passed')).toBeInTheDocument()
+  })
+
+  it('renders all test case results with pass/fail icon', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({ id: 'tc-1', name: 'Happy Path' }),
+      makeEvalSuiteTestCase({ id: 'tc-2', name: 'Edge Case' }),
+    ]
+    const results = [
+      makeTestCaseResult({ testCaseId: 'tc-1', passed: true }),
+      makeTestCaseResult({ testCaseId: 'tc-2', passed: false }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} testCases={testCases} />)
+
+    expect(screen.getByText('Happy Path')).toBeInTheDocument()
+    expect(screen.getByText('Edge Case')).toBeInTheDocument()
+  })
+
+  it('shows evaluator pass count per result', () => {
+    const results = [
+      makeTestCaseResult({
+        testCaseId: 'tc-1',
+        scores: [
+          makeEvalRunScore({ id: 's-1', evalConfigId: 'c-1', result: 'pass' }),
+          makeEvalRunScore({ id: 's-2', evalConfigId: 'c-2', result: 'fail' }),
+          makeEvalRunScore({ id: 's-3', evalConfigId: 'c-3', result: 'pass' }),
+        ],
+      }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} />)
+
+    expect(screen.getByText('2/3 evaluators passed')).toBeInTheDocument()
+  })
+
+  it('expands result on click and shows score breakdown', () => {
+    const results = [
+      makeTestCaseResult({
+        testCaseId: 'tc-1',
+        scores: [
+          makeEvalRunScore({
+            id: 's-1',
+            evalConfigId: 'c-1',
+            name: 'tool_called: get_order',
+            result: 'pass',
+          }),
+        ],
+      }),
+    ]
+    const testCases = [makeEvalSuiteTestCase({ id: 'tc-1', name: 'Happy Path' })]
+
+    render(<RunResultsCard testCaseResults={results} testCases={testCases} />)
+
+    // Score details should not be visible yet
+    expect(screen.queryByText('Score Breakdown:')).not.toBeInTheDocument()
+
+    // Click to expand
+    fireEvent.click(screen.getByText('Happy Path'))
+
+    expect(screen.getByText('Score Breakdown:')).toBeInTheDocument()
+    expect(screen.getByText('tool_called: get_order')).toBeInTheDocument()
+    expect(screen.getByText('pass')).toBeInTheDocument()
+  })
+
+  it('shows score name, result, and evaluator type for each score', () => {
+    const results = [
+      makeTestCaseResult({
+        testCaseId: 'tc-1',
+        scores: [
+          makeEvalRunScore({
+            id: 's-1',
+            evalConfigId: 'c-1',
+            name: 'tool_called: get_order',
+            result: 'pass',
+            evaluatorType: 'tool_called',
+          }),
+          makeEvalRunScore({
+            id: 's-2',
+            evalConfigId: 'c-2',
+            name: 'llm_judge: Confirms status',
+            result: 'fail',
+            evaluatorType: 'llm_judge',
+          }),
+        ],
+      }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} />)
+
+    // Expand
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('tool_called: get_order')).toBeInTheDocument()
+    expect(screen.getByText('llm_judge: Confirms status')).toBeInTheDocument()
+    expect(screen.getByText('pass')).toBeInTheDocument()
+    expect(screen.getByText('fail')).toBeInTheDocument()
+  })
+
+  it('shows reasoning text for failed scores', () => {
+    const results = [
+      makeTestCaseResult({
+        testCaseId: 'tc-1',
+        scores: [
+          makeEvalRunScore({
+            id: 's-1',
+            evalConfigId: 'c-1',
+            name: 'tool_called: update_order',
+            result: 'fail',
+            reasoning: 'Tool was not called during the session',
+          }),
+        ],
+      }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} />)
+
+    // Expand
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Tool was not called during the session')).toBeInTheDocument()
+  })
+
+  it('shows percentage badge in summary', () => {
+    const results = [
+      makeTestCaseResult({ testCaseId: 'tc-1', passed: true }),
+      makeTestCaseResult({ testCaseId: 'tc-2', passed: true }),
+    ]
+
+    render(<RunResultsCard testCaseResults={results} />)
+
+    expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
+  it('resolves test case names from provided testCases', () => {
+    const testCases = [makeEvalSuiteTestCase({ id: 'tc-1', name: 'Order Lookup Test' })]
+    const results = [makeTestCaseResult({ testCaseId: 'tc-1' })]
+
+    render(<RunResultsCard testCaseResults={results} testCases={testCases} />)
+
+    expect(screen.getByText('Order Lookup Test')).toBeInTheDocument()
+  })
+
+  it('shows "Unknown Test Case" when test case not found', () => {
+    const results = [makeTestCaseResult({ testCaseId: 'non-existent' })]
+
+    render(<RunResultsCard testCaseResults={results} testCases={[]} />)
+
+    expect(screen.getByText('Unknown Test Case')).toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/features/evals/components/run-results-card.tsx
+++ b/modelguide-ui/src/features/evals/components/run-results-card.tsx
@@ -1,0 +1,234 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  MinusCircle,
+  XCircle,
+} from 'lucide-react'
+import { useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { cn } from '~/lib/cn'
+import type { EvalRunScore, EvalSuiteTestCase, TestCaseResult } from '~/schemas/eval-suites'
+
+export interface RunResultsCardProps {
+  testCaseResults: TestCaseResult[]
+  testCases?: EvalSuiteTestCase[]
+}
+
+function getTestCaseName(result: TestCaseResult, testCases?: EvalSuiteTestCase[]): string {
+  // Prefer the name returned directly in the run result
+  if (result.testCaseName) return result.testCaseName
+  // Fallback: look up from suite test cases
+  if (result.testCaseId && testCases) {
+    const tc = testCases.find((t) => t.id === result.testCaseId)
+    if (tc) return tc.name
+  }
+  return 'Unknown Test Case'
+}
+
+function scoreIcon(score: EvalRunScore) {
+  if (score.result === 'pass') return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-success" />
+  if (score.result === 'skip') return <MinusCircle className="h-3.5 w-3.5 shrink-0 text-warning" />
+  return <XCircle className="h-3.5 w-3.5 shrink-0 text-error" />
+}
+
+function scoreResultVariant(result: string): 'success' | 'error' | 'warning' | 'default' {
+  if (result === 'pass') return 'success'
+  if (result === 'skip') return 'warning'
+  return 'error'
+}
+
+export function RunResultsCard({ testCaseResults, testCases }: RunResultsCardProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
+
+  const toggle = (index: number) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }
+
+  const totalCases = testCaseResults.length
+  const passedCases = testCaseResults.filter((r) => r.passed === true).length
+  const failedCases = testCaseResults.filter((r) => r.passed === false).length
+  const inconclusiveCases = testCaseResults.filter((r) => r.passed == null).length
+  const allPassed = passedCases === totalCases && totalCases > 0
+  const allInconclusive = inconclusiveCases === totalCases && totalCases > 0
+  const pct = totalCases > 0 ? Math.round((passedCases / totalCases) * 100) : 0
+
+  const summaryVariant = allPassed ? 'success' : failedCases > 0 ? 'error' : 'warning'
+
+  return (
+    <div className="space-y-4">
+      {/* Summary bar */}
+      <div
+        className={cn(
+          'group relative overflow-hidden rounded-2xl border bg-bg-elevated px-5 py-4',
+          'transition-all duration-300',
+          summaryVariant === 'success' &&
+            'border-success/20 shadow-[0_0_30px_-10px_rgba(16,185,129,0.2)]',
+          summaryVariant === 'warning' &&
+            'border-warning/20 shadow-[0_0_30px_-10px_rgba(245,158,11,0.15)]',
+          summaryVariant === 'error' &&
+            'border-error/20 shadow-[0_0_30px_-10px_rgba(239,68,68,0.15)]',
+        )}
+      >
+        {/* Ambient gradient */}
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-0 bg-gradient-to-r opacity-60',
+            summaryVariant === 'success' && 'from-success/8 via-transparent to-transparent',
+            summaryVariant === 'warning' && 'from-warning/8 via-transparent to-transparent',
+            summaryVariant === 'error' && 'from-error/8 via-transparent to-transparent',
+          )}
+        />
+
+        <div className="relative flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            {summaryVariant === 'success' ? (
+              <CheckCircle2 className="h-5 w-5 text-success" />
+            ) : summaryVariant === 'warning' ? (
+              <AlertTriangle className="h-5 w-5 text-warning" />
+            ) : (
+              <XCircle className="h-5 w-5 text-error" />
+            )}
+            <span className="font-display text-sm font-semibold text-fg-primary">
+              {allInconclusive ? (
+                <span className="text-warning">
+                  {totalCases} test {totalCases === 1 ? 'case' : 'cases'} inconclusive
+                </span>
+              ) : (
+                <>
+                  {passedCases}/{totalCases} test cases passed
+                  {inconclusiveCases > 0 ? (
+                    <span className="ml-1 text-warning">({inconclusiveCases} inconclusive)</span>
+                  ) : null}
+                </>
+              )}
+            </span>
+          </div>
+          <div className="flex-1">
+            <div className="h-2 overflow-hidden rounded-full bg-bg-subtle">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-all duration-500',
+                  summaryVariant === 'success' && 'bg-gradient-to-r from-success/80 to-success',
+                  summaryVariant === 'warning' && 'bg-gradient-to-r from-warning/80 to-warning',
+                  summaryVariant === 'error' && 'bg-gradient-to-r from-error/80 to-error',
+                )}
+                style={{ width: allInconclusive ? '100%' : `${pct}%` }}
+              />
+            </div>
+          </div>
+          <Badge variant={summaryVariant}>{allInconclusive ? 'Inconclusive' : `${pct}%`}</Badge>
+        </div>
+      </div>
+
+      {/* Per-test-case results */}
+      <div className="space-y-2">
+        {testCaseResults.map((result, index) => {
+          const isExpanded = expandedIds.has(index)
+          const name = getTestCaseName(result, testCases)
+          const passedScores = result.scores.filter((s) => s.result === 'pass').length
+          const skippedScores = result.scores.filter((s) => s.result === 'skip').length
+          const totalScores = result.scores.length
+          const allScoresSkipped = skippedScores === totalScores && totalScores > 0
+
+          return (
+            <div
+              key={result.testCaseId ?? index}
+              className={cn(
+                'group/row overflow-hidden rounded-xl border bg-bg-elevated transition-all duration-200',
+                result.passed === true
+                  ? 'border-fg-subtle/10 hover:border-success/20'
+                  : result.passed === false
+                    ? 'border-fg-subtle/10 hover:border-error/20'
+                    : 'border-fg-subtle/10 hover:border-warning/20',
+                isExpanded && result.passed === false && 'border-error/15',
+                isExpanded && result.passed === true && 'border-success/15',
+                isExpanded && result.passed == null && 'border-warning/15',
+              )}
+              style={{ animationDelay: `${index * 40}ms` }}
+            >
+              <button
+                type="button"
+                onClick={() => toggle(index)}
+                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg-subtle/30"
+              >
+                {result.passed === true ? (
+                  <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
+                ) : result.passed === false ? (
+                  <XCircle className="h-5 w-5 shrink-0 text-error" />
+                ) : (
+                  <AlertTriangle className="h-5 w-5 shrink-0 text-warning" />
+                )}
+
+                <span className="flex-1 text-sm font-medium text-fg-primary">{name}</span>
+
+                <span className="text-xs text-fg-muted">
+                  {allScoresSkipped
+                    ? `${totalScores} skipped`
+                    : `${passedScores}/${totalScores} evaluators passed`}
+                </span>
+
+                {isExpanded ? (
+                  <ChevronUp className="h-4 w-4 text-fg-muted transition-transform" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-fg-muted transition-transform" />
+                )}
+              </button>
+
+              {isExpanded ? (
+                <div className="border-t border-fg-subtle/10 px-4 py-3 animate-fade-in">
+                  {allScoresSkipped ? (
+                    <div className="mb-3 flex items-center gap-2 rounded-lg border border-warning/20 bg-warning/5 px-3 py-2">
+                      <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
+                      <p className="text-xs text-warning">
+                        All evaluators were skipped — results are inconclusive.
+                      </p>
+                    </div>
+                  ) : null}
+                  <p className="mb-2 font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                    Score Breakdown:
+                  </p>
+                  <div className="space-y-0.5 rounded-lg border border-fg-subtle/10 bg-bg-base p-1.5">
+                    {result.scores.map((score) => (
+                      <div key={score.id}>
+                        <div
+                          className={cn(
+                            'flex items-center gap-2 rounded-md px-2.5 py-2 text-xs transition-colors',
+                            score.result === 'pass' && 'hover:bg-success/5',
+                            score.result === 'skip' && 'hover:bg-warning/5',
+                            (score.result === 'fail' || score.result === 'error') &&
+                              'hover:bg-error/5',
+                          )}
+                        >
+                          {scoreIcon(score)}
+                          <span className="flex-1 font-mono text-fg-secondary">{score.name}</span>
+                          <Badge variant="info">{score.evaluatorType}</Badge>
+                          {score.required ? <Badge variant="warning">required</Badge> : null}
+                          <Badge variant={scoreResultVariant(score.result)}>{score.result}</Badge>
+                        </div>
+                        {score.result !== 'pass' && score.reasoning ? (
+                          <p className="ml-8 pb-1.5 text-xs text-fg-muted italic">
+                            {score.reasoning}
+                          </p>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/modelguide-ui/src/features/evals/components/run-suite-dialog.tsx
+++ b/modelguide-ui/src/features/evals/components/run-suite-dialog.tsx
@@ -1,0 +1,94 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogFooter } from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import { Select } from '~/components/ui/select'
+import { api } from '~/lib/api'
+import type { EvalSuiteRun } from '~/schemas/eval-suites'
+import { PROMPT_SOURCE_LABELS } from '~/schemas/eval-suites'
+
+export interface RunSuiteDialogProps {
+  open: boolean
+  onClose: () => void
+  suiteId: string
+  onSuccess?: () => void
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function RunSuiteDialog({ open, onClose, suiteId, onSuccess }: RunSuiteDialogProps) {
+  const queryClient = useQueryClient()
+
+  const [sessionId, setSessionId] = useState('')
+  const [promptSource, setPromptSource] = useState('compiled')
+
+  const runMutation = useMutation({
+    mutationFn: () =>
+      api
+        .post(`eval-suites/${suiteId}/run`, { json: { sessionId, promptSource } })
+        .json<EvalSuiteRun>(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['eval-suites', suiteId, 'runs'] })
+      onClose()
+      setSessionId('')
+      setPromptSource('compiled')
+      onSuccess?.()
+    },
+  })
+
+  const isValidUuid = UUID_RE.test(sessionId.trim())
+  const canSubmit = isValidUuid
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Run Eval Suite"
+      description="Evaluate a session against this suite's test cases and assertions."
+    >
+      <div className="space-y-4">
+        <div>
+          <Input
+            label="Session ID"
+            placeholder="Paste a session UUID…"
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+          />
+          {sessionId.trim() !== '' && !isValidUuid ? (
+            <p className="mt-1 text-xs text-warning">Enter a valid UUID</p>
+          ) : null}
+        </div>
+
+        <Select
+          label="Prompt Source"
+          value={promptSource}
+          onChange={(e) => setPromptSource(e.target.value)}
+        >
+          {Object.entries(PROMPT_SOURCE_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </Select>
+
+        {runMutation.error ? (
+          <p className="text-xs text-error">Failed to start run. Please try again.</p>
+        ) : null}
+      </div>
+
+      <DialogFooter>
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => runMutation.mutate()}
+          disabled={!canSubmit}
+          loading={runMutation.isPending}
+        >
+          Run Suite
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/modelguide-ui/src/features/evals/components/suite-runs-table.test.tsx
+++ b/modelguide-ui/src/features/evals/components/suite-runs-table.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { makeEvalSuiteRun, makeTestCaseResult } from '../../../../test/eval-suite-fixtures'
+import { SuiteRunsTable } from './suite-runs-table'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('~/lib/utils', () => ({
+  formatDate: (date: string) => date,
+  formatDuration: (seconds: number) => `${Math.round(seconds)}s`,
+}))
+
+describe('SuiteRunsTable', () => {
+  const suiteId = '00000000-0000-0000-0000-d00000000001'
+
+  it('renders table headers', () => {
+    render(<SuiteRunsTable runs={[]} suiteId={suiteId} />)
+
+    // Empty state is shown instead of headers when runs=[]
+    expect(screen.getByText('No runs yet')).toBeInTheDocument()
+  })
+
+  it('renders passed run with success badge', () => {
+    const runs = [makeEvalSuiteRun({ passed: true })]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('Passed')).toBeInTheDocument()
+  })
+
+  it('renders failed run with error badge', () => {
+    const runs = [makeEvalSuiteRun({ passed: false })]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+  })
+
+  it('renders inconclusive run (passed=null) with warning badge', () => {
+    const runs = [makeEvalSuiteRun({ passed: null })]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('Inconclusive')).toBeInTheDocument()
+  })
+
+  it('shows prompt source badge', () => {
+    const runs = [makeEvalSuiteRun({ promptSource: 'compiled' })]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('Compiled')).toBeInTheDocument()
+  })
+
+  it('shows pass count', () => {
+    const runs = [
+      makeEvalSuiteRun({
+        testCaseResults: [
+          makeTestCaseResult({ testCaseId: 'tc-1', passed: true }),
+          makeTestCaseResult({ testCaseId: 'tc-2', passed: false }),
+          makeTestCaseResult({ testCaseId: 'tc-3', passed: true }),
+        ],
+      }),
+    ]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('2/3 passed')).toBeInTheDocument()
+  })
+
+  it('shows formatted duration', () => {
+    const runs = [makeEvalSuiteRun({ durationMs: 2500 })]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    // 2500ms / 1000 = 2.5 → Math.round → "3s" from mock
+    expect(screen.getByText('3s')).toBeInTheDocument()
+  })
+
+  it('shows empty state when runs=[]', () => {
+    render(<SuiteRunsTable runs={[]} suiteId={suiteId} />)
+
+    expect(screen.getByText('No runs yet')).toBeInTheDocument()
+    expect(screen.getByText('Run this suite against a session to see results')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton when isLoading=true', () => {
+    const { container } = render(<SuiteRunsTable runs={[]} suiteId={suiteId} isLoading />)
+
+    const skeletonElements = container.querySelectorAll('.animate-pulse')
+    expect(skeletonElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders table headers when runs exist', () => {
+    const runs = [makeEvalSuiteRun()]
+
+    render(<SuiteRunsTable runs={runs} suiteId={suiteId} />)
+
+    expect(screen.getByText('Result')).toBeInTheDocument()
+    expect(screen.getByText('Prompt Source')).toBeInTheDocument()
+    expect(screen.getByText('Test Cases')).toBeInTheDocument()
+    expect(screen.getByText('Duration')).toBeInTheDocument()
+    expect(screen.getByText('Started')).toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/features/evals/components/suite-runs-table.tsx
+++ b/modelguide-ui/src/features/evals/components/suite-runs-table.tsx
@@ -1,0 +1,144 @@
+import { useNavigate } from '@tanstack/react-router'
+import { FlaskConical } from 'lucide-react'
+import { Badge } from '~/components/ui/badge'
+import { formatDate, formatDuration } from '~/lib/utils'
+import type { EvalSuiteRun } from '~/schemas/eval-suites'
+import { PROMPT_SOURCE_LABELS } from '~/schemas/eval-suites'
+
+export interface SuiteRunsTableProps {
+  runs: EvalSuiteRun[]
+  suiteId: string
+  isLoading?: boolean
+}
+
+function getPassCount(run: EvalSuiteRun): { passed: number; total: number } {
+  const total = run.testCaseResults.length
+  const passed = run.testCaseResults.filter((r) => r.passed === true).length
+  return { passed, total }
+}
+
+export function SuiteRunsTable({ runs, suiteId, isLoading }: SuiteRunsTableProps) {
+  const navigate = useNavigate()
+
+  if (isLoading) {
+    return (
+      <div className="overflow-hidden rounded-2xl border border-fg-subtle/10 bg-bg-elevated">
+        <div className="space-y-0">
+          {['skel-1', 'skel-2', 'skel-3'].map((key, i) => (
+            <div
+              key={key}
+              className="h-16 border-b border-fg-subtle/5 last:border-0"
+              style={{ animationDelay: `${i * 50}ms` }}
+            >
+              <div className="flex h-full items-center gap-4 px-5">
+                <div className="h-6 w-16 animate-pulse rounded-full bg-bg-subtle" />
+                <div className="h-3 w-20 animate-pulse rounded bg-bg-subtle" />
+                <div className="h-3 w-24 animate-pulse rounded bg-bg-subtle" />
+                <div className="flex-1" />
+                <div className="h-3 w-16 animate-pulse rounded bg-bg-subtle" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="relative flex flex-col items-center justify-center overflow-hidden rounded-2xl border border-fg-subtle/10 bg-bg-elevated py-20">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-brand-500/[0.03] via-transparent to-transparent" />
+        <div className="relative mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-bg-subtle">
+          <FlaskConical className="h-8 w-8 text-fg-muted" />
+        </div>
+        <p className="relative font-display text-lg font-semibold text-fg-primary">No runs yet</p>
+        <p className="relative mt-1 text-sm text-fg-muted">
+          Run this suite against a session to see results
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-fg-subtle/15 bg-bg-elevated">
+      <table className="w-full">
+        <thead className="bg-bg-elevated">
+          <tr className="border-b border-fg-subtle/10">
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Result
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Prompt Source
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Test Cases
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Duration
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Started
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run, index) => {
+            const { passed, total } = getPassCount(run)
+            const resultVariant =
+              run.passed === true ? 'success' : run.passed === false ? 'error' : 'warning'
+            const resultLabel =
+              run.passed === true ? 'Passed' : run.passed === false ? 'Failed' : 'Inconclusive'
+
+            return (
+              <tr
+                key={run.id}
+                className="group cursor-pointer border-b border-fg-subtle/5 transition-colors hover:bg-bg-subtle/50 animate-fade-up"
+                style={{ animationDelay: `${index * 30}ms` }}
+                onClick={() =>
+                  navigate({
+                    to: '/evals/suites/$suiteId/runs/$runId',
+                    params: { suiteId, runId: run.id },
+                  })
+                }
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    navigate({
+                      to: '/evals/suites/$suiteId/runs/$runId',
+                      params: { suiteId, runId: run.id },
+                    })
+                  }
+                }}
+                tabIndex={0}
+              >
+                <td className="px-4 py-3">
+                  <Badge variant={resultVariant}>{resultLabel}</Badge>
+                </td>
+                <td className="px-4 py-3">
+                  <Badge variant="info">
+                    {PROMPT_SOURCE_LABELS[run.promptSource] ?? run.promptSource}
+                  </Badge>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-sm tabular-nums text-fg-secondary">
+                    {passed}/{total} passed
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="font-mono text-sm tabular-nums text-fg-secondary">
+                    {run.durationMs != null ? formatDuration(run.durationMs / 1000) : '\u2014'}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-xs text-fg-muted">
+                    {formatDate(run.startedAt, { format: 'relative' })}
+                  </span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/modelguide-ui/src/features/evals/components/suites-table.test.tsx
+++ b/modelguide-ui/src/features/evals/components/suites-table.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { makeEvalSuiteSummary } from '../../../../test/eval-suite-fixtures'
+import { SuitesTable } from './suites-table'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('~/lib/utils', () => ({
+  formatDate: (date: string) => date,
+}))
+
+describe('SuitesTable', () => {
+  it('renders table headers', () => {
+    const suites = [makeEvalSuiteSummary()]
+
+    render(<SuitesTable suites={suites} />)
+
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(screen.getByText('SOP')).toBeInTheDocument()
+    expect(screen.getByText('Created')).toBeInTheDocument()
+  })
+
+  it('renders suite rows with name', () => {
+    const suites = [makeEvalSuiteSummary({ name: 'WISMO Eval Suite' })]
+
+    render(<SuitesTable suites={suites} />)
+
+    expect(screen.getByText('WISMO Eval Suite')).toBeInTheDocument()
+  })
+
+  it('shows description when present', () => {
+    const suites = [makeEvalSuiteSummary({ description: 'Evaluates order lookup flow' })]
+
+    render(<SuitesTable suites={suites} />)
+
+    expect(screen.getByText('Evaluates order lookup flow')).toBeInTheDocument()
+  })
+
+  it('shows "Manual" when sopId is null', () => {
+    const suites = [makeEvalSuiteSummary({ sopId: null })]
+
+    render(<SuitesTable suites={suites} />)
+
+    expect(screen.getByText('Manual')).toBeInTheDocument()
+  })
+
+  it('renders multiple rows', () => {
+    const suites = [
+      makeEvalSuiteSummary({ id: 'a', name: 'Suite Alpha' }),
+      makeEvalSuiteSummary({ id: 'b', name: 'Suite Beta' }),
+      makeEvalSuiteSummary({ id: 'c', name: 'Suite Gamma' }),
+    ]
+
+    render(<SuitesTable suites={suites} />)
+
+    expect(screen.getByText('Suite Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Suite Beta')).toBeInTheDocument()
+    expect(screen.getByText('Suite Gamma')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton when isLoading=true', () => {
+    const { container } = render(<SuitesTable suites={[]} isLoading />)
+
+    const skeletonElements = container.querySelectorAll('.animate-pulse')
+    expect(skeletonElements.length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state when suites=[]', () => {
+    render(<SuitesTable suites={[]} />)
+
+    expect(screen.getByText('No eval suites yet')).toBeInTheDocument()
+    expect(screen.getByText('Init your first suite from an agent + SOP pair')).toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/features/evals/components/suites-table.tsx
+++ b/modelguide-ui/src/features/evals/components/suites-table.tsx
@@ -1,0 +1,126 @@
+import { useNavigate } from '@tanstack/react-router'
+import { FlaskConical } from 'lucide-react'
+import { formatDate } from '~/lib/utils'
+import type { EvalSuiteSummary } from '~/schemas/eval-suites'
+
+export interface SuitesTableProps {
+  suites: EvalSuiteSummary[]
+  isLoading?: boolean
+}
+
+export function SuitesTable({ suites, isLoading }: SuitesTableProps) {
+  const navigate = useNavigate()
+
+  if (isLoading) {
+    return (
+      <div className="overflow-hidden rounded-2xl border border-fg-subtle/10 bg-bg-elevated">
+        <div className="space-y-0">
+          {['skel-1', 'skel-2', 'skel-3', 'skel-4', 'skel-5'].map((key, i) => (
+            <div
+              key={key}
+              className="h-16 border-b border-fg-subtle/5 last:border-0"
+              style={{ animationDelay: `${i * 50}ms` }}
+            >
+              <div className="flex h-full items-center gap-4 px-5">
+                <div className="h-3 w-32 animate-pulse rounded bg-bg-subtle" />
+                <div className="h-3 w-20 animate-pulse rounded bg-bg-subtle" />
+                <div className="h-3 w-20 animate-pulse rounded bg-bg-subtle" />
+                <div className="flex-1" />
+                <div className="h-3 w-16 animate-pulse rounded bg-bg-subtle" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (suites.length === 0) {
+    return (
+      <div className="relative flex flex-col items-center justify-center overflow-hidden rounded-2xl border border-fg-subtle/10 bg-bg-elevated py-20">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-brand-500/[0.03] via-transparent to-transparent" />
+        <div className="relative mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-bg-subtle">
+          <FlaskConical className="h-8 w-8 text-fg-muted" />
+        </div>
+        <p className="relative font-display text-lg font-semibold text-fg-primary">
+          No eval suites yet
+        </p>
+        <p className="relative mt-1 text-sm text-fg-muted">
+          Init your first suite from an agent + SOP pair
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-fg-subtle/15 bg-bg-elevated">
+      <table className="w-full">
+        <thead className="bg-bg-elevated">
+          <tr className="border-b border-fg-subtle/10">
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Name
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Agent
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              SOP
+            </th>
+            <th className="px-4 py-3 text-left font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+              Created
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {suites.map((suite, index) => (
+            <tr
+              key={suite.id}
+              className="group cursor-pointer border-b border-fg-subtle/5 transition-colors hover:bg-bg-subtle/50 animate-fade-up"
+              style={{ animationDelay: `${index * 30}ms` }}
+              onClick={() =>
+                navigate({ to: '/evals/suites/$suiteId', params: { suiteId: suite.id } })
+              }
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  navigate({ to: '/evals/suites/$suiteId', params: { suiteId: suite.id } })
+                }
+              }}
+              tabIndex={0}
+            >
+              <td className="px-4 py-3">
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-fg-primary group-hover:text-brand-500 transition-colors">
+                    {suite.name}
+                  </span>
+                  {suite.description ? (
+                    <span className="text-xs text-fg-muted">{suite.description}</span>
+                  ) : null}
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono text-xs tabular-nums text-fg-secondary">
+                  {suite.agentId.slice(0, 8)}…
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                {suite.sopId ? (
+                  <span className="font-mono text-xs tabular-nums text-fg-secondary">
+                    {suite.sopId.slice(0, 8)}…
+                  </span>
+                ) : (
+                  <span className="text-xs text-fg-muted">Manual</span>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-xs text-fg-muted">
+                  {formatDate(suite.createdAt, { format: 'relative' })}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/modelguide-ui/src/features/evals/components/test-cases-panel.test.tsx
+++ b/modelguide-ui/src/features/evals/components/test-cases-panel.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { makeEvalSuiteAssertion, makeEvalSuiteTestCase } from '../../../../test/eval-suite-fixtures'
+import { TestCasesPanel } from './test-cases-panel'
+
+describe('TestCasesPanel', () => {
+  it('renders all test case names', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({ id: 'tc-1', name: 'Happy Path' }),
+      makeEvalSuiteTestCase({ id: 'tc-2', name: 'Edge Case' }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    expect(screen.getByText('Happy Path')).toBeInTheDocument()
+    expect(screen.getByText('Edge Case')).toBeInTheDocument()
+  })
+
+  it('shows source badge for each test case', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({ id: 'tc-1', source: 'auto' }),
+      makeEvalSuiteTestCase({ id: 'tc-2', source: 'manual' }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    expect(screen.getByText('auto')).toBeInTheDocument()
+    expect(screen.getByText('manual')).toBeInTheDocument()
+  })
+
+  it('shows evaluator count per test case', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        evaluators: [
+          makeEvalSuiteAssertion({ id: 'a-1' }),
+          makeEvalSuiteAssertion({ id: 'a-2' }),
+          makeEvalSuiteAssertion({ id: 'a-3' }),
+        ],
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    expect(screen.getByText('3 evaluators')).toBeInTheDocument()
+  })
+
+  it('shows singular "evaluator" for single evaluator', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        evaluators: [makeEvalSuiteAssertion({ id: 'a-1' })],
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    expect(screen.getByText('1 evaluator')).toBeInTheDocument()
+  })
+
+  it('expands test case on click and shows evaluators', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        name: 'Happy Path',
+        evaluators: [makeEvalSuiteAssertion({ id: 'a-1', name: 'tool_called: get_order' })],
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    // Evaluator details should not be visible yet
+    expect(screen.queryByText('tool_called: get_order')).not.toBeInTheDocument()
+
+    // Click to expand
+    fireEvent.click(screen.getByText('Happy Path'))
+
+    // Now evaluators should be visible
+    expect(screen.getByText('tool_called: get_order')).toBeInTheDocument()
+  })
+
+  it('shows required/optional badges on evaluators', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        evaluators: [
+          makeEvalSuiteAssertion({ id: 'a-1', required: true }),
+          makeEvalSuiteAssertion({ id: 'a-2', required: false }),
+        ],
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    // Expand
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('required')).toBeInTheDocument()
+    expect(screen.getByText('optional')).toBeInTheDocument()
+  })
+
+  it('shows expected behavior when expanded', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        expectedBehavior: 'Agent looks up order and reports status',
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Agent looks up order and reports status')).toBeInTheDocument()
+  })
+
+  it('shows input JSON when expanded', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        input: { userMessage: 'Where is my order?' },
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText(/Where is my order/)).toBeInTheDocument()
+  })
+
+  it('collapses test case on second click', () => {
+    const testCases = [
+      makeEvalSuiteTestCase({
+        id: 'tc-1',
+        name: 'Happy Path',
+        expectedBehavior: 'Agent looks up order',
+      }),
+    ]
+
+    render(<TestCasesPanel testCases={testCases} />)
+
+    // Expand
+    fireEvent.click(screen.getByText('Happy Path'))
+    expect(screen.getByText('Agent looks up order')).toBeInTheDocument()
+
+    // Collapse
+    fireEvent.click(screen.getByText('Happy Path'))
+    expect(screen.queryByText('Agent looks up order')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no test cases', () => {
+    render(<TestCasesPanel testCases={[]} />)
+
+    expect(screen.getByText('No test cases yet')).toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/features/evals/components/test-cases-panel.tsx
+++ b/modelguide-ui/src/features/evals/components/test-cases-panel.tsx
@@ -1,0 +1,136 @@
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { cn } from '~/lib/cn'
+import type { EvalSuiteTestCase } from '~/schemas/eval-suites'
+
+export interface TestCasesPanelProps {
+  testCases: EvalSuiteTestCase[]
+}
+
+export function TestCasesPanel({ testCases }: TestCasesPanelProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+
+  const toggle = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  if (testCases.length === 0) {
+    return (
+      <div className="rounded-lg border border-fg-subtle/10 bg-bg-elevated px-6 py-12 text-center">
+        <p className="text-sm text-fg-muted">No test cases yet</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {testCases.map((tc, index) => {
+        const isExpanded = expandedIds.has(tc.id)
+        return (
+          <div
+            key={tc.id}
+            className={cn(
+              'group/tc overflow-hidden rounded-xl border bg-bg-elevated transition-all duration-200',
+              isExpanded
+                ? 'border-brand-500/20 shadow-[0_0_20px_-8px_rgba(249,115,22,0.15)]'
+                : 'border-fg-subtle/10 hover:border-fg-subtle/20',
+            )}
+            style={{ animationDelay: `${index * 40}ms` }}
+          >
+            <button
+              type="button"
+              onClick={() => toggle(tc.id)}
+              className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg-subtle/30"
+            >
+              <span
+                className={cn(
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-md font-mono text-[10px] font-medium transition-colors',
+                  isExpanded
+                    ? 'bg-brand-500/15 text-brand-500'
+                    : 'bg-bg-subtle text-fg-muted group-hover/tc:bg-bg-subtle/80',
+                )}
+              >
+                #{tc.order}
+              </span>
+              <span className="flex-1 text-sm font-medium text-fg-primary">{tc.name}</span>
+              <Badge variant={tc.source === 'auto' ? 'info' : 'default'}>{tc.source}</Badge>
+              <span className="text-xs text-fg-muted">
+                {tc.evaluators.length} evaluator{tc.evaluators.length !== 1 ? 's' : ''}
+              </span>
+              {isExpanded ? (
+                <ChevronUp className="h-4 w-4 text-fg-muted transition-transform" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-fg-muted transition-transform" />
+              )}
+            </button>
+
+            {isExpanded ? (
+              <div className="border-t border-fg-subtle/10 px-4 py-3 animate-fade-in">
+                {tc.description ? (
+                  <p className="mb-2 text-sm text-fg-secondary">{tc.description}</p>
+                ) : null}
+
+                {tc.expectedBehavior ? (
+                  <div className="mb-2">
+                    <span className="font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                      Expected:{' '}
+                    </span>
+                    <span className="text-xs text-fg-secondary">{tc.expectedBehavior}</span>
+                  </div>
+                ) : null}
+
+                {tc.input ? (
+                  <div className="mb-3">
+                    <span className="font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                      Input:{' '}
+                    </span>
+                    <code className="font-mono text-xs text-fg-secondary">
+                      {JSON.stringify(tc.input)}
+                    </code>
+                  </div>
+                ) : null}
+
+                {tc.evaluators.length > 0 ? (
+                  <div>
+                    <p className="mb-1.5 font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                      Evaluators:
+                    </p>
+                    <div className="space-y-0.5 rounded-lg border border-fg-subtle/10 bg-bg-base p-1.5">
+                      {tc.evaluators.map((assertion) => (
+                        <div
+                          key={assertion.id}
+                          className="flex items-center gap-2 rounded-md px-2.5 py-2 text-xs transition-colors hover:bg-bg-subtle/40"
+                        >
+                          <span className="flex-1 font-mono text-fg-secondary">
+                            {assertion.name}
+                          </span>
+                          <Badge variant={assertion.source === 'auto' ? 'info' : 'default'}>
+                            {assertion.source}
+                          </Badge>
+                          {assertion.required ? (
+                            <Badge variant="warning">required</Badge>
+                          ) : (
+                            <span className="text-fg-muted">optional</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
+++ b/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   Check,
   Copy,
+  FlaskConical,
   Key,
   Link2,
   Plug,
@@ -24,12 +25,14 @@ import { AddConnectorDialog } from '~/features/agents/components/add-connector-d
 import { ApiKeyModal } from '~/features/agents/components/api-key-modal'
 import { ElevenLabsCard } from '~/features/agents/components/elevenlabs-card'
 import { api } from '~/lib/api'
+import type { PaginatedResponse } from '~/lib/pagination'
 import type {
   Agent,
   AgentConnector,
   AgentConnectorTool,
   RegenerateKeyResponse,
 } from '~/schemas/agents'
+import type { EvalSuiteSummary } from '~/schemas/eval-suites'
 import { useAuthStore } from '~/stores/auth'
 
 export const Route = createFileRoute('/_authenticated/agents/$id')({
@@ -411,6 +414,9 @@ function AgentDetailPage() {
             isAdmin={isAdmin}
           />
 
+          {/* Eval Suites */}
+          <AgentEvalSuitesCard agentId={id} />
+
           {/* Platform */}
           <ElevenLabsCard agent={agent} isAdmin={isAdmin} />
 
@@ -522,5 +528,50 @@ function AgentDetailPage() {
         />
       ) : null}
     </div>
+  )
+}
+
+function AgentEvalSuitesCard({ agentId }: { agentId: string }) {
+  const { data } = useQuery({
+    queryKey: ['eval-suites', { agentId }],
+    queryFn: () =>
+      api
+        .get('eval-suites', { searchParams: { agentId } })
+        .json<PaginatedResponse<EvalSuiteSummary>>(),
+  })
+
+  const suites = data?.data ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FlaskConical className="h-4 w-4" />
+          Eval Suites
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {suites.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <FlaskConical className="h-8 w-8 text-fg-muted" />
+            <p className="mt-3 text-sm text-fg-muted">No eval suites for this agent</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {suites.map((suite) => (
+              <Link
+                key={suite.id}
+                to="/evals/suites/$suiteId"
+                params={{ suiteId: suite.id }}
+                className="flex items-center gap-2 rounded-lg border border-fg-subtle/10 bg-bg-subtle/50 px-3 py-2.5 transition-colors hover:border-fg-subtle/20 hover:bg-bg-subtle"
+              >
+                <FlaskConical className="h-3.5 w-3.5 text-cyan-400" />
+                <span className="flex-1 text-sm font-medium text-fg-primary">{suite.name}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/modelguide-ui/src/routes/_authenticated/evals.index.test.tsx
+++ b/modelguide-ui/src/routes/_authenticated/evals.index.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeEvalSuiteSummary } from '../../../test/eval-suite-fixtures'
+import type { EvalSuiteSummary } from '../../schemas/eval-suites'
+
+// --- Mocks ---
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => options,
+  useNavigate: () => vi.fn(),
+  Link: ({ children, className }: { children: ReactNode; className?: string }) => (
+    // biome-ignore lint/a11y/useValidAnchor: mock Link for tests
+    <a className={className}>{children}</a>
+  ),
+}))
+
+let mockIsAdmin = true
+vi.mock('~/lib/permissions', () => ({
+  useIsAdmin: () => mockIsAdmin,
+}))
+
+vi.mock('~/lib/utils', () => ({
+  formatDate: (date: string) => date,
+}))
+
+let suitesFixture: EvalSuiteSummary[] = []
+let shouldRejectGet = false
+
+vi.mock('~/lib/api', () => ({
+  api: {
+    get: () => ({
+      json: () =>
+        shouldRejectGet
+          ? Promise.reject(new Error('Failed'))
+          : Promise.resolve({
+              data: suitesFixture,
+              pagination: {
+                page: 1,
+                pageSize: 20,
+                totalItems: suitesFixture.length,
+                totalPages: 1,
+                hasNextPage: false,
+                hasPreviousPage: false,
+              },
+            }),
+    }),
+  },
+}))
+
+// Mock dialog methods
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn()
+  HTMLDialogElement.prototype.close = vi.fn()
+})
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EvalsPage />
+    </QueryClientProvider>,
+  )
+}
+
+const { Route } = await import('./evals.index')
+// biome-ignore lint/suspicious/noExplicitAny: accessing internal Route.component for test rendering
+const EvalsPage = (Route as any).component as React.ComponentType
+
+// --- Tests ---
+
+describe('EvalsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAdmin = true
+    suitesFixture = []
+    shouldRejectGet = false
+  })
+
+  it('renders page header with "Eval Suites" title', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Eval Suites')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Evaluate agent performance against SOPs')).toBeInTheDocument()
+  })
+
+  it('shows suites table with data when API returns suites', async () => {
+    suitesFixture = [
+      makeEvalSuiteSummary({ id: 'a', name: 'WISMO Suite' }),
+      makeEvalSuiteSummary({ id: 'b', name: 'Returns Suite' }),
+    ]
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('WISMO Suite')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Returns Suite')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no suites', async () => {
+    suitesFixture = []
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('No eval suites yet')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Create Eval Suite" button for admin users', async () => {
+    mockIsAdmin = true
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Create Eval Suite')).toBeInTheDocument()
+    })
+  })
+
+  it('hides "Create Eval Suite" button for non-admin users', async () => {
+    mockIsAdmin = false
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Eval Suites')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Create Eval Suite')).not.toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/routes/_authenticated/evals.index.tsx
+++ b/modelguide-ui/src/routes/_authenticated/evals.index.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { FlaskConical, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '~/components/ui/button'
+import { PageHeader } from '~/components/ui/page-header'
+import { Pagination } from '~/components/ui/pagination'
+import { InitSuiteDialog } from '~/features/evals/components/init-suite-dialog'
+import { SuitesTable } from '~/features/evals/components/suites-table'
+import { api } from '~/lib/api'
+import type { PaginatedResponse } from '~/lib/pagination'
+import { useIsAdmin } from '~/lib/permissions'
+import type { EvalSuiteSummary } from '~/schemas/eval-suites'
+
+export const Route = createFileRoute('/_authenticated/evals/')({
+  component: EvalsPage,
+})
+
+function EvalsPage() {
+  const isAdmin = useIsAdmin()
+  const [showInitDialog, setShowInitDialog] = useState(false)
+  const [page, setPage] = useState(1)
+  const pageSize = 20
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['eval-suites', page],
+    queryFn: () =>
+      api
+        .get('eval-suites', { searchParams: { page, pageSize } })
+        .json<PaginatedResponse<EvalSuiteSummary>>(),
+  })
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={FlaskConical}
+        iconBg="bg-cyan-500/15"
+        iconColor="text-cyan-400"
+        title="Eval Suites"
+        description="Evaluate agent performance against SOPs"
+        actions={
+          isAdmin ? (
+            <Button onClick={() => setShowInitDialog(true)}>
+              <Plus className="h-4 w-4" />
+              Create Eval Suite
+            </Button>
+          ) : null
+        }
+      />
+
+      <SuitesTable suites={data?.data ?? []} isLoading={isLoading} />
+
+      {data && (
+        <Pagination
+          page={page}
+          pageSize={pageSize}
+          total={data.pagination.totalItems}
+          onPageChange={setPage}
+        />
+      )}
+
+      {isAdmin ? (
+        <InitSuiteDialog open={showInitDialog} onClose={() => setShowInitDialog(false)} />
+      ) : null}
+    </div>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.runs.$runId.tsx
+++ b/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.runs.$runId.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { ArrowLeft, Clock, MessageSquare, Play, Square } from 'lucide-react'
+import { Badge } from '~/components/ui/badge'
+import { Spinner } from '~/components/ui/spinner'
+import { RunResultsCard } from '~/features/evals/components/run-results-card'
+import { api } from '~/lib/api'
+import { cn } from '~/lib/cn'
+import { formatDate, formatDuration } from '~/lib/utils'
+import type { EvalSuiteDetail, EvalSuiteRun } from '~/schemas/eval-suites'
+import { PROMPT_SOURCE_LABELS } from '~/schemas/eval-suites'
+
+export const Route = createFileRoute('/_authenticated/evals/suites/$suiteId/runs/$runId')({
+  component: RunDetailPage,
+})
+
+function RunDetailPage() {
+  const { suiteId, runId } = Route.useParams()
+
+  const {
+    data: run,
+    isLoading: runLoading,
+    error: runError,
+  } = useQuery({
+    queryKey: ['eval-suites', suiteId, 'runs', runId],
+    queryFn: () => api.get(`eval-suites/${suiteId}/runs/${runId}`).json<EvalSuiteRun>(),
+  })
+
+  const { data: suite } = useQuery({
+    queryKey: ['eval-suites', suiteId],
+    queryFn: () => api.get(`eval-suites/${suiteId}`).json<EvalSuiteDetail>(),
+  })
+
+  const resultVariant =
+    run?.passed === true ? 'success' : run?.passed === false ? 'error' : 'warning'
+  const resultLabel =
+    run?.passed === true ? 'Passed' : run?.passed === false ? 'Failed' : 'Inconclusive'
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4 animate-fade-up">
+        <Link
+          to="/evals/suites/$suiteId"
+          params={{ suiteId }}
+          className="flex h-8 w-8 items-center justify-center rounded text-fg-secondary hover:bg-bg-subtle hover:text-fg-primary"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold text-fg-primary">Run Results</h1>
+          {suite ? <p className="mt-1 font-sans text-sm text-fg-secondary">{suite.name}</p> : null}
+        </div>
+        {run ? (
+          <div className="flex items-center gap-2">
+            <Badge variant={resultVariant}>{resultLabel}</Badge>
+            <Badge variant="info">
+              {PROMPT_SOURCE_LABELS[run.promptSource] ?? run.promptSource}
+            </Badge>
+          </div>
+        ) : null}
+      </div>
+
+      {runLoading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : runError ? (
+        <div className="rounded-lg border border-error/30 bg-error-muted p-6 text-center">
+          <p className="text-sm text-error">Failed to load run results</p>
+        </div>
+      ) : run ? (
+        <>
+          {/* Metadata */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              {
+                icon: Clock,
+                label: 'Duration',
+                value: run.durationMs != null ? formatDuration(run.durationMs / 1000) : '\u2014',
+              },
+              {
+                icon: Play,
+                label: 'Started',
+                value: formatDate(run.startedAt, { format: 'full' }),
+              },
+              {
+                icon: Square,
+                label: 'Completed',
+                value: run.completedAt ? formatDate(run.completedAt, { format: 'full' }) : '\u2014',
+              },
+            ].map((card, i) => (
+              <div
+                key={card.label}
+                className={cn(
+                  'group relative overflow-hidden rounded-xl border border-fg-subtle/10 bg-bg-elevated px-4 py-3',
+                  'transition-all duration-200 hover:border-fg-subtle/20',
+                )}
+                style={{ animationDelay: `${i * 60}ms` }}
+              >
+                <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-500/[0.03] via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+                <div className="relative flex items-center gap-2">
+                  <card.icon className="h-3.5 w-3.5 text-fg-muted" />
+                  <p className="font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                    {card.label}
+                  </p>
+                </div>
+                <p className="relative mt-1 font-mono text-sm tabular-nums text-fg-primary">
+                  {card.value}
+                </p>
+              </div>
+            ))}
+            {run.sessionId ? (
+              <Link
+                to="/sessions/$id"
+                params={{ id: run.sessionId }}
+                className={cn(
+                  'group relative overflow-hidden rounded-xl border border-fg-subtle/10 bg-bg-elevated px-4 py-3',
+                  'transition-all duration-200 hover:border-brand-500/30',
+                )}
+                style={{ animationDelay: '180ms' }}
+              >
+                <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-500/[0.03] via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+                <div className="relative flex items-center gap-2">
+                  <MessageSquare className="h-3.5 w-3.5 text-fg-muted" />
+                  <p className="font-display text-[10px] font-semibold uppercase tracking-wider text-fg-muted">
+                    Session
+                  </p>
+                </div>
+                <p className="relative mt-1 truncate font-mono text-xs tabular-nums text-brand-400">
+                  {run.sessionId}
+                </p>
+              </Link>
+            ) : null}
+          </div>
+
+          {/* Results */}
+          <RunResultsCard testCaseResults={run.testCaseResults} testCases={suite?.testCases} />
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.test.tsx
+++ b/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.test.tsx
@@ -1,0 +1,196 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeEvalSuiteDetail, makeEvalSuiteRun } from '../../../test/eval-suite-fixtures'
+import type { EvalSuiteDetail, EvalSuiteRun } from '../../schemas/eval-suites'
+
+// --- Mocks ---
+
+const mockNavigate = vi.fn()
+const mockParams: Record<string, string> = { suiteId: '00000000-0000-0000-0000-d00000000001' }
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    useParams: () => mockParams,
+  }),
+  useNavigate: () => mockNavigate,
+  useMatch: () => null,
+  Outlet: () => null,
+  Link: ({ children, className }: { children: ReactNode; className?: string }) => (
+    // biome-ignore lint/a11y/useValidAnchor: mock Link for tests
+    <a className={className}>{children}</a>
+  ),
+}))
+
+let mockIsAdmin = true
+vi.mock('~/lib/permissions', () => ({
+  useIsAdmin: () => mockIsAdmin,
+}))
+
+vi.mock('~/lib/utils', () => ({
+  formatDate: (date: string) => date,
+  formatDuration: (seconds: number) => `${Math.round(seconds)}s`,
+}))
+
+let suiteFixture: EvalSuiteDetail = makeEvalSuiteDetail()
+let runsFixture: EvalSuiteRun[] = []
+let shouldRejectGet = false
+
+vi.mock('~/lib/api', () => ({
+  api: {
+    get: (url: string) => ({
+      json: () => {
+        if (shouldRejectGet) return Promise.reject(new Error('Not found'))
+        if (url.includes('/runs')) {
+          return Promise.resolve({
+            data: runsFixture,
+            pagination: {
+              page: 1,
+              pageSize: 20,
+              totalItems: runsFixture.length,
+              totalPages: 1,
+              hasNextPage: false,
+              hasPreviousPage: false,
+            },
+          })
+        }
+        return Promise.resolve(suiteFixture)
+      },
+    }),
+    delete: () => Promise.resolve({}),
+  },
+}))
+
+// Mock dialog methods
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn()
+  HTMLDialogElement.prototype.close = vi.fn()
+})
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SuiteDetailPage />
+    </QueryClientProvider>,
+  )
+}
+
+const { Route } = await import('./evals.suites.$suiteId')
+// biome-ignore lint/suspicious/noExplicitAny: accessing internal Route.component for test rendering
+const SuiteDetailPage = (Route as any).component as React.ComponentType
+
+// --- Tests ---
+
+describe('SuiteDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAdmin = true
+    suiteFixture = makeEvalSuiteDetail()
+    runsFixture = []
+    shouldRejectGet = false
+  })
+
+  it('renders suite name and description after loading', async () => {
+    suiteFixture = makeEvalSuiteDetail({
+      name: 'WISMO Eval Suite',
+      description: 'Evaluates order lookup flow',
+    })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('WISMO Eval Suite')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Evaluates order lookup flow')).toBeInTheDocument()
+  })
+
+  it('renders Test Cases and Runs tabs', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Cases')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Runs')).toBeInTheDocument()
+  })
+
+  it('shows test cases in default tab', async () => {
+    suiteFixture = makeEvalSuiteDetail()
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Happy Path')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Edge Case')).toBeInTheDocument()
+    expect(screen.getByText('Guardrail Test')).toBeInTheDocument()
+  })
+
+  it('switches to Runs tab and shows run history', async () => {
+    runsFixture = [
+      makeEvalSuiteRun({ id: 'run-1', passed: true }),
+      makeEvalSuiteRun({ id: 'run-2', passed: false }),
+    ]
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Cases')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Runs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Passed')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+  })
+
+  it('shows "Run Suite" button for admin', async () => {
+    mockIsAdmin = true
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Run Suite')).toBeInTheDocument()
+    })
+  })
+
+  it('hides "Run Suite" and "Delete" for non-admin', async () => {
+    mockIsAdmin = false
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Cases')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Run Suite')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('shows error state when API fails', async () => {
+    shouldRejectGet = true
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load eval suite')).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading spinner while fetching', () => {
+    // Don't resolve the promise to keep it loading
+    renderPage()
+
+    expect(screen.getByText('Suite Detail')).toBeInTheDocument()
+  })
+})

--- a/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.tsx
+++ b/modelguide-ui/src/routes/_authenticated/evals.suites.$suiteId.tsx
@@ -1,0 +1,256 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, Outlet, createFileRoute, useMatch, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft, Bot, FileText, FlaskConical, Play, RefreshCw, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogFooter } from '~/components/ui/dialog'
+import { Spinner } from '~/components/ui/spinner'
+import { RunSuiteDialog } from '~/features/evals/components/run-suite-dialog'
+import { SuiteRunsTable } from '~/features/evals/components/suite-runs-table'
+import { TestCasesPanel } from '~/features/evals/components/test-cases-panel'
+import { api } from '~/lib/api'
+import { cn } from '~/lib/cn'
+import type { PaginatedResponse } from '~/lib/pagination'
+import { useIsAdmin } from '~/lib/permissions'
+import type { Agent } from '~/schemas/agents'
+import type { EvalSuiteDetail, EvalSuiteRun } from '~/schemas/eval-suites'
+import type { SopDetail } from '~/schemas/sops'
+
+export const Route = createFileRoute('/_authenticated/evals/suites/$suiteId')({
+  component: SuiteDetailPage,
+})
+
+function SuiteDetailPage() {
+  const { suiteId } = Route.useParams()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const isAdmin = useIsAdmin()
+  const [activeTab, setActiveTab] = useState<'test-cases' | 'runs'>('test-cases')
+  const [showRunDialog, setShowRunDialog] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+
+  // If a child route (e.g. runs/$runId) is active, render it instead
+  const childMatch = useMatch({
+    from: '/_authenticated/evals/suites/$suiteId/runs/$runId',
+    shouldThrow: false,
+  })
+
+  const {
+    data: suite,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['eval-suites', suiteId],
+    queryFn: () => api.get(`eval-suites/${suiteId}`).json<EvalSuiteDetail>(),
+  })
+
+  const { data: agent } = useQuery({
+    queryKey: ['agents', suite?.agentId],
+    queryFn: () => api.get(`agents/${suite?.agentId}`).json<Agent>(),
+    enabled: !!suite?.agentId,
+  })
+
+  const { data: sop } = useQuery({
+    queryKey: ['sops', suite?.sopId],
+    queryFn: () => api.get(`sops/${suite?.sopId}`).json<SopDetail>(),
+    enabled: !!suite?.sopId,
+  })
+
+  const { data: runsData, isLoading: runsLoading } = useQuery({
+    queryKey: ['eval-suites', suiteId, 'runs'],
+    queryFn: () => api.get(`eval-suites/${suiteId}/runs`).json<PaginatedResponse<EvalSuiteRun>>(),
+  })
+
+  const reinitMutation = useMutation({
+    mutationFn: () =>
+      api
+        .post('eval-suites/init', { json: { agentId: suite?.agentId, sopId: suite?.sopId } })
+        .json<EvalSuiteDetail>(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['eval-suites', suiteId] })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => api.delete(`eval-suites/${suiteId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['eval-suites'] })
+      navigate({ to: '/evals' })
+    },
+  })
+
+  if (childMatch) return <Outlet />
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4 animate-fade-up">
+        <Link
+          to="/evals"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-fg-secondary transition-colors hover:bg-bg-subtle hover:text-fg-primary"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="font-display text-2xl font-bold text-fg-primary">
+              {suite?.name ?? 'Suite Detail'}
+            </h1>
+            {suite ? (
+              <Badge variant="info">
+                <FlaskConical className="h-3 w-3" />
+                eval suite
+              </Badge>
+            ) : null}
+          </div>
+          {suite?.description ? (
+            <p className="mt-1 font-sans text-sm text-fg-secondary">{suite.description}</p>
+          ) : null}
+        </div>
+        {isAdmin && suite ? (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => reinitMutation.mutate()}
+              loading={reinitMutation.isPending}
+              title="Re-generate test cases and evaluators from SOP"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Re-init
+            </Button>
+            <Button onClick={() => setShowRunDialog(true)}>
+              <Play className="h-4 w-4" />
+              Run Suite
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => {
+                deleteMutation.reset()
+                setShowDeleteDialog(true)
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Agent & SOP links */}
+      {suite ? (
+        <div className="flex items-center gap-4 text-sm">
+          {agent ? (
+            <Link
+              to="/agents/$id"
+              params={{ id: suite.agentId }}
+              className="flex items-center gap-1.5 rounded-lg border border-fg-subtle/10 bg-bg-elevated px-3 py-1.5 text-fg-secondary transition-colors hover:border-fg-subtle/20 hover:text-fg-primary"
+            >
+              <Bot className="h-3.5 w-3.5 text-fg-muted" />
+              {agent.name}
+            </Link>
+          ) : null}
+          {sop ? (
+            <Link
+              to="/sops/$id"
+              params={{ id: suite.sopId ?? '' }}
+              className="flex items-center gap-1.5 rounded-lg border border-fg-subtle/10 bg-bg-elevated px-3 py-1.5 text-fg-secondary transition-colors hover:border-fg-subtle/20 hover:text-fg-primary"
+            >
+              <FileText className="h-3.5 w-3.5 text-fg-muted" />
+              {sop.name}
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-error/30 bg-error-muted p-6 text-center">
+          <p className="text-sm text-error">Failed to load eval suite</p>
+        </div>
+      ) : suite ? (
+        <>
+          {/* Tabs */}
+          <div className="flex gap-1 rounded-xl bg-bg-subtle p-1">
+            <button
+              type="button"
+              onClick={() => setActiveTab('test-cases')}
+              className={cn(
+                'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                activeTab === 'test-cases'
+                  ? 'bg-bg-elevated text-fg-primary shadow-sm'
+                  : 'text-fg-secondary hover:text-fg-primary',
+              )}
+            >
+              Test Cases
+              {suite.testCases ? (
+                <span className="ml-1.5 text-xs text-fg-muted">({suite.testCases.length})</span>
+              ) : null}
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('runs')}
+              className={cn(
+                'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+                activeTab === 'runs'
+                  ? 'bg-bg-elevated text-fg-primary shadow-sm'
+                  : 'text-fg-secondary hover:text-fg-primary',
+              )}
+            >
+              Runs
+              {runsData ? (
+                <span className="ml-1.5 text-xs text-fg-muted">
+                  ({runsData.pagination.totalItems})
+                </span>
+              ) : null}
+            </button>
+          </div>
+
+          {/* Tab Content */}
+          {activeTab === 'test-cases' ? (
+            <TestCasesPanel testCases={suite.testCases ?? []} />
+          ) : (
+            <SuiteRunsTable runs={runsData?.data ?? []} suiteId={suiteId} isLoading={runsLoading} />
+          )}
+        </>
+      ) : null}
+
+      {/* Run Suite Dialog */}
+      {isAdmin ? (
+        <RunSuiteDialog
+          open={showRunDialog}
+          onClose={() => setShowRunDialog(false)}
+          suiteId={suiteId}
+          onSuccess={() => setActiveTab('runs')}
+        />
+      ) : null}
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={showDeleteDialog}
+        onClose={() => setShowDeleteDialog(false)}
+        title="Delete Eval Suite"
+        description="This will permanently delete this eval suite, all its test cases, assertions, and run history. This action cannot be undone."
+      >
+        {deleteMutation.error ? (
+          <p className="mb-3 text-xs text-error">Failed to delete suite. Please try again.</p>
+        ) : null}
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => setShowDeleteDialog(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => deleteMutation.mutate()}
+            loading={deleteMutation.isPending}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/sops.$id.tsx
+++ b/modelguide-ui/src/routes/_authenticated/sops.$id.tsx
@@ -1,6 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Archive, ArrowLeft, CirclePause, ClipboardList, GitFork, Pencil, Play } from 'lucide-react'
+import {
+  Archive,
+  ArrowLeft,
+  CirclePause,
+  ClipboardList,
+  FlaskConical,
+  GitFork,
+  Pencil,
+  Play,
+} from 'lucide-react'
 import { useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -13,8 +22,10 @@ import { SopStepsTimeline } from '~/features/sops/components/sop-steps-timeline'
 import { SopTriggerDetail } from '~/features/sops/components/sop-trigger-badge'
 import { api } from '~/lib/api'
 import { cn } from '~/lib/cn'
+import type { PaginatedResponse } from '~/lib/pagination'
 import { useCanMutate, useIsAdmin } from '~/lib/permissions'
 import { formatDate } from '~/lib/utils'
+import type { EvalSuiteSummary } from '~/schemas/eval-suites'
 import type { SopDetail } from '~/schemas/sops'
 import { TRIGGER_LABELS, statusVariantMap } from '~/schemas/sops'
 
@@ -183,13 +194,14 @@ function SopDetailPage() {
   )
 }
 
-type SidebarTab = 'details' | 'trigger' | 'metadata' | 'agents' | 'settings'
+type SidebarTab = 'details' | 'trigger' | 'metadata' | 'agents' | 'evals' | 'settings'
 
 const sidebarTabs: { key: SidebarTab; label: string }[] = [
   { key: 'details', label: 'Details' },
   { key: 'trigger', label: 'Trigger' },
   { key: 'metadata', label: 'Metadata' },
   { key: 'agents', label: 'Agents' },
+  { key: 'evals', label: 'Evals' },
   { key: 'settings', label: 'Settings' },
 ]
 
@@ -236,6 +248,7 @@ function SidebarTabs({
       {activeTab === 'agents' ? (
         <SopAgentsCard sopId={sop.id} agents={sop.assignedAgents} canMutate={canMutate} />
       ) : null}
+      {activeTab === 'evals' ? <SopEvalSuitesCard sopId={sop.id} /> : null}
       {activeTab === 'settings' && isAdmin ? (
         <div className="space-y-6">
           {canMutate && sop.status !== 'archived' ? (
@@ -340,6 +353,45 @@ function TriggerCard({ sop }: { sop: SopDetail }) {
             </div>
           ) : null}
         </dl>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SopEvalSuitesCard({ sopId }: { sopId: string }) {
+  const { data } = useQuery({
+    queryKey: ['eval-suites', { sopId }],
+    queryFn: () =>
+      api
+        .get('eval-suites', { searchParams: { sopId } })
+        .json<PaginatedResponse<EvalSuiteSummary>>(),
+  })
+
+  const suites = data?.data ?? []
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        {suites.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <FlaskConical className="h-8 w-8 text-fg-muted" />
+            <p className="mt-3 text-sm text-fg-muted">No eval suites for this SOP</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {suites.map((suite) => (
+              <Link
+                key={suite.id}
+                to="/evals/suites/$suiteId"
+                params={{ suiteId: suite.id }}
+                className="flex items-center gap-2 rounded-lg border border-fg-subtle/10 bg-bg-subtle/50 px-3 py-2.5 transition-colors hover:border-fg-subtle/20 hover:bg-bg-subtle"
+              >
+                <FlaskConical className="h-3.5 w-3.5 text-cyan-400" />
+                <span className="flex-1 text-sm font-medium text-fg-primary">{suite.name}</span>
+              </Link>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/modelguide-ui/src/schemas/eval-suites.ts
+++ b/modelguide-ui/src/schemas/eval-suites.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod'
+
+// --- Assertion ---
+
+export const evalSuiteAssertionSchema = z.object({
+  id: z.string().uuid(),
+  testCaseId: z.string().uuid(),
+  evalConfigId: z.string().uuid(),
+  name: z.string(),
+  sopStepId: z.string().nullable().optional(),
+  source: z.enum(['auto', 'manual']),
+  order: z.number(),
+  required: z.boolean(),
+  createdAt: z.string(),
+})
+
+export type EvalSuiteAssertion = z.infer<typeof evalSuiteAssertionSchema>
+
+// --- Test Case ---
+
+export const evalSuiteTestCaseSchema = z.object({
+  id: z.string().uuid(),
+  suiteId: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  source: z.enum(['auto', 'manual']),
+  input: z.record(z.unknown()).nullable().optional(),
+  expectedBehavior: z.string().nullable().optional(),
+  order: z.number(),
+  evaluators: z.array(evalSuiteAssertionSchema),
+  createdAt: z.string(),
+  updatedAt: z.string().nullable().optional(),
+})
+
+export type EvalSuiteTestCase = z.infer<typeof evalSuiteTestCaseSchema>
+
+// --- Suite Summary (list view) ---
+
+export const evalSuiteSummarySchema = z.object({
+  id: z.string().uuid(),
+  agentId: z.string().uuid(),
+  sopId: z.string().uuid().nullable().optional(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  createdBy: z.string().uuid().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().nullable().optional(),
+})
+
+export type EvalSuiteSummary = z.infer<typeof evalSuiteSummarySchema>
+
+// --- Suite Detail (includes test cases) ---
+
+export const evalSuiteDetailSchema = evalSuiteSummarySchema.extend({
+  testCases: z.array(evalSuiteTestCaseSchema).optional(),
+})
+
+export type EvalSuiteDetail = z.infer<typeof evalSuiteDetailSchema>
+
+// --- Run Score ---
+
+export const evalRunScoreSchema = z.object({
+  id: z.string().uuid(),
+  evalConfigId: z.string().uuid(),
+  name: z.string(),
+  scoreOrder: z.number(),
+  required: z.boolean(),
+  evaluatorType: z.string(),
+  result: z.enum(['pass', 'fail', 'skip', 'error']),
+  reasoning: z.string().nullable().optional(),
+  failureClassification: z.string().nullable().optional(),
+  expected: z.record(z.unknown()).nullable().optional(),
+  actual: z.record(z.unknown()).nullable().optional(),
+  durationMs: z.number().nullable().optional(),
+  createdAt: z.string(),
+})
+
+export type EvalRunScore = z.infer<typeof evalRunScoreSchema>
+
+// --- Test Case Result ---
+
+export const testCaseResultSchema = z.object({
+  testCaseId: z.string().uuid().nullable().optional(),
+  testCaseName: z.string().nullable().optional(),
+  evalRunId: z.string().uuid(),
+  passed: z.boolean().nullable().optional(),
+  status: z.string(),
+  scores: z.array(evalRunScoreSchema),
+})
+
+export type TestCaseResult = z.infer<typeof testCaseResultSchema>
+
+// --- Suite Run ---
+
+export const evalSuiteRunSchema = z.object({
+  id: z.string().uuid(),
+  suiteId: z.string().uuid(),
+  sessionId: z.string().uuid().nullable().optional(),
+  promptSource: z.enum(['compiled', 'hand_written', 'edited']),
+  passed: z.boolean().nullable().optional(),
+  triggeredBy: z.string().uuid().nullable().optional(),
+  startedAt: z.string(),
+  completedAt: z.string().nullable().optional(),
+  durationMs: z.number().nullable().optional(),
+  metadata: z.record(z.unknown()).nullable().optional(),
+  testCaseResults: z.array(testCaseResultSchema),
+})
+
+export type EvalSuiteRun = z.infer<typeof evalSuiteRunSchema>
+
+// --- Request types ---
+
+export const initSuiteRequestSchema = z.object({
+  agentId: z.string().uuid(),
+  sopId: z.string().uuid(),
+})
+
+export type InitSuiteRequest = z.infer<typeof initSuiteRequestSchema>
+
+export const runSuiteRequestSchema = z.object({
+  sessionId: z.string().uuid(),
+  promptSource: z.enum(['compiled', 'hand_written', 'edited']),
+})
+
+export type RunSuiteRequest = z.infer<typeof runSuiteRequestSchema>
+
+// --- Prompt source labels ---
+
+export const PROMPT_SOURCE_LABELS: Record<string, string> = {
+  compiled: 'Compiled',
+  hand_written: 'Hand Written',
+  edited: 'Edited',
+}

--- a/modelguide-ui/test/eval-suite-fixtures.ts
+++ b/modelguide-ui/test/eval-suite-fixtures.ts
@@ -1,0 +1,143 @@
+import type {
+  EvalRunScore,
+  EvalSuiteAssertion,
+  EvalSuiteDetail,
+  EvalSuiteRun,
+  EvalSuiteSummary,
+  EvalSuiteTestCase,
+  TestCaseResult,
+} from '~/schemas/eval-suites'
+
+export function makeEvalSuiteAssertion(
+  overrides: Partial<EvalSuiteAssertion> = {},
+): EvalSuiteAssertion {
+  return {
+    id: '00000000-0000-0000-0000-a00000000001',
+    testCaseId: '00000000-0000-0000-0000-b00000000001',
+    evalConfigId: '00000000-0000-0000-0000-c00000000001',
+    name: 'tool_called: get_order',
+    sopStepId: 'step-1',
+    source: 'auto',
+    order: 1,
+    required: true,
+    createdAt: '2026-02-15T10:00:00Z',
+    ...overrides,
+  }
+}
+
+export function makeEvalSuiteTestCase(
+  overrides: Partial<EvalSuiteTestCase> = {},
+): EvalSuiteTestCase {
+  return {
+    id: '00000000-0000-0000-0000-b00000000001',
+    suiteId: '00000000-0000-0000-0000-d00000000001',
+    name: 'Happy Path',
+    description: 'Tests normal order flow',
+    source: 'auto',
+    input: { userMessage: 'Where is my order?' },
+    expectedBehavior: 'Agent looks up order and reports status',
+    order: 1,
+    evaluators: [makeEvalSuiteAssertion()],
+    createdAt: '2026-02-15T10:00:00Z',
+    updatedAt: '2026-02-16T12:00:00Z',
+    ...overrides,
+  }
+}
+
+export function makeEvalSuiteSummary(overrides: Partial<EvalSuiteSummary> = {}): EvalSuiteSummary {
+  return {
+    id: '00000000-0000-0000-0000-d00000000001',
+    agentId: '00000000-0000-0000-0000-e00000000001',
+    sopId: '00000000-0000-0000-0000-f00000000001',
+    name: 'WISMO Eval Suite',
+    description: 'Evaluates order lookup flow',
+    createdBy: '00000000-0000-0000-0000-100000000001',
+    createdAt: '2026-02-15T10:00:00Z',
+    updatedAt: '2026-02-16T12:00:00Z',
+    ...overrides,
+  }
+}
+
+export function makeEvalSuiteDetail(overrides: Partial<EvalSuiteDetail> = {}): EvalSuiteDetail {
+  return {
+    ...makeEvalSuiteSummary(),
+    testCases: [
+      makeEvalSuiteTestCase({ id: 'tc-1', name: 'Happy Path', order: 1 }),
+      makeEvalSuiteTestCase({
+        id: 'tc-2',
+        name: 'Edge Case',
+        order: 2,
+        source: 'manual',
+        description: 'Tests edge case scenario',
+        evaluators: [
+          makeEvalSuiteAssertion({
+            id: 'a-2a',
+            testCaseId: 'tc-2',
+            name: 'llm_judge: Confirms status',
+            order: 1,
+          }),
+          makeEvalSuiteAssertion({
+            id: 'a-2b',
+            testCaseId: 'tc-2',
+            name: 'tool_called: search_products',
+            order: 2,
+            required: false,
+          }),
+        ],
+      }),
+      makeEvalSuiteTestCase({
+        id: 'tc-3',
+        name: 'Guardrail Test',
+        order: 3,
+        description: 'Tests guardrail behavior',
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+export function makeEvalRunScore(overrides: Partial<EvalRunScore> = {}): EvalRunScore {
+  return {
+    id: '00000000-0000-0000-0000-s00000000001',
+    evalConfigId: '00000000-0000-0000-0000-c00000000001',
+    name: 'tool_called: get_order',
+    scoreOrder: 1,
+    required: true,
+    evaluatorType: 'tool_called',
+    result: 'pass',
+    reasoning: null,
+    failureClassification: null,
+    expected: null,
+    actual: null,
+    durationMs: 50,
+    createdAt: '2026-02-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+export function makeTestCaseResult(overrides: Partial<TestCaseResult> = {}): TestCaseResult {
+  return {
+    testCaseId: '00000000-0000-0000-0000-b00000000001',
+    evalRunId: '00000000-0000-0000-0000-200000000001',
+    passed: true,
+    status: 'completed',
+    scores: [makeEvalRunScore()],
+    ...overrides,
+  }
+}
+
+export function makeEvalSuiteRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
+  return {
+    id: '00000000-0000-0000-0000-200000000001',
+    suiteId: '00000000-0000-0000-0000-d00000000001',
+    promptSource: 'compiled',
+    passed: true,
+    triggeredBy: '00000000-0000-0000-0000-100000000001',
+    startedAt: '2026-02-17T10:00:00Z',
+    completedAt: '2026-02-17T10:00:01Z',
+    durationMs: 1234,
+    metadata: null,
+    testCaseResults: [makeTestCaseResult()],
+    ...overrides,
+  }
+}


### PR DESCRIPTION
## Summary

Adds the full Eval Suites dashboard UI — list page, suite detail with test cases/runs tabs, and run detail with score breakdowns. Improves the API layer with agent-SOP assignment validation, descriptive evaluator names from SOP step instructions, three-state pass/fail/inconclusive aggregation, and session ID tracking on runs.

## Changes

- feat: SOP-to-Agent Compiler Phase 1 (single email SOP) (#151)
- feat(evals): eval suite infrastructure — auto-generation, compilation, suite runner (Phase 2) (#153)
- feat(evals): add eval suites UI with bidirectional navigation and improved scoring

## How to Test

1. Log in to the app as admin (`delivered+admin-glowbox@resend.dev`)
2. Navigate to "Eval Suites" in the sidebar — verify the list page loads
3. Click "Create Eval Suite" — select an agent, verify SOP dropdown filters by agent
4. Select an agent with no SOPs assigned — verify the "no active SOPs" warning appears with link to agent settings
5. Create a suite from a valid agent+SOP pair — verify redirect to suite detail
6. On suite detail, verify Test Cases and Runs tabs, agent/SOP link pills, Re-init button
7. Run the suite, then view the run detail — verify session ID link, score breakdowns with descriptive names, inconclusive handling
8. Navigate to an agent detail page — verify "Eval Suites" card appears with links to suites
9. Navigate to a SOP detail page — verify "Evals" sidebar tab with links to suites

## Verification

- [x] Type check passes (API + UI)
- [x] Lint passes (API + UI)
- [x] Tests pass (584 API unit, 166 UI tests)
- [x] Scoped to eval suites feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)