### PR TITLE
fix(connectors): request metadata field from Medusa Store API

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/medusa/handlers.ts
@@ -21,7 +21,7 @@ export const listProducts = withMedusa(async (fetcher, ctx) => {
       limit: input.limit ?? 20,
       offset: input.offset ?? 0,
       q: input.query,
-      fields: "+variants.inventory_quantity",
+      fields: "+variants.inventory_quantity,+metadata",
     },
   });
   return { success: true, data };
@@ -33,7 +33,7 @@ export const getProduct = withMedusa(async (fetcher, ctx) => {
     `/store/products/${productId}`,
     {
       params: {
-        fields: "+variants.inventory_quantity",
+        fields: "+variants.inventory_quantity,+metadata",
       },
     },
   );


### PR DESCRIPTION
## Summary

Adds `+metadata` to the Medusa Store API field selection so product metadata is included in responses. This enables AI agents to access custom product attributes (e.g., ingredients, certifications, care instructions) stored in Medusa's metadata field.

## Changes

- fix(connectors): request metadata field from Medusa Store API

## How to Test

1. Connect a Medusa store connector with products that have metadata populated
2. Use the `list_products` or `get_product` MCP tools via an agent
3. Verify that the `metadata` field is present in the product response

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Tests pass (696 API, 248 UI)
- [x] Scoped to one concern