### PR TITLE
feat(connectors): add metadata to Medusa PRODUCT response shape

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/medusa/response-shapes.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/response-shapes.ts
@@ -94,6 +94,7 @@ export const PRODUCT: ResponseShape = {
   status: true,
   thumbnail: true,
   images: true,
+  metadata: true,
   variants: VARIANT,
   options: { id: true, title: true, values: true },
 };

--- a/modelguide-api/tests/unit/connectors/medusa-response-shapes.test.ts
+++ b/modelguide-api/tests/unit/connectors/medusa-response-shapes.test.ts
@@ -110,6 +110,7 @@ describe("PRODUCT shape", () => {
       handle: "cerave",
       status: "published",
       thumbnail: "https://example.com/t.jpg",
+      metadata: { conflict_categories: ["retinol"], skin_type: "oily" },
       variants: [
         {
           id: "var_1",
@@ -130,6 +131,10 @@ describe("PRODUCT shape", () => {
       PRODUCT,
     );
     expect(result!.id).toBe("prod_1");
+    expect(result!.metadata).toEqual({
+      conflict_categories: ["retinol"],
+      skin_type: "oily",
+    });
     expect(result!.raw_metadata).toBeUndefined();
     expect(result!.type_id).toBeUndefined();
 


### PR DESCRIPTION
## Summary

The voice agent relies on product metadata fields (`conflict_categories`, `safe_for_pregnancy`, `skin_type`, etc.) for compatibility checks and safety workflows. The Medusa Store API returns `metadata` by default, but the response trimmer was stripping it because `metadata` wasn't in the PRODUCT allowlist.

## Changes

- Add `metadata: true` to the `PRODUCT` response shape in `response-shapes.ts`
- Update the unit test fixture with a metadata object and assert it's preserved after trimming

## How to Test

1. Run `cd modelguide-api && bun test tests/unit/connectors/medusa-response-shapes.test.ts`
2. Verify the PRODUCT shape test passes with metadata preserved
3. Confirm `raw_metadata` is still stripped (existing assertion)

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (691 API unit, 248 UI)
- [x] Scoped to one concern