### PR TITLE
feat(compiler): GptVoiceStrategy — prompt compiler for GPT voice agents

### DIFF
--- a/modelguide-api/drizzle/0033_add-model-family-prompt-config.sql
+++ b/modelguide-api/drizzle/0033_add-model-family-prompt-config.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."model_family" AS ENUM('gpt', 'claude', 'gemini', 'generic');--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "model_family" "model_family" DEFAULT 'generic' NOT NULL;--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "prompt_config" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/modelguide-api/drizzle/meta/0033_snapshot.json
+++ b/modelguide-api/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,4436 @@
+{
+  "id": "c555a8e2-f9fe-4e34-96e4-851b7700dada",
+  "prevId": "dd72187c-b258-405d-9227-8d04b403a4c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_connector_tools": {
+      "name": "agent_connector_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_tool_id": {
+          "name": "connector_tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "requires_confirmation": {
+          "name": "requires_confirmation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_connector_tools_unique": {
+          "name": "agent_connector_tools_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_connector_tools_agent_idx": {
+          "name": "agent_connector_tools_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_connector_tools_tool_idx": {
+          "name": "agent_connector_tools_tool_idx",
+          "columns": [
+            {
+              "expression": "connector_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connector_tools_agent_id_agents_id_fk": {
+          "name": "agent_connector_tools_agent_id_agents_id_fk",
+          "tableFrom": "agent_connector_tools",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connector_tools_connector_tool_id_connector_tools_id_fk": {
+          "name": "agent_connector_tools_connector_tool_id_connector_tools_id_fk",
+          "tableFrom": "agent_connector_tools",
+          "tableTo": "connector_tools",
+          "columnsFrom": [
+            "connector_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_knowledge_base": {
+      "name": "agent_knowledge_base",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_kb_unique": {
+          "name": "agent_kb_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_kb_agent_idx": {
+          "name": "agent_kb_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_kb_kb_idx": {
+          "name": "agent_kb_kb_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_knowledge_base_agent_id_agents_id_fk": {
+          "name": "agent_knowledge_base_agent_id_agents_id_fk",
+          "tableFrom": "agent_knowledge_base",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "agent_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "agent_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sops": {
+      "name": "agent_sops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sop_id": {
+          "name": "sop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sops_unique": {
+          "name": "agent_sops_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sops_agent_idx": {
+          "name": "agent_sops_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_sops_sop_idx": {
+          "name": "agent_sops_sop_idx",
+          "columns": [
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sops_agent_id_agents_id_fk": {
+          "name": "agent_sops_agent_id_agents_id_fk",
+          "tableFrom": "agent_sops",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sops_sop_id_sops_id_fk": {
+          "name": "agent_sops_sop_id_sops_id_fk",
+          "tableFrom": "agent_sops",
+          "tableTo": "sops",
+          "columnsFrom": [
+            "sop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "modality",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'voice'"
+        },
+        "model_family": {
+          "name": "model_family",
+          "type": "model_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "prompt_config": {
+          "name": "prompt_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_platform": {
+          "name": "agent_platform",
+          "type": "agent_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "compiled_instructions": {
+          "name": "compiled_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_at": {
+          "name": "compiled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compiled_from": {
+          "name": "compiled_from",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_org_slug_unique": {
+          "name": "agents_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_org_idx": {
+          "name": "agents_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_active_idx": {
+          "name": "agents_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_users_id_fk": {
+          "name": "agents_created_by_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_unique": {
+          "name": "api_keys_hash_unique",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_org_idx": {
+          "name": "api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_agent_idx": {
+          "name": "api_keys_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_agent_id_agents_id_fk": {
+          "name": "api_keys_agent_id_agents_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.connector_tools": {
+      "name": "connector_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_schema": {
+          "name": "tool_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "connection_config": {
+          "name": "connection_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connector_tools_connector_slug_unique": {
+          "name": "connector_tools_connector_slug_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connector_tools\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connector_tools_org_idx": {
+          "name": "connector_tools_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connector_tools_connector_idx": {
+          "name": "connector_tools_connector_idx",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connector_tools_organization_id_organizations_id_fk": {
+          "name": "connector_tools_organization_id_organizations_id_fk",
+          "tableFrom": "connector_tools",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connector_tools_connector_id_connectors_id_fk": {
+          "name": "connector_tools_connector_id_connectors_id_fk",
+          "tableFrom": "connector_tools",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_catalog_id": {
+          "name": "connector_catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "secrets": {
+          "name": "secrets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connectors_org_slug_unique": {
+          "name": "connectors_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connectors_org_idx": {
+          "name": "connectors_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organizations_id_fk": {
+          "name": "connectors_organization_id_organizations_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connectors_connector_catalog_id_connectors_catalog_id_fk": {
+          "name": "connectors_connector_catalog_id_connectors_catalog_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "connectors_catalog",
+          "columnsFrom": [
+            "connector_catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.connectors_catalog": {
+      "name": "connectors_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "connector_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_schema": {
+          "name": "config_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "auth_methods": {
+          "name": "auth_methods",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectors_catalog_slug_unique": {
+          "name": "connectors_catalog_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base": {
+      "name": "knowledge_base",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "knowledge_base_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kb_org_type_slug_unique": {
+          "name": "kb_org_type_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_org_type_active_idx": {
+          "name": "kb_org_type_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_base_organization_id_organizations_id_fk": {
+          "name": "knowledge_base_organization_id_organizations_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_created_by_users_id_fk": {
+          "name": "knowledge_base_created_by_users_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.magic_tokens": {
+      "name": "magic_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_tokens_hash_unique": {
+          "name": "magic_tokens_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_tokens_user_idx": {
+          "name": "magic_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_tokens_user_id_users_id_fk": {
+          "name": "magic_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "demo_enabled": {
+          "name": "demo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_type": {
+          "name": "secret_type",
+          "type": "secret_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "secret_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "secrets_org_idx": {
+          "name": "secrets_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_scope_idx": {
+          "name": "secrets_scope_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_organization_id_organizations_id_fk": {
+          "name": "secrets_organization_id_organizations_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.security_tokens": {
+      "name": "security_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_revoked": {
+          "name": "is_revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "security_tokens_user_idx": {
+          "name": "security_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_tokens_expires_idx": {
+          "name": "security_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_tokens_user_id_users_id_fk": {
+          "name": "security_tokens_user_id_users_id_fk",
+          "tableFrom": "security_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_source": {
+          "name": "feedback_source",
+          "type": "feedback_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_ref": {
+          "name": "feedback_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_tags": {
+          "name": "feedback_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_identifier": {
+          "name": "user_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_feedback_session_idx": {
+          "name": "session_feedback_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_feedback_source_ref_uniq": {
+          "name": "session_feedback_source_ref_uniq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedback_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedback_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_feedback_session_id_sessions_id_fk": {
+          "name": "session_feedback_session_id_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_feedback_message_id_session_messages_id_fk": {
+          "name": "session_feedback_message_id_session_messages_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "session_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_links": {
+      "name": "session_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_links_session_url_unique": {
+          "name": "session_links_session_url_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_links_session_idx": {
+          "name": "session_links_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_links_session_id_sessions_id_fk": {
+          "name": "session_links_session_id_sessions_id_fk",
+          "tableFrom": "session_links",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_duration_ms": {
+          "name": "audio_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_status": {
+          "name": "tool_status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_messages_session_idx": {
+          "name": "session_messages_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_session_occurred_idx": {
+          "name": "session_messages_session_occurred_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_session_id_sessions_id_fk": {
+          "name": "session_messages_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'voice'"
+        },
+        "user_identifier": {
+          "name": "user_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_metadata": {
+          "name": "user_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "session_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "sessions_org_idx": {
+          "name": "sessions_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_agent_status_idx": {
+          "name": "sessions_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_started_at_idx": {
+          "name": "sessions_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_external_id_idx": {
+          "name": "sessions_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_organization_id_organizations_id_fk": {
+          "name": "sessions_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_agent_id_agents_id_fk": {
+          "name": "sessions_agent_id_agents_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.sop_steps": {
+      "name": "sop_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sop_id": {
+          "name": "sop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "connector_tool_id": {
+          "name": "connector_tool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eval_config_id": {
+          "name": "eval_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sop_steps_sop_step_id_unique": {
+          "name": "sop_steps_sop_step_id_unique",
+          "columns": [
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sop_steps_sop_idx": {
+          "name": "sop_steps_sop_idx",
+          "columns": [
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sop_steps_connector_tool_idx": {
+          "name": "sop_steps_connector_tool_idx",
+          "columns": [
+            {
+              "expression": "connector_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sop_steps_eval_config_idx": {
+          "name": "sop_steps_eval_config_idx",
+          "columns": [
+            {
+              "expression": "eval_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sop_steps_sop_id_sops_id_fk": {
+          "name": "sop_steps_sop_id_sops_id_fk",
+          "tableFrom": "sop_steps",
+          "tableTo": "sops",
+          "columnsFrom": [
+            "sop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sop_steps_connector_tool_id_connector_tools_id_fk": {
+          "name": "sop_steps_connector_tool_id_connector_tools_id_fk",
+          "tableFrom": "sop_steps",
+          "tableTo": "connector_tools",
+          "columnsFrom": [
+            "connector_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_templates": {
+      "name": "sop_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog_slugs": {
+          "name": "catalog_slugs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sop_templates_slug_unique": {
+          "name": "sop_templates_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sop_templates_is_active_idx": {
+          "name": "sop_templates_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sops": {
+      "name": "sops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sop_template_id": {
+          "name": "sop_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "sop_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sops_org_slug_unique": {
+          "name": "sops_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sops_org_idx": {
+          "name": "sops_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sops_org_status_idx": {
+          "name": "sops_org_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sops_organization_id_organizations_id_fk": {
+          "name": "sops_organization_id_organizations_id_fk",
+          "tableFrom": "sops",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sops_sop_template_id_sop_templates_id_fk": {
+          "name": "sops_sop_template_id_sop_templates_id_fk",
+          "tableFrom": "sops",
+          "tableTo": "sop_templates",
+          "columnsFrom": [
+            "sop_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sops_created_by_users_id_fk": {
+          "name": "sops_created_by_users_id_fk",
+          "tableFrom": "sops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_configs": {
+      "name": "eval_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluator_type": {
+          "name": "evaluator_type",
+          "type": "evaluator_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eval_configs_org_idx": {
+          "name": "eval_configs_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_configs_evaluator_type_idx": {
+          "name": "eval_configs_evaluator_type_idx",
+          "columns": [
+            {
+              "expression": "evaluator_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_configs_organization_id_organizations_id_fk": {
+          "name": "eval_configs_organization_id_organizations_id_fk",
+          "tableFrom": "eval_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_configs_created_by_users_id_fk": {
+          "name": "eval_configs_created_by_users_id_fk",
+          "tableFrom": "eval_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_run_scores": {
+      "name": "eval_run_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eval_run_id": {
+          "name": "eval_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eval_config_id": {
+          "name": "eval_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_order": {
+          "name": "score_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluator_type": {
+          "name": "evaluator_type",
+          "type": "evaluator_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "eval_score_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_classification": {
+          "name": "failure_classification",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected": {
+          "name": "expected",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual": {
+          "name": "actual",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eval_run_scores_run_idx": {
+          "name": "eval_run_scores_run_idx",
+          "columns": [
+            {
+              "expression": "eval_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_run_scores_config_idx": {
+          "name": "eval_run_scores_config_idx",
+          "columns": [
+            {
+              "expression": "eval_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_run_scores_org_idx": {
+          "name": "eval_run_scores_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_run_scores_eval_run_id_eval_runs_id_fk": {
+          "name": "eval_run_scores_eval_run_id_eval_runs_id_fk",
+          "tableFrom": "eval_run_scores",
+          "tableTo": "eval_runs",
+          "columnsFrom": [
+            "eval_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_run_scores_organization_id_organizations_id_fk": {
+          "name": "eval_run_scores_organization_id_organizations_id_fk",
+          "tableFrom": "eval_run_scores",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_run_scores_eval_config_id_eval_configs_id_fk": {
+          "name": "eval_run_scores_eval_config_id_eval_configs_id_fk",
+          "tableFrom": "eval_run_scores",
+          "tableTo": "eval_configs",
+          "columnsFrom": [
+            "eval_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_runs": {
+      "name": "eval_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "eval_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "eval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_run_url": {
+          "name": "external_run_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suite_run_id": {
+          "name": "suite_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eval_runs_active_unique": {
+          "name": "eval_runs_active_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_runs_session_idx": {
+          "name": "eval_runs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_runs_source_idx": {
+          "name": "eval_runs_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_runs_created_idx": {
+          "name": "eval_runs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_runs_org_idx": {
+          "name": "eval_runs_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_runs_suite_run_idx": {
+          "name": "eval_runs_suite_run_idx",
+          "columns": [
+            {
+              "expression": "suite_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_runs_organization_id_organizations_id_fk": {
+          "name": "eval_runs_organization_id_organizations_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_runs_session_id_sessions_id_fk": {
+          "name": "eval_runs_session_id_sessions_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_runs_triggered_by_users_id_fk": {
+          "name": "eval_runs_triggered_by_users_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eval_runs_suite_run_id_eval_suite_runs_id_fk": {
+          "name": "eval_runs_suite_run_id_eval_suite_runs_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "eval_suite_runs",
+          "columnsFrom": [
+            "suite_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eval_runs_test_case_id_eval_suite_test_cases_id_fk": {
+          "name": "eval_runs_test_case_id_eval_suite_test_cases_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "eval_suite_test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_suite_evaluators": {
+      "name": "eval_suite_evaluators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eval_config_id": {
+          "name": "eval_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sop_step_id": {
+          "name": "sop_step_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "eval_suite_test_case_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eval_suite_evaluators_suite_idx": {
+          "name": "eval_suite_evaluators_suite_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suite_evaluators_config_idx": {
+          "name": "eval_suite_evaluators_config_idx",
+          "columns": [
+            {
+              "expression": "eval_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suite_evaluators_org_idx": {
+          "name": "eval_suite_evaluators_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_suite_evaluators_organization_id_organizations_id_fk": {
+          "name": "eval_suite_evaluators_organization_id_organizations_id_fk",
+          "tableFrom": "eval_suite_evaluators",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suite_evaluators_suite_id_eval_suites_id_fk": {
+          "name": "eval_suite_evaluators_suite_id_eval_suites_id_fk",
+          "tableFrom": "eval_suite_evaluators",
+          "tableTo": "eval_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suite_evaluators_eval_config_id_eval_configs_id_fk": {
+          "name": "eval_suite_evaluators_eval_config_id_eval_configs_id_fk",
+          "tableFrom": "eval_suite_evaluators",
+          "tableTo": "eval_configs",
+          "columnsFrom": [
+            "eval_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_suite_runs": {
+      "name": "eval_suite_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "eval_suite_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "prompt_source": {
+          "name": "prompt_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eval_suite_runs_suite_idx": {
+          "name": "eval_suite_runs_suite_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suite_runs_org_idx": {
+          "name": "eval_suite_runs_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_suite_runs_organization_id_organizations_id_fk": {
+          "name": "eval_suite_runs_organization_id_organizations_id_fk",
+          "tableFrom": "eval_suite_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suite_runs_suite_id_eval_suites_id_fk": {
+          "name": "eval_suite_runs_suite_id_eval_suites_id_fk",
+          "tableFrom": "eval_suite_runs",
+          "tableTo": "eval_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suite_runs_triggered_by_users_id_fk": {
+          "name": "eval_suite_runs_triggered_by_users_id_fk",
+          "tableFrom": "eval_suite_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_suite_test_cases": {
+      "name": "eval_suite_test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "eval_suite_test_case_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_behavior": {
+          "name": "expected_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_responses": {
+          "name": "mock_tool_responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eval_suite_test_cases_suite_idx": {
+          "name": "eval_suite_test_cases_suite_idx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suite_test_cases_org_idx": {
+          "name": "eval_suite_test_cases_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_suite_test_cases_organization_id_organizations_id_fk": {
+          "name": "eval_suite_test_cases_organization_id_organizations_id_fk",
+          "tableFrom": "eval_suite_test_cases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suite_test_cases_suite_id_eval_suites_id_fk": {
+          "name": "eval_suite_test_cases_suite_id_eval_suites_id_fk",
+          "tableFrom": "eval_suite_test_cases",
+          "tableTo": "eval_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.eval_suites": {
+      "name": "eval_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sop_id": {
+          "name": "sop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eval_suite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eval_suites_agent_sop_idx": {
+          "name": "eval_suites_agent_sop_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suites_org_idx": {
+          "name": "eval_suites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suites_agent_idx": {
+          "name": "eval_suites_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eval_suites_sop_idx": {
+          "name": "eval_suites_sop_idx",
+          "columns": [
+            {
+              "expression": "sop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eval_suites_organization_id_organizations_id_fk": {
+          "name": "eval_suites_organization_id_organizations_id_fk",
+          "tableFrom": "eval_suites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suites_agent_id_agents_id_fk": {
+          "name": "eval_suites_agent_id_agents_id_fk",
+          "tableFrom": "eval_suites",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suites_sop_id_sops_id_fk": {
+          "name": "eval_suites_sop_id_sops_id_fk",
+          "tableFrom": "eval_suites",
+          "tableTo": "sops",
+          "columnsFrom": [
+            "sop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eval_suites_created_by_users_id_fk": {
+          "name": "eval_suites_created_by_users_id_fk",
+          "tableFrom": "eval_suites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.agent_platform": {
+      "name": "agent_platform",
+      "schema": "public",
+      "values": [
+        "custom",
+        "elevenlabs",
+        "livekit"
+      ]
+    },
+    "public.channel_type": {
+      "name": "channel_type",
+      "schema": "public",
+      "values": [
+        "voice",
+        "web",
+        "api",
+        "slack",
+        "widget",
+        "sms",
+        "whatsapp",
+        "email"
+      ]
+    },
+    "public.connector_type": {
+      "name": "connector_type",
+      "schema": "public",
+      "values": [
+        "api",
+        "webhook",
+        "database",
+        "messaging"
+      ]
+    },
+    "public.eval_score_result": {
+      "name": "eval_score_result",
+      "schema": "public",
+      "values": [
+        "pass",
+        "fail",
+        "skip",
+        "error"
+      ]
+    },
+    "public.eval_source_type": {
+      "name": "eval_source_type",
+      "schema": "public",
+      "values": [
+        "suite",
+        "replay_test",
+        "live"
+      ]
+    },
+    "public.eval_status": {
+      "name": "eval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.eval_suite_run_status": {
+      "name": "eval_suite_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "completed_with_errors",
+        "failed"
+      ]
+    },
+    "public.eval_suite_status": {
+      "name": "eval_suite_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.eval_suite_test_case_source": {
+      "name": "eval_suite_test_case_source",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.evaluator_type": {
+      "name": "evaluator_type",
+      "schema": "public",
+      "values": [
+        "tool_called",
+        "tool_input_contains",
+        "no_tool_called",
+        "llm_judge"
+      ]
+    },
+    "public.feedback_source": {
+      "name": "feedback_source",
+      "schema": "public",
+      "values": [
+        "customer",
+        "support",
+        "system"
+      ]
+    },
+    "public.knowledge_base_type": {
+      "name": "knowledge_base_type",
+      "schema": "public",
+      "values": [
+        "guardrail"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool"
+      ]
+    },
+    "public.modality": {
+      "name": "modality",
+      "schema": "public",
+      "values": [
+        "voice",
+        "text"
+      ]
+    },
+    "public.model_family": {
+      "name": "model_family",
+      "schema": "public",
+      "values": [
+        "gpt",
+        "claude",
+        "gemini",
+        "generic"
+      ]
+    },
+    "public.secret_scope": {
+      "name": "secret_scope",
+      "schema": "public",
+      "values": [
+        "connector",
+        "agent"
+      ]
+    },
+    "public.secret_type": {
+      "name": "secret_type",
+      "schema": "public",
+      "values": [
+        "api_key",
+        "oauth_token",
+        "credentials",
+        "platform_api_key",
+        "webhook_secret"
+      ]
+    },
+    "public.session_mode": {
+      "name": "session_mode",
+      "schema": "public",
+      "values": [
+        "live",
+        "simulation"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "abandoned"
+      ]
+    },
+    "public.sop_status": {
+      "name": "sop_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "error"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "support",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/modelguide-api/drizzle/meta/_journal.json
+++ b/modelguide-api/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1775731684794,
       "tag": "0032_eval-config-tags",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1775736766520,
+      "tag": "0033_add-model-family-prompt-config",
+      "breakpoints": true
     }
   ]
 }

--- a/modelguide-api/src/db/schema/core.ts
+++ b/modelguide-api/src/db/schema/core.ts
@@ -29,6 +29,7 @@ import {
   knowledgeBaseTypeEnum,
   messageRoleEnum,
   modalityEnum,
+  modelFamilyEnum,
   secretScopeEnum,
   secretTypeEnum,
   sessionModeEnum,
@@ -43,6 +44,19 @@ import {
  * Used to look up secrets by field name from the org vault.
  */
 export type EntitySecretsMap = Record<string, string>;
+
+/**
+ * Prompt configuration stored as JSONB on agents.
+ * Used by the compiler to build model- and channel-optimized system prompts.
+ */
+export interface PromptConfig {
+  /** Free-form text defining personality, tone, behavioral rules. */
+  persona?: string;
+  /** Approved filler phrases for voice tool preambles. */
+  fillerPhrases?: string[];
+  /** Free-form language instructions (e.g. "English only" or multi-line rules). */
+  language?: string;
+}
 
 // ============================================================================
 // Organizations
@@ -381,6 +395,11 @@ export const agents = pgTable(
     slug: varchar("slug", { length: 100 }).notNull(),
     description: text("description"),
     modality: modalityEnum("modality").notNull().default("voice"),
+    modelFamily: modelFamilyEnum("model_family").notNull().default("generic"),
+    promptConfig: jsonb("prompt_config")
+      .$type<PromptConfig>()
+      .notNull()
+      .default({}),
     agentPlatform: agentPlatformEnum("agent_platform")
       .notNull()
       .default("custom"),

--- a/modelguide-api/src/db/schema/enums.ts
+++ b/modelguide-api/src/db/schema/enums.ts
@@ -185,6 +185,16 @@ export const evalSuiteTestCaseSourceEnum = pgEnum(
 // ============================================================================
 
 /**
+ * Model family — which prompting conventions the compiler should follow
+ */
+export const modelFamilyEnum = pgEnum("model_family", [
+  "gpt",
+  "claude",
+  "gemini",
+  "generic",
+]);
+
+/**
  * Knowledge base item types — discriminator for the unified KB table
  */
 export const knowledgeBaseTypeEnum = pgEnum("knowledge_base_type", [

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -187,7 +187,7 @@ export async function seedCompileAgents(db: SeedDb): Promise<void> {
         description: agent.description ?? "AI customer support agent",
         promptConfig: agent.promptConfig ?? {},
         modelFamily: agent.modelFamily ?? "generic",
-        channel:
+        modality:
           agent.modality === "voice" ? ("voice" as const) : ("text" as const),
       },
     };

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -185,6 +185,10 @@ export async function seedCompileAgents(db: SeedDb): Promise<void> {
         name: agent.name,
         model: "anthropic/claude-haiku-4-5-20251001",
         description: agent.description ?? "AI customer support agent",
+        promptConfig: agent.promptConfig ?? {},
+        modelFamily: agent.modelFamily ?? "generic",
+        channel:
+          agent.modality === "voice" ? ("voice" as const) : ("text" as const),
       },
     };
 

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -118,13 +118,12 @@ const createAgentSchema = z.object({
     .optional()
     .openapi({ description: "Auto-generated from name if omitted" }),
   description: z.string().optional(),
-  modality: z.enum(["voice", "text"]).default("voice").optional(),
-  modelFamily: modelFamilySchema.default("generic").optional(),
+  modality: z.enum(["voice", "text"]).default("voice"),
+  modelFamily: modelFamilySchema.default("generic"),
   promptConfig: promptConfigSchema.optional(),
   agentPlatform: z
     .enum(["custom", "elevenlabs", "livekit"])
-    .default("custom")
-    .optional(),
+    .default("custom"),
   metadata: z.record(z.unknown()).optional(),
   secrets: z.record(z.string().uuid()).optional().openapi({
     description: "Secret ref map: { fieldName: secretId }",
@@ -163,8 +162,8 @@ const assignConnectorSchema = z.object({
   tools: z.array(
     z.object({
       slug: z.string().openapi({ description: "Tool slug" }),
-      isEnabled: z.boolean().optional().default(true),
-      requiresConfirmation: z.boolean().optional().default(false),
+      isEnabled: z.boolean().default(true),
+      requiresConfirmation: z.boolean().default(false),
     }),
   ),
 });

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -42,12 +42,22 @@ const router = createRouter();
 
 const compiledFromSchema = z.record(z.unknown()).nullable();
 
+const promptConfigSchema = z.object({
+  persona: z.string().optional(),
+  fillerPhrases: z.array(z.string()).optional(),
+  language: z.string().optional(),
+});
+
+const modelFamilySchema = z.enum(["gpt", "claude", "gemini", "generic"]);
+
 const agentResponseSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   slug: z.string(),
   description: z.string().nullable(),
   modality: z.enum(["voice", "text"]),
+  modelFamily: modelFamilySchema,
+  promptConfig: promptConfigSchema,
   agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]),
   isActive: z.boolean(),
   metadata: z.record(z.unknown()).optional(),
@@ -107,6 +117,8 @@ const createAgentSchema = z.object({
     .openapi({ description: "Auto-generated from name if omitted" }),
   description: z.string().optional(),
   modality: z.enum(["voice", "text"]).default("voice").optional(),
+  modelFamily: modelFamilySchema.default("generic").optional(),
+  promptConfig: promptConfigSchema.optional(),
   agentPlatform: z
     .enum(["custom", "elevenlabs", "livekit"])
     .default("custom")
@@ -121,6 +133,8 @@ const updateAgentSchema = z
   .object({
     name: z.string().min(1).max(255).optional(),
     description: z.string().optional(),
+    modelFamily: modelFamilySchema.optional(),
+    promptConfig: promptConfigSchema.optional(),
     metadata: z.record(z.unknown()).optional(),
     agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]).optional(),
     secrets: z.record(z.string().uuid()).optional().openapi({
@@ -132,6 +146,8 @@ const updateAgentSchema = z
     (data) =>
       data.name !== undefined ||
       data.description !== undefined ||
+      data.modelFamily !== undefined ||
+      data.promptConfig !== undefined ||
       data.metadata !== undefined ||
       data.agentPlatform !== undefined ||
       data.secrets !== undefined,
@@ -218,6 +234,8 @@ function formatAgent(
     slug: agent.slug,
     description: agent.description,
     modality: agent.modality,
+    modelFamily: agent.modelFamily,
+    promptConfig: (agent.promptConfig ?? {}) as Record<string, unknown>,
     agentPlatform: agent.agentPlatform,
     isActive: agent.isActive,
     metadata,

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -121,9 +121,7 @@ const createAgentSchema = z.object({
   modality: z.enum(["voice", "text"]).default("voice"),
   modelFamily: modelFamilySchema.default("generic"),
   promptConfig: promptConfigSchema.optional(),
-  agentPlatform: z
-    .enum(["custom", "elevenlabs", "livekit"])
-    .default("custom"),
+  agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]).default("custom"),
   metadata: z.record(z.unknown()).optional(),
   secrets: z.record(z.string().uuid()).optional().openapi({
     description: "Secret ref map: { fieldName: secretId }",

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -42,11 +42,13 @@ const router = createRouter();
 
 const compiledFromSchema = z.record(z.unknown()).nullable();
 
-const promptConfigSchema = z.object({
-  persona: z.string().optional(),
-  fillerPhrases: z.array(z.string()).optional(),
-  language: z.string().optional(),
-});
+const promptConfigSchema = z
+  .object({
+    persona: z.string().max(5000).optional(),
+    fillerPhrases: z.array(z.string().max(200)).max(20).optional(),
+    language: z.string().max(100).optional(),
+  })
+  .strict();
 
 const modelFamilySchema = z.enum(["gpt", "claude", "gemini", "generic"]);
 

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -13,7 +13,7 @@ import {
   connectorsCatalog,
   secrets,
 } from "@db/schema";
-import type { EntitySecretsMap } from "@db/schema";
+import type { EntitySecretsMap, PromptConfig } from "@db/schema";
 import { getAgentSecretByType } from "@features/secrets/secrets.service";
 import {
   createSession,
@@ -33,6 +33,7 @@ import { nanoid } from "nanoid";
 import { dispatchAgentToRoom, pingLivekit } from "./livekit";
 
 type Modality = (typeof agents.modality.enumValues)[number];
+type ModelFamily = (typeof agents.modelFamily.enumValues)[number];
 type AgentPlatform = (typeof agents.agentPlatform.enumValues)[number];
 
 // ============================================================================
@@ -141,6 +142,8 @@ export async function createAgent(
     slug?: string;
     description?: string;
     modality?: Modality;
+    modelFamily?: ModelFamily;
+    promptConfig?: PromptConfig;
     agentPlatform?: AgentPlatform;
     metadata?: Record<string, unknown>;
     secrets?: EntitySecretsMap;
@@ -189,6 +192,8 @@ export async function createAgent(
         slug,
         description: data.description,
         modality: data.modality ?? "voice",
+        modelFamily: data.modelFamily ?? "generic",
+        promptConfig: data.promptConfig ?? {},
         agentPlatform: data.agentPlatform ?? "custom",
         metadata: data.metadata ?? {},
         secrets: secretsMap,
@@ -217,6 +222,8 @@ export async function updateAgent(
   data: {
     name?: string;
     description?: string;
+    modelFamily?: ModelFamily;
+    promptConfig?: PromptConfig;
     metadata?: Record<string, unknown>;
     agentPlatform?: AgentPlatform;
     secrets?: EntitySecretsMap;

--- a/modelguide-api/src/features/compiler/compiler.routes.ts
+++ b/modelguide-api/src/features/compiler/compiler.routes.ts
@@ -45,6 +45,20 @@ const compileAgentBodySchema = z.object({
     .openapi({ description: "Override agent description/role context" }),
 });
 
+const compilerWarningSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  tokens: z.number().optional(),
+});
+
+const compilerMetadataSchema = z.object({
+  systemPromptTokens: z.number(),
+  estimatedToolSchemaTokens: z.number(),
+  totalEstimatedTokens: z.number(),
+  cacheablePrefix: z.number(),
+  warnings: z.array(compilerWarningSchema),
+});
+
 const compileAgentResponseSchema = z.object({
   agentId: z.string().uuid(),
   compiledAt: z.string(),
@@ -52,6 +66,7 @@ const compileAgentResponseSchema = z.object({
   compiledPrompt: z.string(),
   promptLength: z.number(),
   toolCount: z.number(),
+  metadata: compilerMetadataSchema,
 });
 
 // ============================================================================
@@ -129,6 +144,7 @@ router.openapi(compileRoute, async (c) => {
       compiledPrompt: result.ir.systemPrompt,
       promptLength: result.ir.systemPrompt.length,
       toolCount: result.ir.tools.length,
+      metadata: result.ir.metadata,
     },
     200,
   );

--- a/modelguide-api/src/features/compiler/compiler.service.ts
+++ b/modelguide-api/src/features/compiler/compiler.service.ts
@@ -21,9 +21,9 @@ import { getSopById } from "@features/sops/sops.service";
 import { z } from "zod";
 import { compile } from "./core/compile";
 import type {
-  Channel,
   CompilerInput,
   KnowledgeBaseDetailResponse,
+  Modality,
   ModelFamily,
 } from "./core/types";
 
@@ -179,8 +179,8 @@ export async function compileAgent(input: CompileAgentInput) {
     updatedAt: sopDetail.updatedAt?.toISOString() ?? null,
   };
 
-  // 7. Derive channel from modality (AC4)
-  const channel: Channel = agent.modality === "voice" ? "voice" : "text";
+  // 7. Agent modality for strategy selection (AC4)
+  const modality: Modality = agent.modality === "voice" ? "voice" : "text";
 
   // 8. Run compiler
   const compilerInput: CompilerInput = {
@@ -194,7 +194,7 @@ export async function compileAgent(input: CompileAgentInput) {
         agentDescription ?? agent.description ?? "AI customer support agent",
       promptConfig: promptConfigSchema.parse(agent.promptConfig ?? {}),
       modelFamily: agent.modelFamily as ModelFamily,
-      channel,
+      modality,
     },
     agentSops: agentSopRows,
     toolConfirmationMap,

--- a/modelguide-api/src/features/compiler/compiler.service.ts
+++ b/modelguide-api/src/features/compiler/compiler.service.ts
@@ -4,7 +4,14 @@
  */
 
 import { forOrg } from "@db/rls";
-import { agentKnowledgeBase, agents, knowledgeBase } from "@db/schema";
+import {
+  agentConnectorTools,
+  agentKnowledgeBase,
+  agents,
+  connectorTools,
+  connectors,
+  knowledgeBase,
+} from "@db/schema";
 import { Errors } from "@lib/errors";
 import { getLogger } from "@lib/logger";
 import { and, eq } from "drizzle-orm";
@@ -12,7 +19,12 @@ import { and, eq } from "drizzle-orm";
 import { resolveAgentSops } from "@features/mcp/mcp.service";
 import { getSopById } from "@features/sops/sops.service";
 import { compile } from "./core/compile";
-import type { CompilerInput, KnowledgeBaseDetailResponse } from "./core/types";
+import type {
+  Channel,
+  CompilerInput,
+  KnowledgeBaseDetailResponse,
+  ModelFamily,
+} from "./core/types";
 
 const log = getLogger();
 
@@ -51,6 +63,9 @@ export async function compileAgent(input: CompileAgentInput) {
         id: agents.id,
         name: agents.name,
         description: agents.description,
+        modality: agents.modality,
+        modelFamily: agents.modelFamily,
+        promptConfig: agents.promptConfig,
       })
       .from(agents)
       .where(eq(agents.id, agentId));
@@ -106,10 +121,33 @@ export async function compileAgent(input: CompileAgentInput) {
     }),
   );
 
-  // 4. Load all active SOPs assigned to the agent (for intent classification)
+  // 4. Load tool confirmation settings from agent_connector_tools (AC6)
+  const toolConfirmationMap: Record<string, boolean> = {};
+  const agentToolSettings = await forOrg(orgId, async (tx) => {
+    return tx
+      .select({
+        slug: connectorTools.slug,
+        connectorSlug: connectors.slug,
+        requiresConfirmation: agentConnectorTools.requiresConfirmation,
+      })
+      .from(agentConnectorTools)
+      .innerJoin(
+        connectorTools,
+        eq(agentConnectorTools.connectorToolId, connectorTools.id),
+      )
+      .innerJoin(connectors, eq(connectorTools.connectorId, connectors.id))
+      .where(eq(agentConnectorTools.agentId, agentId));
+  });
+
+  for (const row of agentToolSettings) {
+    const resolvedName = `${row.connectorSlug}_${row.slug}`;
+    toolConfirmationMap[resolvedName] = row.requiresConfirmation;
+  }
+
+  // 5. Load all active SOPs assigned to the agent (for intent classification)
   const agentSopRows = await resolveAgentSops(orgId, agentId);
 
-  // 5. Convert SOP DB result to SopDetailResponse shape
+  // 6. Convert SOP DB result to SopDetailResponse shape
   const sopResponse = {
     id: sopDetail.id,
     name: sopDetail.name,
@@ -130,7 +168,10 @@ export async function compileAgent(input: CompileAgentInput) {
     updatedAt: sopDetail.updatedAt?.toISOString() ?? null,
   };
 
-  // 6. Run compiler
+  // 7. Derive channel from modality (AC4)
+  const channel: Channel = agent.modality === "voice" ? "voice" : "text";
+
+  // 8. Run compiler
   const compilerInput: CompilerInput = {
     sops: [sopResponse],
     guardrails: guardrailResponses,
@@ -140,13 +181,17 @@ export async function compileAgent(input: CompileAgentInput) {
       model: agentModel ?? "anthropic/claude-haiku-4-5-20251001",
       description:
         agentDescription ?? agent.description ?? "AI customer support agent",
+      promptConfig: agent.promptConfig ?? {},
+      modelFamily: agent.modelFamily as ModelFamily,
+      channel,
     },
     agentSops: agentSopRows,
+    toolConfirmationMap,
   };
 
   const ir = compile(compilerInput);
 
-  // 7. Build provenance metadata
+  // 9. Build provenance metadata
   const compiledFrom = {
     sopId,
     sopName: sopDetail.name,
@@ -155,7 +200,7 @@ export async function compileAgent(input: CompileAgentInput) {
     stepCount: ir.sop.steps.length,
   };
 
-  // 7. Dry-run: return result without persisting
+  // 10. Dry-run: return result without persisting
   if (dryRun) {
     log.info(
       {
@@ -176,7 +221,7 @@ export async function compileAgent(input: CompileAgentInput) {
     };
   }
 
-  // 8. Persist compiled instructions
+  // 11. Persist compiled instructions
   const updatedAgent = await forOrg(orgId, async (tx) => {
     const [row] = await tx
       .update(agents)

--- a/modelguide-api/src/features/compiler/compiler.service.ts
+++ b/modelguide-api/src/features/compiler/compiler.service.ts
@@ -18,6 +18,7 @@ import { and, eq } from "drizzle-orm";
 
 import { resolveAgentSops } from "@features/mcp/mcp.service";
 import { getSopById } from "@features/sops/sops.service";
+import { z } from "zod";
 import { compile } from "./core/compile";
 import type {
   Channel,
@@ -27,6 +28,16 @@ import type {
 } from "./core/types";
 
 const log = getLogger();
+
+/** Parse promptConfig JSONB safely — fall back to empty on malformed data. */
+const promptConfigSchema = z
+  .object({
+    persona: z.string().optional(),
+    fillerPhrases: z.array(z.string()).optional(),
+    language: z.string().optional(),
+  })
+  .strict()
+  .catch({});
 
 // ============================================================================
 // Types
@@ -181,7 +192,7 @@ export async function compileAgent(input: CompileAgentInput) {
       model: agentModel ?? "anthropic/claude-haiku-4-5-20251001",
       description:
         agentDescription ?? agent.description ?? "AI customer support agent",
-      promptConfig: agent.promptConfig ?? {},
+      promptConfig: promptConfigSchema.parse(agent.promptConfig ?? {}),
       modelFamily: agent.modelFamily as ModelFamily,
       channel,
     },

--- a/modelguide-api/src/features/compiler/compiler.service.ts
+++ b/modelguide-api/src/features/compiler/compiler.service.ts
@@ -235,6 +235,15 @@ export async function compileAgent(input: CompileAgentInput) {
     return row;
   });
 
+  if (ir.metadata?.warnings?.length) {
+    for (const w of ir.metadata.warnings) {
+      log.warn(
+        { agentId, sopId, warningCode: w.code, tokens: w.tokens },
+        `compiler warning: ${w.message}`,
+      );
+    }
+  }
+
   log.info(
     {
       agentId,
@@ -242,6 +251,7 @@ export async function compileAgent(input: CompileAgentInput) {
       promptLength: ir.systemPrompt.length,
       toolCount: ir.tools.length,
       guardrailCount: guardrails.length,
+      warningCount: ir.metadata?.warnings?.length ?? 0,
     },
     "agent compiled successfully",
   );

--- a/modelguide-api/src/features/compiler/core/compile.ts
+++ b/modelguide-api/src/features/compiler/core/compile.ts
@@ -14,9 +14,9 @@ import type {
   CompilerWarning,
 } from "./types";
 
-/** Voice channel token budget threshold. */
+/** Voice modality token budget threshold. */
 const VOICE_TOKEN_BUDGET = 2500;
-/** Text channel token budget threshold. */
+/** Text modality token budget threshold. */
 const TEXT_TOKEN_BUDGET = 8000;
 /** Average tokens per tool schema (MCP tools/list overhead). */
 const TOKENS_PER_TOOL_SCHEMA = 180;
@@ -38,9 +38,9 @@ export function compile(input: CompilerInput): CompilerIR {
 
   const ir = transform(sop, tools, guardrails, input.agentConfig);
 
-  // Select strategy based on model family + channel
-  const { modelFamily, channel } = input.agentConfig;
-  const strategy = getStrategy(modelFamily, channel);
+  // Select strategy based on model family + modality
+  const { modelFamily, modality } = input.agentConfig;
+  const strategy = getStrategy(modelFamily, modality);
 
   // Build prompt via strategy
   const {
@@ -57,13 +57,13 @@ export function compile(input: CompilerInput): CompilerIR {
   const warnings: CompilerWarning[] = [...strategyWarnings];
 
   // AC23: warn when budget exceeded
-  const budget = channel === "voice" ? VOICE_TOKEN_BUDGET : TEXT_TOKEN_BUDGET;
+  const budget = modality === "voice" ? VOICE_TOKEN_BUDGET : TEXT_TOKEN_BUDGET;
   if (totalEstimatedTokens > budget) {
     const code =
-      channel === "voice" ? "VOICE_BUDGET_EXCEEDED" : "TEXT_BUDGET_EXCEEDED";
+      modality === "voice" ? "VOICE_BUDGET_EXCEEDED" : "TEXT_BUDGET_EXCEEDED";
     warnings.push({
       code,
-      message: `Estimated ${totalEstimatedTokens} tokens exceeds ${channel} budget of ${budget}`,
+      message: `Estimated ${totalEstimatedTokens} tokens exceeds ${modality} budget of ${budget}`,
       tokens: totalEstimatedTokens,
     });
   }

--- a/modelguide-api/src/features/compiler/core/compile.ts
+++ b/modelguide-api/src/features/compiler/core/compile.ts
@@ -36,13 +36,7 @@ export function compile(input: CompilerInput): CompilerIR {
     requiresConfirmation: confirmMap[t.resolvedName] ?? t.requiresConfirmation,
   }));
 
-  const ir = transform(
-    sop,
-    tools,
-    guardrails,
-    input.agentConfig,
-    input.agentSops,
-  );
+  const ir = transform(sop, tools, guardrails, input.agentConfig);
 
   // Select strategy based on model family + channel
   const { modelFamily, channel } = input.agentConfig;

--- a/modelguide-api/src/features/compiler/core/compile.ts
+++ b/modelguide-api/src/features/compiler/core/compile.ts
@@ -1,12 +1,25 @@
 /**
  * compile() — top-level orchestrator for the core pipeline.
  *
- * parse → transform → CompilerIR
+ * parse → transform → strategy → metadata → CompilerIR
  */
 
 import { parse } from "./parse";
+import { getStrategy } from "./prompt-strategies";
 import { transform } from "./transform";
-import type { CompilerIR, CompilerInput } from "./types";
+import type {
+  CompilerIR,
+  CompilerInput,
+  CompilerMetadata,
+  CompilerWarning,
+} from "./types";
+
+/** Voice channel token budget threshold. */
+const VOICE_TOKEN_BUDGET = 2500;
+/** Text channel token budget threshold. */
+const TEXT_TOKEN_BUDGET = 8000;
+/** Average tokens per tool schema (MCP tools/list overhead). */
+const TOKENS_PER_TOOL_SCHEMA = 180;
 
 /**
  * Compile a single SOP + guardrails into a CompilerIR.
@@ -14,6 +27,64 @@ import type { CompilerIR, CompilerInput } from "./types";
  * @throws CompilerError on validation failures
  */
 export function compile(input: CompilerInput): CompilerIR {
-  const { sop, tools, guardrails } = parse(input);
-  return transform(sop, tools, guardrails, input.agentConfig, input.agentSops);
+  const { sop, tools: parsedTools, guardrails } = parse(input);
+
+  // Enrich tools with requiresConfirmation from the input map (AC6)
+  const confirmMap = input.toolConfirmationMap ?? {};
+  const tools = parsedTools.map((t) => ({
+    ...t,
+    requiresConfirmation: confirmMap[t.resolvedName] ?? t.requiresConfirmation,
+  }));
+
+  const ir = transform(
+    sop,
+    tools,
+    guardrails,
+    input.agentConfig,
+    input.agentSops,
+  );
+
+  // Select strategy based on model family + channel
+  const { modelFamily, channel } = input.agentConfig;
+  const strategy = getStrategy(modelFamily, channel);
+
+  // Build prompt via strategy
+  const {
+    prompt,
+    cacheablePrefix,
+    warnings: strategyWarnings,
+  } = strategy.buildPrompt(ir);
+
+  // Compute metadata (AC22, AC23)
+  const systemPromptTokens = Math.ceil(prompt.length / 4);
+  const estimatedToolSchemaTokens = tools.length * TOKENS_PER_TOOL_SCHEMA;
+  const totalEstimatedTokens = systemPromptTokens + estimatedToolSchemaTokens;
+
+  const warnings: CompilerWarning[] = [...strategyWarnings];
+
+  // AC23: warn when budget exceeded
+  const budget = channel === "voice" ? VOICE_TOKEN_BUDGET : TEXT_TOKEN_BUDGET;
+  if (totalEstimatedTokens > budget) {
+    const code =
+      channel === "voice" ? "VOICE_BUDGET_EXCEEDED" : "TEXT_BUDGET_EXCEEDED";
+    warnings.push({
+      code,
+      message: `Estimated ${totalEstimatedTokens} tokens exceeds ${channel} budget of ${budget}`,
+      tokens: totalEstimatedTokens,
+    });
+  }
+
+  const metadata: CompilerMetadata = {
+    systemPromptTokens,
+    estimatedToolSchemaTokens,
+    totalEstimatedTokens,
+    cacheablePrefix,
+    warnings,
+  };
+
+  return {
+    ...ir,
+    systemPrompt: prompt,
+    metadata,
+  };
 }

--- a/modelguide-api/src/features/compiler/core/parse.ts
+++ b/modelguide-api/src/features/compiler/core/parse.ts
@@ -113,6 +113,7 @@ export function parseGuardrails(
     return {
       id: kb.id,
       name: kb.name,
+      description: kb.description,
       content: kb.content,
       config: configResult.data,
     };

--- a/modelguide-api/src/features/compiler/core/prompt-builder.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-builder.ts
@@ -1,41 +1,12 @@
 /**
- * Prompt builder — assembles system prompt and per-step scoped prompts.
+ * Prompt builder — per-step scoped prompts.
  *
- * All content comes from the compiler input. The builder owns only the
- * section structure (ordering, markdown formatting, priority grouping).
- * Template is hardcoded for Phase 1.
- *
- * See PRD Appendix A.3.1 for concrete output examples.
+ * buildScopedPrompt is used by the transform stage to enrich each
+ * SOP step with matched guardrails.
  */
 
 import type { SopStep } from "@features/sops/sops.types";
-import type {
-  AgentSopInfo,
-  GuardrailPriority,
-  ParsedGuardrail,
-  ResolvedTool,
-} from "./types";
-
-/** Minimal SOP shape for prompt building (avoids Zod inference type conflicts). */
-interface SopForPrompt {
-  name: string;
-  description: string | null;
-  definition: {
-    steps: Array<{
-      order: number;
-      instruction: string;
-      required: boolean;
-      tool?: { resolvedName?: string };
-    }>;
-    metadata: {
-      escalationTriggers?: string[];
-    };
-  };
-}
-
-// ============================================================================
-// System prompt
-// ============================================================================
+import type { GuardrailPriority, ParsedGuardrail } from "./types";
 
 /** Priority display order (critical first). */
 const PRIORITY_ORDER: GuardrailPriority[] = [
@@ -44,98 +15,6 @@ const PRIORITY_ORDER: GuardrailPriority[] = [
   "medium",
   "low",
 ];
-
-/** Capitalize first letter of a priority for section headers. */
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-/**
- * Build the system prompt — set once as the agent's `instructions`.
- *
- * Structure:
- * 1. agentConfig.description (role context)
- * 2. ## Workflow: {name} + description
- * 3. ## Tools — bullet list of available tool names
- * 4. ## Guardrails grouped by priority (Critical, High, Medium, Low)
- * 5. ## Escalation Triggers as bullet list
- */
-export function buildSystemPrompt(
-  agentDescription: string,
-  sop: SopForPrompt,
-  guardrails: ParsedGuardrail[],
-  tools: ResolvedTool[],
-  agentSops?: AgentSopInfo[],
-): string {
-  const sections: string[] = [];
-
-  // 1. Agent description (preamble)
-  sections.push(agentDescription);
-
-  // 1.5. Intent Classification (Step 0) — before workflow
-  const classificationSection = buildIntentClassificationSection(agentSops);
-  if (classificationSection) {
-    sections.push(classificationSection);
-  }
-
-  // 2. SOP context
-  sections.push(`## Workflow: ${sop.name}`);
-  if (sop.description) {
-    sections.push(sop.description);
-  }
-
-  // 2b. Steps
-  const steps = sop.definition.steps;
-  if (steps.length > 0) {
-    const stepLines = steps
-      .slice()
-      .sort((a, b) => a.order - b.order)
-      .map((s) => {
-        const toolSuffix = s.tool?.resolvedName
-          ? ` → \`${s.tool.resolvedName}\``
-          : "";
-        const requiredTag = s.required ? " *(required)*" : "";
-        return `${s.order}. ${s.instruction}${toolSuffix}${requiredTag}`;
-      });
-    const enforcement =
-      "Follow these steps in order. Every step must be reflected in your response — do not skip steps.";
-    sections.push(`### Steps\n${enforcement}\n${stepLines.join("\n")}`);
-  }
-
-  // 3. Tools
-  if (tools.length > 0) {
-    sections.push("## Tools");
-    sections.push(tools.map((t) => `- ${t.resolvedName}`).join("\n"));
-  }
-
-  // 4. Guardrails grouped by priority
-  const guardrailsByPriority = groupByPriority(guardrails);
-  const guardrailSections: string[] = [];
-
-  for (const priority of PRIORITY_ORDER) {
-    const group = guardrailsByPriority.get(priority);
-    if (!group || group.length === 0) continue;
-
-    guardrailSections.push(`### ${capitalize(priority)}`);
-    for (const g of group) {
-      guardrailSections.push(`**${g.name}:** ${g.content}`);
-    }
-  }
-
-  if (guardrailSections.length > 0) {
-    sections.push("## Guardrails");
-    sections.push(guardrailSections.join("\n\n"));
-  }
-
-  // 5. Escalation triggers
-  const triggers = sop.definition.metadata.escalationTriggers;
-  if (triggers && triggers.length > 0) {
-    sections.push("## Escalation Triggers");
-    sections.push(triggers.map((t) => `- ${t}`).join("\n"));
-  }
-
-  return sections.join("\n\n");
-}
 
 // ============================================================================
 // Scoped prompt (per-step)
@@ -178,56 +57,4 @@ export function buildScopedPrompt(
   }
 
   return sections.join("\n\n");
-}
-
-// ============================================================================
-// Intent classification
-// ============================================================================
-
-/**
- * Build the "## Intent Classification (Step 0)" section.
- * Returns null if no agent SOPs are available.
- */
-export function buildIntentClassificationSection(
-  agentSops?: AgentSopInfo[],
-): string | null {
-  if (!agentSops || agentSops.length === 0) return null;
-
-  const sopList = agentSops
-    .map((sop) => {
-      const desc = sop.description ? `: ${sop.description}` : "";
-      return `- \`${sop.slug}\` — ${sop.name}${desc}`;
-    })
-    .join("\n");
-
-  return `## Intent Classification (Step 0)
-
-Before executing any workflow steps, classify the customer's intent by calling \`core_classify_sop\`.
-
-Available SOPs:
-${sopList}
-
-Call \`core_classify_sop\` with:
-- \`sop_slug\`: the matching SOP slug from the list above (or null if no match)
-- \`confidence\`: your confidence in the classification (0.0–1.0)
-- \`session_id\`: the current session ID
-
-Do not wait for the response before proceeding with the conversation.`;
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function groupByPriority(
-  guardrails: ParsedGuardrail[],
-): Map<GuardrailPriority, ParsedGuardrail[]> {
-  const map = new Map<GuardrailPriority, ParsedGuardrail[]>();
-  for (const g of guardrails) {
-    const priority = g.config.priority;
-    const group = map.get(priority) ?? [];
-    group.push(g);
-    map.set(priority, group);
-  }
-  return map;
 }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
@@ -1,0 +1,31 @@
+/**
+ * GenericStrategy — backward-compatible prompt format.
+ *
+ * Wraps the existing buildSystemPrompt() to produce the same markdown output
+ * as Phase 1. Used as fallback for all (modelFamily, channel) combinations
+ * that don't have a dedicated strategy.
+ */
+
+import { buildSystemPrompt } from "../prompt-builder";
+import type { CompilerIR } from "../types";
+import type { PromptStrategy, StrategyOutput } from "./types";
+
+export class GenericStrategy implements PromptStrategy {
+  readonly name = "GenericStrategy";
+
+  buildPrompt(ir: CompilerIR): StrategyOutput {
+    const prompt = buildSystemPrompt(
+      ir.agentConfig.description,
+      {
+        name: ir.sop.name,
+        description: ir.sop.description,
+        definition: ir.sop.definition,
+      },
+      ir.guardrails,
+      ir.tools,
+    );
+
+    // Generic strategy: entire prompt is static (no [Reminders] section)
+    return { prompt, cacheablePrefix: prompt.length, warnings: [] };
+  }
+}

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
@@ -1,31 +1,109 @@
 /**
  * GenericStrategy — backward-compatible prompt format.
  *
- * Wraps the existing buildSystemPrompt() to produce the same markdown output
- * as Phase 1. Used as fallback for all (modelFamily, modality) combinations
- * that don't have a dedicated strategy.
+ * Produces the same markdown output as Phase 1. Used as fallback for all
+ * (modelFamily, modality) combinations that don't have a dedicated strategy.
  */
 
-import { buildSystemPrompt } from "../prompt-builder";
-import type { TransformResult } from "../types";
+import type {
+  GuardrailPriority,
+  ParsedGuardrail,
+  TransformResult,
+} from "../types";
 import type { PromptStrategy, StrategyOutput } from "./types";
+
+/** Priority display order (critical first). */
+const PRIORITY_ORDER: GuardrailPriority[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+];
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function groupByPriority(
+  guardrails: ParsedGuardrail[],
+): Map<GuardrailPriority, ParsedGuardrail[]> {
+  const map = new Map<GuardrailPriority, ParsedGuardrail[]>();
+  for (const g of guardrails) {
+    const group = map.get(g.config.priority) ?? [];
+    group.push(g);
+    map.set(g.config.priority, group);
+  }
+  return map;
+}
 
 export class GenericStrategy implements PromptStrategy {
   readonly name = "GenericStrategy";
 
   buildPrompt(ir: TransformResult): StrategyOutput {
-    const prompt = buildSystemPrompt(
-      ir.agentConfig.description,
-      {
-        name: ir.sop.name,
-        description: ir.sop.description,
-        definition: ir.sop.definition,
-      },
-      ir.guardrails,
-      ir.tools,
-    );
+    const sections: string[] = [];
 
-    // Generic strategy: entire prompt is static (no [Reminders] section)
+    // 1. Agent description (preamble)
+    sections.push(ir.agentConfig.description);
+
+    // 2. SOP context
+    sections.push(`## Workflow: ${ir.sop.name}`);
+    if (ir.sop.description) {
+      sections.push(ir.sop.description);
+    }
+
+    // 2b. Steps
+    const steps = ir.sop.definition.steps;
+    if (steps.length > 0) {
+      const stepLines = steps
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((s) => {
+          const toolSuffix = s.tool?.resolvedName
+            ? ` → \`${s.tool.resolvedName}\``
+            : "";
+          const requiredTag = s.required ? " *(required)*" : "";
+          return `${s.order}. ${s.instruction}${toolSuffix}${requiredTag}`;
+        });
+      const enforcement =
+        "Follow these steps in order. Every step must be reflected in your response — do not skip steps.";
+      sections.push(`### Steps\n${enforcement}\n${stepLines.join("\n")}`);
+    }
+
+    // 3. Tools
+    if (ir.tools.length > 0) {
+      sections.push("## Tools");
+      sections.push(ir.tools.map((t) => `- ${t.resolvedName}`).join("\n"));
+    }
+
+    // 4. Guardrails grouped by priority
+    const guardrailsByPriority = groupByPriority(ir.guardrails);
+    const guardrailSections: string[] = [];
+
+    for (const priority of PRIORITY_ORDER) {
+      const group = guardrailsByPriority.get(priority);
+      if (!group || group.length === 0) continue;
+
+      guardrailSections.push(`### ${capitalize(priority)}`);
+      for (const g of group) {
+        guardrailSections.push(`**${g.name}:** ${g.content}`);
+      }
+    }
+
+    if (guardrailSections.length > 0) {
+      sections.push("## Guardrails");
+      sections.push(guardrailSections.join("\n\n"));
+    }
+
+    // 5. Escalation triggers
+    const triggers = ir.sop.definition.metadata.escalationTriggers;
+    if (triggers && triggers.length > 0) {
+      sections.push("## Escalation Triggers");
+      sections.push(triggers.map((t) => `- ${t}`).join("\n"));
+    }
+
+    const prompt = sections.join("\n\n");
+
+    // Generic strategy: entire prompt is static (no Reminders section)
     return { prompt, cacheablePrefix: prompt.length, warnings: [] };
   }
 }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
@@ -7,13 +7,13 @@
  */
 
 import { buildSystemPrompt } from "../prompt-builder";
-import type { CompilerIR } from "../types";
+import type { TransformResult } from "../types";
 import type { PromptStrategy, StrategyOutput } from "./types";
 
 export class GenericStrategy implements PromptStrategy {
   readonly name = "GenericStrategy";
 
-  buildPrompt(ir: CompilerIR): StrategyOutput {
+  buildPrompt(ir: TransformResult): StrategyOutput {
     const prompt = buildSystemPrompt(
       ir.agentConfig.description,
       {

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
@@ -2,7 +2,7 @@
  * GenericStrategy — backward-compatible prompt format.
  *
  * Wraps the existing buildSystemPrompt() to produce the same markdown output
- * as Phase 1. Used as fallback for all (modelFamily, channel) combinations
+ * as Phase 1. Used as fallback for all (modelFamily, modality) combinations
  * that don't have a dedicated strategy.
  */
 

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -185,7 +185,7 @@ export class GptVoiceStrategy implements PromptStrategy {
 
     const lines: string[] = [
       "# Rules",
-      "Rules below may contain illustrative examples in parentheses (e.g., …). These are templates only — use ONLY data from the Role Context above. If the Role Context does not include a value referenced in an example, say you do not have that information and redirect to the recruiter.",
+      "Rules below may contain illustrative examples in parentheses (e.g., …). These are templates only — use ONLY data from the Role Context above.",
     ];
     for (const g of guardrails) {
       lines.push(`\n## ${g.name}`);

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -96,7 +96,14 @@ export class GptVoiceStrategy implements PromptStrategy {
 
   /** 1. Role & Objective — AC3: description first */
   private renderRoleAndObjective(description: string): string {
-    return `# Role & Objective\nYou are ${description}.`;
+    const trimmed = description.trim();
+    if (!trimmed) {
+      return "# Role & Objective\nYou are a helpful AI assistant.";
+    }
+    const body = /^you are\b/i.test(trimmed) ? trimmed : `You are ${trimmed}`;
+    // Ensure it ends with punctuation
+    const punctuated = /[.!?]$/.test(body) ? body : `${body}.`;
+    return `# Role & Objective\n${punctuated}`;
   }
 
   /** 2. Personality & Tone — AC3: persona second, AC11-14: response rules */

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -1,7 +1,7 @@
 /**
- * GptVoiceStrategy — optimized for GPT Realtime voice agents.
+ * GptVoiceStrategy — optimized for GPT voice agents (e.g. gpt-4.1-mini).
  *
- * Section ordering follows the OpenAI Realtime Prompting Guide:
+ * Section ordering follows the OpenAI voice prompting best practices:
  *   # Role & Objective
  *   # Personality & Tone (persona + response rules)
  *   # Reference Pronunciations (vocal normalization)

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -1,0 +1,272 @@
+/**
+ * GptVoiceStrategy — optimized for GPT Realtime voice agents.
+ *
+ * Section ordering follows the OpenAI Realtime Prompting Guide:
+ *   # Role & Objective
+ *   # Personality & Tone (persona + response rules)
+ *   # Reference Pronunciations (vocal normalization)
+ *   # Tools (filler preamble, hallucination guard, per-tool blocks)
+ *   # Rules (all guardrails as bullets)
+ *   # Conversation Flow (SOP steps with GOAL/EXIT)
+ *   # Safety & Escalation
+ *   # Reminders (all guardrails repeated — sandwich technique)
+ *
+ * Key conventions:
+ * - Markdown # headers for sections (model reads these, not TTS)
+ * - No markdown in model OUTPUT (AC13) — but system prompt uses markdown structure
+ * - All guardrails rendered uniformly and repeated in Reminders (sandwich)
+ * - Safety & escalation at agent level, not per SOP step
+ */
+
+import type {
+  CompilerIR,
+  CompilerWarning,
+  EnrichedStep,
+  ParsedGuardrail,
+  PromptConfig,
+  ResolvedTool,
+} from "../types";
+import type { PromptStrategy, StrategyOutput } from "./types";
+
+/** Max tokens per tool block before warning (chars / 4). */
+const TOOL_BLOCK_TOKEN_LIMIT = 60;
+
+const DEFAULT_FILLER_PHRASES = [
+  "One moment.",
+  "Let me check.",
+  "Just a second.",
+  "I'm looking into that.",
+];
+
+/**
+ * Rewrite symbolic operators to plain English for small voice models.
+ * E.g. `> 240` → "more than 240", `!= null` → "exists".
+ */
+function normalizeSymbolicOperators(text: string): string {
+  return (
+    text
+      // Comparison with null
+      .replace(/!=\s*null/gi, "exists")
+      .replace(/==\s*null/gi, "does not exist")
+      // Comparison operators with numbers (order matters: >= before >)
+      .replace(/>=\s*(\d+)/g, "at least $1")
+      .replace(/<=\s*(\d+)/g, "at most $1")
+      .replace(/>\s*(\d+)/g, "more than $1")
+      .replace(/<\s*(\d+)/g, "less than $1")
+      // Equality with quoted or unquoted values
+      .replace(/!=\s*"([^"]+)"/g, 'is not "$1"')
+      .replace(/==\s*"([^"]+)"/g, 'equals "$1"')
+      .replace(/!=\s*(\w+)/g, "is not $1")
+      .replace(/==\s*(\w+)/g, "equals $1")
+  );
+}
+
+export class GptVoiceStrategy implements PromptStrategy {
+  readonly name = "GptVoiceStrategy";
+
+  buildPrompt(ir: CompilerIR): StrategyOutput {
+    const { agentConfig, sop, guardrails, tools } = ir;
+    const warnings: CompilerWarning[] = [];
+
+    const staticSections = [
+      this.renderRoleAndObjective(agentConfig.description),
+      this.renderPersonalityAndTone(agentConfig.promptConfig),
+      this.renderReferencePronunciations(),
+      this.renderTools(tools, agentConfig.promptConfig, warnings),
+      this.renderRules(guardrails),
+      this.renderConversationFlow(sop.steps),
+      this.renderSafetyAndEscalation(
+        sop.definition.metadata?.escalationTriggers,
+      ),
+    ].filter(Boolean);
+
+    const staticContent = staticSections.join("\n\n");
+    const cacheablePrefix = staticContent.length;
+
+    const reminders = this.renderReminders(guardrails);
+    const prompt = reminders
+      ? `${staticContent}\n\n${reminders}`
+      : staticContent;
+
+    // AC19: No agentic boilerplate (persistence/tool-calling/planning) — intentionally omitted
+
+    return { prompt, cacheablePrefix, warnings };
+  }
+
+  /** 1. Role & Objective — AC3: description first */
+  private renderRoleAndObjective(description: string): string {
+    return `# Role & Objective\nYou are ${description}.`;
+  }
+
+  /** 2. Personality & Tone — AC3: persona second, AC11-14: response rules */
+  private renderPersonalityAndTone(promptConfig: PromptConfig): string {
+    const lines: string[] = ["# Personality & Tone"];
+
+    if (promptConfig.persona) {
+      lines.push(promptConfig.persona);
+      lines.push("");
+    }
+
+    lines.push("- Keep responses to 2-3 sentences per turn.");
+    lines.push("- Do not repeat the same sentence twice. Vary your responses.");
+    lines.push(
+      "- Do not use markdown, bullet points, lists, or any text formatting in your responses. Speak only in natural sentences meant to be read aloud.",
+    );
+    lines.push(
+      "- Use only the information provided — do not supplement with general knowledge.",
+    );
+
+    if (promptConfig.language) {
+      lines.push("");
+      lines.push("## Language");
+      lines.push(promptConfig.language);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** 3. Reference Pronunciations — AC10: vocal normalization */
+  private renderReferencePronunciations(): string {
+    return [
+      "# Reference Pronunciations",
+      "When speaking numbers, dates, and symbols aloud:",
+      '- Dollar amounts: say "one hundred dollars" not "$100"',
+      '- Times: say "ten thirty A M" not "10:30am"',
+      '- Ordinals: say "second" not "2nd"',
+    ].join("\n");
+  }
+
+  /** 4. Tools — AC6, AC16, AC17 */
+  private renderTools(
+    tools: ResolvedTool[],
+    promptConfig: PromptConfig,
+    warnings: CompilerWarning[],
+  ): string {
+    const lines: string[] = ["# Tools"];
+
+    if (tools.length === 0) {
+      lines.push("No tools assigned.");
+      return lines.join("\n");
+    }
+
+    const fillers =
+      promptConfig.fillerPhrases && promptConfig.fillerPhrases.length > 0
+        ? promptConfig.fillerPhrases
+        : DEFAULT_FILLER_PHRASES;
+
+    lines.push(
+      `Approved filler phrases while tools execute: ${fillers.map((f) => `"${f}"`).join(", ")}`,
+    );
+    lines.push("- Never use the same filler twice in a row.");
+    lines.push(
+      "- If you don't have enough information to call a tool, ask the user before calling it.",
+    );
+
+    for (const tool of tools) {
+      const block = this.renderToolBlock(tool);
+      const blockTokens = Math.ceil(block.length / 4);
+      if (blockTokens > TOOL_BLOCK_TOKEN_LIMIT) {
+        warnings.push({
+          code: "TOOL_BLOCK_OVER_BUDGET",
+          message: `Tool "${tool.resolvedName}" block is ~${blockTokens} tokens (limit: ${TOOL_BLOCK_TOKEN_LIMIT})`,
+          tokens: blockTokens,
+        });
+      }
+      lines.push("");
+      lines.push(block);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** 5. Rules — full content for detailed guidance in cached prefix */
+  private renderRules(guardrails: ParsedGuardrail[]): string | null {
+    if (guardrails.length === 0) return null;
+
+    const lines: string[] = [
+      "# Rules",
+      "Rules below may contain illustrative examples in parentheses (e.g., …). These are templates only — use ONLY data from the Role Context above. If the Role Context does not include a value referenced in an example, say you do not have that information and redirect to the recruiter.",
+    ];
+    for (const g of guardrails) {
+      lines.push(`\n## ${g.name}`);
+      lines.push(g.content);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** 6. Conversation Flow — AC15: SOP steps with GOAL/EXIT */
+  private renderConversationFlow(steps: EnrichedStep[]): string {
+    const lines: string[] = ["# Conversation Flow"];
+    const sorted = steps.slice().sort((a, b) => a.order - b.order);
+
+    for (let i = 0; i < sorted.length; i++) {
+      const step = sorted[i];
+      const stepLabel = step.id
+        ? `Step ${step.order}: ${step.id}`
+        : `Step ${step.order}`;
+      const nextLabel =
+        i < sorted.length - 1 ? `Step ${sorted[i + 1].order}` : "End";
+
+      lines.push("");
+      lines.push(`## ${stepLabel}`);
+      if (step.id) {
+        const goal = step.id
+          .replace(/[-_]/g, " ")
+          .replace(/\b\w/g, (c) => c.toUpperCase());
+        lines.push(`GOAL: ${goal}`);
+      }
+      lines.push(normalizeSymbolicOperators(step.instruction));
+      lines.push(`EXIT → ${nextLabel}`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** 7. Safety & Escalation — AC20: compiled once at agent level */
+  private renderSafetyAndEscalation(
+    triggers: string[] | undefined,
+  ): string | null {
+    if (!triggers || triggers.length === 0) return null;
+
+    const lines: string[] = ["# Safety & Escalation"];
+    for (const trigger of triggers) {
+      lines.push(`- ${trigger}`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** 8. Reminders — all guardrails repeated (sandwich technique) */
+  private renderReminders(guardrails: ParsedGuardrail[]): string | null {
+    if (guardrails.length === 0) return null;
+
+    const lines: string[] = ["# Reminders"];
+    for (const g of guardrails) {
+      lines.push(`\n## ${g.name}`);
+      lines.push(g.description ?? g.content);
+    }
+
+    return lines.join("\n");
+  }
+
+  /** Render a per-tool block with behaviour tags. */
+  private renderToolBlock(tool: ResolvedTool): string {
+    const lines: string[] = [];
+
+    if (tool.requiresConfirmation) {
+      lines.push(`${tool.resolvedName} — CONFIRMATION_FIRST`);
+      lines.push(
+        'Ask the user for confirmation before executing. Say something like: "I\'d like to {action}. Should I go ahead?"',
+      );
+    } else {
+      lines.push(tool.resolvedName);
+    }
+
+    // AC16: useWhen/doNotUseWhen stubs — commented out for future implementation
+    // lines.push(`  useWhen: <condition when this tool should be used>`);
+    // lines.push(`  doNotUseWhen: <condition when this tool should NOT be used>`);
+
+    return lines.join("\n");
+  }
+}

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -14,7 +14,7 @@
  * Key conventions:
  * - Markdown # headers for sections (model reads these, not TTS)
  * - No markdown in model OUTPUT (AC13) — but system prompt uses markdown structure
- * - All guardrails rendered uniformly and repeated in Reminders (sandwich)
+ * - Guardrails: full content in Rules, concise description in Reminders (sandwich technique)
  * - Safety & escalation at agent level, not per SOP step
  */
 
@@ -275,10 +275,6 @@ export class GptVoiceStrategy implements PromptStrategy {
     } else {
       lines.push(tool.resolvedName);
     }
-
-    // AC16: useWhen/doNotUseWhen stubs — commented out for future implementation
-    // lines.push(`  useWhen: <condition when this tool should be used>`);
-    // lines.push(`  doNotUseWhen: <condition when this tool should NOT be used>`);
 
     return lines.join("\n");
   }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -19,12 +19,12 @@
  */
 
 import type {
-  CompilerIR,
   CompilerWarning,
   EnrichedStep,
   ParsedGuardrail,
   PromptConfig,
   ResolvedTool,
+  TransformResult,
 } from "../types";
 import type { PromptStrategy, StrategyOutput } from "./types";
 
@@ -64,7 +64,7 @@ function normalizeSymbolicOperators(text: string): string {
 export class GptVoiceStrategy implements PromptStrategy {
   readonly name = "GptVoiceStrategy";
 
-  buildPrompt(ir: CompilerIR): StrategyOutput {
+  buildPrompt(ir: TransformResult): StrategyOutput {
     const { agentConfig, sop, guardrails, tools } = ir;
     const warnings: CompilerWarning[] = [];
 

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -18,6 +18,7 @@
  * - Safety & escalation at agent level, not per SOP step
  */
 
+import { getLogger } from "@lib/logger";
 import type {
   CompilerWarning,
   EnrichedStep,
@@ -227,7 +228,12 @@ export class GptVoiceStrategy implements PromptStrategy {
   private renderSafetyAndEscalation(
     triggers: string[] | undefined,
   ): string | null {
-    if (!triggers || triggers.length === 0) return null;
+    if (!triggers || triggers.length === 0) {
+      getLogger().warn(
+        "no escalation triggers defined — Safety & Escalation section omitted from voice prompt",
+      );
+      return null;
+    }
 
     const lines: string[] = ["# Safety & Escalation"];
     for (const trigger of triggers) {

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Strategy selection — picks the right PromptStrategy for (modelFamily, channel).
+ */
+
+import type { Channel, ModelFamily } from "../types";
+import { GenericStrategy } from "./generic-strategy";
+import { GptVoiceStrategy } from "./gpt-voice-strategy";
+import type { PromptStrategy } from "./types";
+
+export type { PromptStrategy, StrategyOutput } from "./types";
+export { GenericStrategy } from "./generic-strategy";
+export { GptVoiceStrategy } from "./gpt-voice-strategy";
+
+/**
+ * Select a prompt strategy based on model family and channel.
+ *
+ * For v1: only (gpt, voice) → GptVoiceStrategy.
+ * All other combinations fall back to GenericStrategy.
+ */
+export function getStrategy(
+  modelFamily: ModelFamily,
+  channel: Channel,
+): PromptStrategy {
+  if (modelFamily === "gpt" && channel === "voice") {
+    return new GptVoiceStrategy();
+  }
+
+  return new GenericStrategy();
+}

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
@@ -2,6 +2,7 @@
  * Strategy selection — picks the right PromptStrategy for (modelFamily, channel).
  */
 
+import { getLogger } from "@lib/logger";
 import type { Channel, ModelFamily } from "../types";
 import { GenericStrategy } from "./generic-strategy";
 import { GptVoiceStrategy } from "./gpt-voice-strategy";
@@ -25,5 +26,9 @@ export function getStrategy(
     return new GptVoiceStrategy();
   }
 
+  getLogger().warn(
+    { modelFamily, channel },
+    `no dedicated prompt strategy for (${modelFamily}, ${channel}) — falling back to GenericStrategy`,
+  );
   return new GenericStrategy();
 }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { getLogger } from "@lib/logger";
-import type { Channel, ModelFamily } from "../types";
+import type { Modality, ModelFamily } from "../types";
 import { GenericStrategy } from "./generic-strategy";
 import { GptVoiceStrategy } from "./gpt-voice-strategy";
 import type { PromptStrategy } from "./types";
@@ -13,22 +13,22 @@ export { GenericStrategy } from "./generic-strategy";
 export { GptVoiceStrategy } from "./gpt-voice-strategy";
 
 /**
- * Select a prompt strategy based on model family and channel.
+ * Select a prompt strategy based on model family and modality.
  *
  * For v1: only (gpt, voice) → GptVoiceStrategy.
  * All other combinations fall back to GenericStrategy.
  */
 export function getStrategy(
   modelFamily: ModelFamily,
-  channel: Channel,
+  modality: Modality,
 ): PromptStrategy {
-  if (modelFamily === "gpt" && channel === "voice") {
+  if (modelFamily === "gpt" && modality === "voice") {
     return new GptVoiceStrategy();
   }
 
   getLogger().warn(
-    { modelFamily, channel },
-    `no dedicated prompt strategy for (${modelFamily}, ${channel}) — falling back to GenericStrategy`,
+    { modelFamily, modality },
+    `no dedicated prompt strategy for (${modelFamily}, ${modality}) — falling back to GenericStrategy`,
   );
   return new GenericStrategy();
 }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
@@ -2,7 +2,7 @@
  * PromptStrategy interface — all strategies implement this.
  *
  * A strategy takes the compiler's intermediate representation and produces
- * a model- and channel-optimized system prompt string.
+ * a model- and modality-optimized system prompt string.
  */
 
 import type { CompilerWarning, TransformResult } from "../types";

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
@@ -1,0 +1,26 @@
+/**
+ * PromptStrategy interface — all strategies implement this.
+ *
+ * A strategy takes the compiler's intermediate representation and produces
+ * a model- and channel-optimized system prompt string.
+ */
+
+import type { CompilerIR, CompilerWarning } from "../types";
+
+/** Return type of PromptStrategy.buildPrompt(). */
+export interface StrategyOutput {
+  /** The compiled system prompt string. */
+  prompt: string;
+  /** Char offset where static content ends (before dynamic sections like Reminders). */
+  cacheablePrefix: number;
+  /** Strategy-specific warnings (e.g. TOOL_BLOCK_OVER_BUDGET). */
+  warnings: CompilerWarning[];
+}
+
+export interface PromptStrategy {
+  /** Human-readable name for logging/debugging. */
+  readonly name: string;
+
+  /** Build a system prompt string from the compiler IR. */
+  buildPrompt(ir: CompilerIR): StrategyOutput;
+}

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/types.ts
@@ -5,7 +5,7 @@
  * a model- and channel-optimized system prompt string.
  */
 
-import type { CompilerIR, CompilerWarning } from "../types";
+import type { CompilerWarning, TransformResult } from "../types";
 
 /** Return type of PromptStrategy.buildPrompt(). */
 export interface StrategyOutput {
@@ -21,6 +21,6 @@ export interface PromptStrategy {
   /** Human-readable name for logging/debugging. */
   readonly name: string;
 
-  /** Build a system prompt string from the compiler IR. */
-  buildPrompt(ir: CompilerIR): StrategyOutput;
+  /** Build a system prompt from the transform result. */
+  buildPrompt(ir: TransformResult): StrategyOutput;
 }

--- a/modelguide-api/src/features/compiler/core/transform.ts
+++ b/modelguide-api/src/features/compiler/core/transform.ts
@@ -125,5 +125,13 @@ export function transform(
     systemPrompt,
     tools,
     guardrails,
+    // Placeholder metadata — compile() replaces this after strategy execution
+    metadata: {
+      systemPromptTokens: 0,
+      estimatedToolSchemaTokens: 0,
+      totalEstimatedTokens: 0,
+      cacheablePrefix: 0,
+      warnings: [],
+    },
   };
 }

--- a/modelguide-api/src/features/compiler/core/transform.ts
+++ b/modelguide-api/src/features/compiler/core/transform.ts
@@ -1,23 +1,22 @@
 /**
  * Transform stage — enriches SOP steps with type, scoped prompts,
- * and matched guardrail IDs. Assembles the system prompt.
+ * and matched guardrail IDs.
  *
  * Input: parsed SOP + guardrails from the parse stage.
- * Output: CompilerIR ready for emitters.
+ * Output: TransformResult — structured data for strategies to build prompts from.
  */
 
 import type { SopStep } from "@features/sops/sops.types";
 import { matchGuardrails } from "./guardrail-matcher";
-import { buildScopedPrompt, buildSystemPrompt } from "./prompt-builder";
+import { buildScopedPrompt } from "./prompt-builder";
 import type {
-  AgentSopInfo,
-  CompilerIR,
   CompilerInput,
   EnrichedSop,
   EnrichedStep,
   ParsedGuardrail,
   ResolvedTool,
   SopDetailResponse,
+  TransformResult,
 } from "./types";
 
 // ============================================================================
@@ -78,8 +77,7 @@ export function transform(
   tools: ResolvedTool[],
   guardrails: ParsedGuardrail[],
   agentConfig: CompilerInput["agentConfig"],
-  agentSops?: AgentSopInfo[],
-): CompilerIR {
+): TransformResult {
   // Normalize and enrich each step
   const normalizedSteps = sop.definition.steps
     .slice()
@@ -96,19 +94,6 @@ export function transform(
     steps: normalizedSteps,
   };
 
-  // Build system prompt
-  const systemPrompt = buildSystemPrompt(
-    agentConfig.description,
-    {
-      name: sop.name,
-      description: sop.description,
-      definition: normalizedDefinition,
-    },
-    guardrails,
-    tools,
-    agentSops,
-  );
-
   // Assemble enriched SOP
   const enrichedSop: EnrichedSop = {
     id: sop.id,
@@ -122,16 +107,7 @@ export function transform(
   return {
     agentConfig,
     sop: enrichedSop,
-    systemPrompt,
     tools,
     guardrails,
-    // Placeholder metadata — compile() replaces this after strategy execution
-    metadata: {
-      systemPromptTokens: 0,
-      estimatedToolSchemaTokens: 0,
-      totalEstimatedTokens: 0,
-      cacheablePrefix: 0,
-      warnings: [],
-    },
   };
 }

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -145,7 +145,7 @@ export interface CompilerMetadata {
   estimatedToolSchemaTokens: number;
   /** Sum of system prompt + tool schema tokens. */
   totalEstimatedTokens: number;
-  /** Char offset where static content ends (before [Reminders] section). */
+  /** JS string offset (UTF-16 code units) where static content ends, before the Reminders section. Non-JS consumers must convert to byte offset. */
   cacheablePrefix: number;
   /** Warnings (e.g. VOICE_BUDGET_EXCEEDED). */
   warnings: CompilerWarning[];

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -42,8 +42,8 @@ export type {
 /** Model families supported by the compiler strategy selector. */
 export type ModelFamily = "gpt" | "claude" | "gemini" | "generic";
 
-/** Channel derived from agent modality. */
-export type Channel = "voice" | "text";
+/** Agent modality — determines strategy selection and token budget. */
+export type Modality = "voice" | "text";
 
 // ============================================================================
 // API response types (inferred from Zod schemas)
@@ -92,8 +92,8 @@ export interface CompilerInput {
     promptConfig: PromptConfig;
     /** Model family for strategy selection. */
     modelFamily: ModelFamily;
-    /** Channel derived from agent modality. */
-    channel: Channel;
+    /** Agent modality — determines strategy selection and token budget. */
+    modality: Modality;
   };
   /** All active SOPs assigned to the agent (for intent classification). */
   agentSops?: AgentSopInfo[];

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -151,13 +151,17 @@ export interface CompilerMetadata {
   warnings: CompilerWarning[];
 }
 
-/** Intermediate representation — output of core, input to emitters. */
-export interface CompilerIR {
+/** Output of transform() — structured data for strategies to build prompts from. */
+export interface TransformResult {
   agentConfig: CompilerInput["agentConfig"];
   sop: EnrichedSop;
-  systemPrompt: string;
   tools: ResolvedTool[];
   guardrails: ParsedGuardrail[];
+}
+
+/** Final compiled output — transform result + strategy-built prompt + metadata. */
+export interface CompilerIR extends TransformResult {
+  systemPrompt: string;
   /** Output metadata — token estimates, cache boundary, warnings. */
   metadata: CompilerMetadata;
 }

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -5,6 +5,7 @@
  * Guardrail types from knowledge-base feature (PR #140).
  */
 
+import type { PromptConfig } from "@db/schema/core";
 import type { knowledgeBaseDetailResponseSchema } from "@features/knowledge-base/knowledge-base.schemas";
 import type {
   GuardrailCategory,
@@ -23,6 +24,7 @@ import type { z } from "zod";
 
 // Re-export API types for consumers
 export type {
+  PromptConfig,
   SopStep,
   SopStepTool,
   SopTrigger,
@@ -32,6 +34,16 @@ export type {
   GuardrailCategory,
   GuardrailPriority,
 };
+
+// ============================================================================
+// Strategy types
+// ============================================================================
+
+/** Model families supported by the compiler strategy selector. */
+export type ModelFamily = "gpt" | "claude" | "gemini" | "generic";
+
+/** Channel derived from agent modality. */
+export type Channel = "voice" | "text";
 
 // ============================================================================
 // API response types (inferred from Zod schemas)
@@ -53,6 +65,8 @@ export type SopDetailResponse = z.infer<typeof sopDetailResponseSchema>;
 export interface ParsedGuardrail {
   id: string;
   name: string;
+  /** Short summary — used by voice strategies instead of full content. */
+  description: string | null;
   content: string;
   config: GuardrailConfig;
 }
@@ -74,9 +88,17 @@ export interface CompilerInput {
     model: string;
     /** Role context, e.g. "You are a customer support agent..." */
     description: string;
+    /** Prompt configuration (persona, fillerPhrases, language). */
+    promptConfig: PromptConfig;
+    /** Model family for strategy selection. */
+    modelFamily: ModelFamily;
+    /** Channel derived from agent modality. */
+    channel: Channel;
   };
   /** All active SOPs assigned to the agent (for intent classification). */
   agentSops?: AgentSopInfo[];
+  /** Map of tool resolvedName → requiresConfirmation from agent_connector_tools. */
+  toolConfirmationMap?: Record<string, boolean>;
 }
 
 /** A tool referenced by at least one SOP step. */
@@ -84,6 +106,8 @@ export interface ResolvedTool {
   resolvedName: string;
   connectorToolId?: string;
   connectorId?: string;
+  /** Whether the tool requires user confirmation before execution. */
+  requiresConfirmation?: boolean;
 }
 
 /** SOP step enriched with computed fields from the transform stage. */
@@ -106,6 +130,27 @@ export interface EnrichedSop {
   steps: EnrichedStep[];
 }
 
+/** Warning emitted by the compiler (e.g. budget overruns). */
+export interface CompilerWarning {
+  code: string;
+  message: string;
+  tokens?: number;
+}
+
+/** Output metadata — token estimates, cache boundary, warnings. */
+export interface CompilerMetadata {
+  /** Estimated system prompt tokens (chars / 4). */
+  systemPromptTokens: number;
+  /** Estimated tool schema tokens (toolCount * 180). */
+  estimatedToolSchemaTokens: number;
+  /** Sum of system prompt + tool schema tokens. */
+  totalEstimatedTokens: number;
+  /** Char offset where static content ends (before [Reminders] section). */
+  cacheablePrefix: number;
+  /** Warnings (e.g. VOICE_BUDGET_EXCEEDED). */
+  warnings: CompilerWarning[];
+}
+
 /** Intermediate representation — output of core, input to emitters. */
 export interface CompilerIR {
   agentConfig: CompilerInput["agentConfig"];
@@ -113,4 +158,6 @@ export interface CompilerIR {
   systemPrompt: string;
   tools: ResolvedTool[];
   guardrails: ParsedGuardrail[];
+  /** Output metadata — token estimates, cache boundary, warnings. */
+  metadata: CompilerMetadata;
 }

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -131,8 +131,13 @@ export interface EnrichedSop {
 }
 
 /** Warning emitted by the compiler (e.g. budget overruns). */
+export type CompilerWarningCode =
+  | "VOICE_BUDGET_EXCEEDED"
+  | "TEXT_BUDGET_EXCEEDED"
+  | "TOOL_BLOCK_OVER_BUDGET";
+
 export interface CompilerWarning {
-  code: string;
+  code: CompilerWarningCode;
   message: string;
   tokens?: number;
 }

--- a/modelguide-api/src/features/knowledge-base/knowledge-base.schemas.ts
+++ b/modelguide-api/src/features/knowledge-base/knowledge-base.schemas.ts
@@ -24,6 +24,10 @@ const guardrailPrioritySchema = z.enum(["critical", "high", "medium", "low"]);
 export const guardrailConfigSchema = z.object({
   category: guardrailCategorySchema.optional(),
   priority: guardrailPrioritySchema,
+  /** Why this guardrail exists — used by strategy renderers (e.g. Claude: "{rule} because {reason}"). */
+  reason: z.string().optional(),
+  /** When true, guardrail is emitted at both top and bottom of compiled prompt. */
+  critical: z.boolean().optional(),
 });
 
 /** Config schema resolved by type. Currently only guardrails. */

--- a/modelguide-api/src/features/knowledge-base/knowledge-base.types.ts
+++ b/modelguide-api/src/features/knowledge-base/knowledge-base.types.ts
@@ -14,6 +14,10 @@ export type GuardrailPriority = "critical" | "high" | "medium" | "low";
 export interface GuardrailConfig {
   category?: GuardrailCategory;
   priority: GuardrailPriority;
+  /** Why this guardrail exists — used by strategy renderers. */
+  reason?: string;
+  /** When true, guardrail is emitted at both top and bottom of compiled prompt. */
+  critical?: boolean;
 }
 
 /** Union of all KB config types (currently just guardrails). */

--- a/modelguide-api/tests/helpers/compiler-fixtures.ts
+++ b/modelguide-api/tests/helpers/compiler-fixtures.ts
@@ -9,7 +9,7 @@ import type { CompilerInput } from "@features/compiler/core/types";
 
 /**
  * A 4-step voice onboarding SOP with 3 guardrails.
- * Model family: gpt, channel: voice → exercises GptVoiceStrategy.
+ * Model family: gpt, modality: voice → exercises GptVoiceStrategy.
  */
 export const gptVoiceOnboardingFixture: CompilerInput = {
   sops: [
@@ -130,6 +130,6 @@ export const gptVoiceOnboardingFixture: CompilerInput = {
       language: "The conversation is conducted in English.",
     },
     modelFamily: "gpt",
-    channel: "voice",
+    modality: "voice",
   },
 };

--- a/modelguide-api/tests/helpers/compiler-fixtures.ts
+++ b/modelguide-api/tests/helpers/compiler-fixtures.ts
@@ -1,0 +1,135 @@
+/**
+ * Generic CompilerInput fixtures for integration and unit tests.
+ *
+ * These fixtures are intentionally domain-agnostic — realistic enough to
+ * exercise all compiler paths but not tied to any specific customer or campaign.
+ */
+
+import type { CompilerInput } from "@features/compiler/core/types";
+
+/**
+ * A 4-step voice onboarding SOP with 3 guardrails.
+ * Model family: gpt, channel: voice → exercises GptVoiceStrategy.
+ */
+export const gptVoiceOnboardingFixture: CompilerInput = {
+  sops: [
+    {
+      id: "sop-onboarding",
+      name: "Customer Onboarding",
+      slug: "customer-onboarding",
+      description:
+        "Structured onboarding call for new customers. Covers account verification, product walkthrough, and next steps.",
+      status: "active",
+      version: "1.0",
+      assignedAgents: [],
+      sopTemplateId: null,
+      template: null,
+      definition: {
+        schemaVersion: 1,
+        trigger: { type: "manual", config: {} },
+        steps: [
+          {
+            id: "introduction",
+            order: 1,
+            instruction:
+              "Greet the customer warmly and explain the purpose of the call. Set expectations for the 5-minute walkthrough.",
+            required: true,
+          },
+          {
+            id: "account-verification",
+            order: 2,
+            instruction:
+              "Verify the customer's account details. Ask for their registered email and confirm their current plan.",
+            required: true,
+          },
+          {
+            id: "product-walkthrough",
+            order: 3,
+            instruction:
+              "Walk through the key features relevant to their plan. Ask if they have tried the dashboard yet and offer to guide them through it.",
+            required: true,
+          },
+          {
+            id: "closing",
+            order: 4,
+            instruction:
+              "Summarize the next steps. Confirm the customer knows how to reach support. End the call warmly.",
+            required: true,
+          },
+        ],
+        metadata: {
+          escalationTriggers: [
+            "customer becomes hostile or abusive",
+            "customer requests legal action",
+            "customer reports a billing dispute over $500",
+          ],
+        },
+      },
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+  ],
+  guardrails: [
+    {
+      id: "g-compensation",
+      type: "guardrail",
+      name: "Compensation — No Quotes",
+      slug: "compensation-no-quotes",
+      content:
+        "Never quote specific compensation or pricing figures unless explicitly listed in the role context. Redirect all compensation discussions to the account manager.",
+      description: "Redirect compensation questions to the account manager",
+      config: { category: "compliance", priority: "critical" },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+    {
+      id: "g-pii",
+      type: "guardrail",
+      name: "PII — Do Not Collect",
+      slug: "pii-no-collect",
+      content:
+        "Never collect or store sensitive personally identifiable information such as SSN, date of birth, or financial account numbers during the call. If the customer volunteers such data, decline politely.",
+      description: "No PII collection during the call",
+      config: { category: "safety", priority: "critical" },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+    {
+      id: "g-no-guarantees",
+      type: "guardrail",
+      name: "No Outcome Guarantees",
+      slug: "no-outcome-guarantees",
+      content:
+        "Never promise or guarantee specific outcomes. Use measured, conditional language. Say 'this typically results in' rather than 'you will get'.",
+      description: "Use conditional language — no outcome promises",
+      config: { category: "compliance", priority: "high" },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+  ],
+  agentConfig: {
+    id: "agent-onboarding",
+    name: "Onboarding Agent",
+    model: "openai:gpt-4o-realtime",
+    description:
+      "Voice agent conducting structured customer onboarding calls. Guides customers through account verification and product setup.",
+    promptConfig: {
+      persona:
+        'You are a professional customer success agent. You DRIVE the conversation — this is an outbound call where you guide the customer through a structured onboarding flow. You are proactive, not reactive.\n\nUse a warm, professional tone — friendly but efficient. NEVER SAY: "Great question!", "Absolutely!", "I\'d be happy to...". USE INSTEAD: "Sure" / "Got it" / "That makes sense".',
+      fillerPhrases: ["One moment.", "Let me check on that.", "Just a second."],
+      language: "The conversation is conducted in English.",
+    },
+    modelFamily: "gpt",
+    channel: "voice",
+  },
+};

--- a/modelguide-api/tests/helpers/compiler-fixtures.ts
+++ b/modelguide-api/tests/helpers/compiler-fixtures.ts
@@ -120,7 +120,7 @@ export const gptVoiceOnboardingFixture: CompilerInput = {
   agentConfig: {
     id: "agent-onboarding",
     name: "Onboarding Agent",
-    model: "openai:gpt-4o-realtime",
+    model: "openai:gpt-4.1-mini",
     description:
       "Voice agent conducting structured customer onboarding calls. Guides customers through account verification and product setup.",
     promptConfig: {

--- a/modelguide-api/tests/helpers/load-demo-fixture.ts
+++ b/modelguide-api/tests/helpers/load-demo-fixture.ts
@@ -178,7 +178,7 @@ export function loadDemoFixture(
     agentConfig: {
       id: `agent-${agent.slug}`,
       name: agent.name,
-      model: "openai:gpt-4o-realtime",
+      model: "openai:gpt-4.1-mini",
       description: agent.description,
       promptConfig,
       modelFamily: agent.modelFamily as ModelFamily,

--- a/modelguide-api/tests/helpers/load-demo-fixture.ts
+++ b/modelguide-api/tests/helpers/load-demo-fixture.ts
@@ -11,9 +11,9 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type {
-  Channel,
   CompilerInput,
   KnowledgeBaseDetailResponse,
+  Modality,
   ModelFamily,
   SopDetailResponse,
 } from "@features/compiler/core/types";
@@ -164,8 +164,7 @@ export function loadDemoFixture(
     }),
   );
 
-  // Derive channel from modality
-  const channel: Channel = agent.modality === "voice" ? "voice" : "text";
+  const modality: Modality = agent.modality === "voice" ? "voice" : "text";
 
   const promptConfig = {
     persona: agent.promptConfig?.persona?.trim(),
@@ -183,7 +182,7 @@ export function loadDemoFixture(
       description: agent.description,
       promptConfig,
       modelFamily: agent.modelFamily as ModelFamily,
-      channel,
+      modality,
     },
   };
 }

--- a/modelguide-api/tests/helpers/load-demo-fixture.ts
+++ b/modelguide-api/tests/helpers/load-demo-fixture.ts
@@ -1,0 +1,189 @@
+/**
+ * Loads a demo seed directory (agents.yaml, sops.yaml, guardrails.yaml)
+ * and builds a CompilerInput for integration testing.
+ *
+ * Convention:
+ *   <demoDir>/agents.yaml    — agent definitions with promptConfig
+ *   <demoDir>/sops.yaml      — SOP definitions with steps
+ *   <demoDir>/guardrails.yaml — guardrails with agent assignments
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  Channel,
+  CompilerInput,
+  KnowledgeBaseDetailResponse,
+  ModelFamily,
+  SopDetailResponse,
+} from "@features/compiler/core/types";
+import yaml from "js-yaml";
+
+interface DemoAgent {
+  name: string;
+  slug: string;
+  description: string;
+  modality: string;
+  modelFamily: string;
+  promptConfig?: {
+    persona?: string;
+    fillerPhrases?: string[];
+    language?: string;
+  };
+}
+
+interface DemoSopStep {
+  id: string;
+  instruction: string;
+  required: boolean;
+}
+
+interface DemoSop {
+  name: string;
+  slug: string;
+  description: string;
+  status: string;
+  agents: string[];
+  trigger: { type: string; config: Record<string, unknown> };
+  metadata?: {
+    reasonCode?: string;
+    tags?: string[];
+    escalationTriggers?: string[];
+  };
+  preamble?: string;
+  steps: DemoSopStep[];
+}
+
+interface DemoGuardrail {
+  name: string;
+  slug: string;
+  description: string;
+  content: string;
+  config: {
+    category?: string;
+    priority: string;
+    critical?: boolean;
+    reason?: string;
+    agents?: string[];
+  };
+}
+
+interface LoadDemoFixtureOptions {
+  agentSlug: string;
+  sopSlug: string;
+}
+
+export function loadDemoFixture(
+  demoDir: string,
+  options: LoadDemoFixtureOptions,
+): CompilerInput {
+  const { agentSlug, sopSlug } = options;
+
+  // Load YAML files
+  const agentsRaw = yaml.load(
+    readFileSync(join(demoDir, "agents.yaml"), "utf-8"),
+  ) as { agents: DemoAgent[] };
+  const sopsRaw = yaml.load(
+    readFileSync(join(demoDir, "sops.yaml"), "utf-8"),
+  ) as { sops: DemoSop[] };
+  const guardrailsRaw = yaml.load(
+    readFileSync(join(demoDir, "guardrails.yaml"), "utf-8"),
+  ) as { guardrails: DemoGuardrail[] };
+
+  // Find agent
+  const agent = agentsRaw.agents.find((a) => a.slug === agentSlug);
+  if (!agent) throw new Error(`Agent "${agentSlug}" not found in agents.yaml`);
+
+  // Find SOP
+  const sop = sopsRaw.sops.find((s) => s.slug === sopSlug);
+  if (!sop) throw new Error(`SOP "${sopSlug}" not found in sops.yaml`);
+
+  // Filter guardrails assigned to this agent
+  const agentGuardrails = guardrailsRaw.guardrails.filter((g) =>
+    g.config.agents?.includes(agentSlug),
+  );
+
+  // Map trigger — demo YAMLs may use types not in the compiler schema
+  const VALID_TRIGGERS = [
+    "channel",
+    "intent_detected",
+    "tool_present",
+    "manual",
+  ];
+  const trigger = VALID_TRIGGERS.includes(sop.trigger.type)
+    ? (sop.trigger as { type: "manual"; config: Record<string, never> })
+    : ({ type: "manual", config: {} } as const);
+
+  // Build SopDetailResponse
+  const sopResponse: SopDetailResponse = {
+    id: `sop-${sop.slug}`,
+    name: sop.name,
+    slug: sop.slug,
+    description: sop.description,
+    status: sop.status as "active" | "draft" | "archived",
+    version: "1.0",
+    assignedAgents: [],
+    sopTemplateId: null,
+    template: null,
+    definition: {
+      schemaVersion: 1,
+      trigger,
+      steps: sop.steps.map((step, i) => ({
+        id: step.id,
+        order: i + 1,
+        instruction: step.instruction,
+        required: step.required,
+      })),
+      metadata: sop.metadata ?? {},
+    },
+    createdBy: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: null,
+  };
+
+  // Build guardrail responses
+  const guardrailResponses: KnowledgeBaseDetailResponse[] = agentGuardrails.map(
+    (g) => ({
+      id: `g-${g.slug}`,
+      type: "guardrail" as const,
+      name: g.name,
+      slug: g.slug,
+      content: g.content.trim(),
+      description: g.description,
+      config: {
+        category: g.config.category,
+        priority: g.config.priority as "critical" | "high" | "medium" | "low",
+        critical: g.config.critical,
+        reason: g.config.reason,
+      },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    }),
+  );
+
+  // Derive channel from modality
+  const channel: Channel = agent.modality === "voice" ? "voice" : "text";
+
+  const promptConfig = {
+    persona: agent.promptConfig?.persona?.trim(),
+    fillerPhrases: agent.promptConfig?.fillerPhrases,
+    language: agent.promptConfig?.language,
+  };
+
+  return {
+    sops: [sopResponse],
+    guardrails: guardrailResponses,
+    agentConfig: {
+      id: `agent-${agent.slug}`,
+      name: agent.name,
+      model: "openai:gpt-4o-realtime",
+      description: agent.description,
+      promptConfig,
+      modelFamily: agent.modelFamily as ModelFamily,
+      channel,
+    },
+  };
+}

--- a/modelguide-api/tests/integration/compiler/demo-fixture.test.ts
+++ b/modelguide-api/tests/integration/compiler/demo-fixture.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Demo-fixture smoke test for the SOP compiler.
+ *
+ * Compiles a prompt from a seed directory and verifies the structural shape
+ * of the compiled output. Optionally writes the prompt to a file.
+ *
+ * Required env vars:
+ *   SEED_DIR    — path to a directory containing agents.yaml, sops.yaml, guardrails.yaml
+ *   AGENT_SLUG  — slug of the agent to compile for
+ *   SOP_SLUG    — slug of the SOP to compile
+ *
+ * Optional env vars:
+ *   PROMPT_OUT  — if set, writes the compiled prompt to this path
+ *
+ * Example:
+ *   SEED_DIR=/path/to/seed AGENT_SLUG=my-agent SOP_SLUG=my-sop \
+ *     PROMPT_OUT=/tmp/prompt.txt \
+ *     bun test tests/integration/compiler/demo-fixture.test.ts
+ */
+
+import { describe, expect, it } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { compile } from "@features/compiler/core/compile";
+import { loadDemoFixture } from "../../helpers/load-demo-fixture";
+
+const SEED_DIR = process.env.SEED_DIR;
+const AGENT_SLUG = process.env.AGENT_SLUG;
+const SOP_SLUG = process.env.SOP_SLUG;
+const PROMPT_OUT = process.env.PROMPT_OUT;
+
+const hasRequiredEnv = Boolean(SEED_DIR && AGENT_SLUG && SOP_SLUG);
+
+describe.skipIf(!hasRequiredEnv)(
+  "Demo fixture — compiled prompt structure",
+  () => {
+    // Guard so module-level code doesn't run when env vars are absent.
+    // describe.skipIf still evaluates the callback body to register tests,
+    // so we need this explicit early return.
+    if (!hasRequiredEnv) return;
+
+    const input = loadDemoFixture(SEED_DIR!, {
+      agentSlug: AGENT_SLUG!,
+      sopSlug: SOP_SLUG!,
+    });
+    const ir = compile(input);
+    const prompt = ir.systemPrompt;
+
+    if (PROMPT_OUT) {
+      writeFileSync(PROMPT_OUT, prompt, "utf-8");
+    }
+
+    // -----------------------------------------------------------------------
+    // Structural shape — no domain-specific content asserted
+    // -----------------------------------------------------------------------
+
+    it("compiled prompt is non-empty", () => {
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+
+    it("contains step headers in ## Step N: format", () => {
+      expect(prompt).toMatch(/## Step \d+:/);
+    });
+
+    it("contains GOAL prefix on at least one step", () => {
+      expect(prompt).toContain("GOAL:");
+    });
+
+    it("contains EXIT transitions", () => {
+      expect(prompt).toContain("EXIT →");
+    });
+
+    it("contains a Rules section", () => {
+      expect(prompt).toContain("# Rules");
+    });
+
+    it("contains a Reminders section", () => {
+      expect(prompt).toContain("# Reminders");
+    });
+  },
+);

--- a/modelguide-api/tests/integration/compiler/eval-helpers.ts
+++ b/modelguide-api/tests/integration/compiler/eval-helpers.ts
@@ -36,6 +36,9 @@ export const agentConfig = {
   model: "anthropic/claude-haiku-4-5-20251001",
   description:
     "You are a customer support agent for an e-commerce store handling inbound support emails. You process one email per run and send a single reply.",
+  promptConfig: {},
+  modelFamily: "generic" as const,
+  channel: "text" as const,
 };
 
 /** Compile the fixture SOP and run the agent against a test email. */

--- a/modelguide-api/tests/integration/compiler/eval-helpers.ts
+++ b/modelguide-api/tests/integration/compiler/eval-helpers.ts
@@ -38,7 +38,7 @@ export const agentConfig = {
     "You are a customer support agent for an e-commerce store handling inbound support emails. You process one email per run and send a single reply.",
   promptConfig: {},
   modelFamily: "generic" as const,
-  channel: "text" as const,
+  modality: "text" as const,
 };
 
 /** Compile the fixture SOP and run the agent against a test email. */

--- a/modelguide-api/tests/integration/compiler/gpt-voice-strategy.test.ts
+++ b/modelguide-api/tests/integration/compiler/gpt-voice-strategy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration test — GptVoiceStrategy general acceptance criteria.
+ *
+ * Uses an inline fixture (generic multi-step SOP + guardrails) to verify
+ * the compiler's structural output: section ordering, guardrail sandwich,
+ * metadata, response rules, safety placement.
+ *
+ * AC3, AC18, AC20, AC24-27.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { compile } from "@features/compiler/core/compile";
+import { gptVoiceOnboardingFixture } from "../../helpers/compiler-fixtures";
+
+// ---------------------------------------------------------------------------
+
+describe("GptVoiceStrategy — integration", () => {
+  const ir = compile(gptVoiceOnboardingFixture);
+  const prompt = ir.systemPrompt;
+
+  it("AC25: compiles successfully from fixture", () => {
+    expect(ir.systemPrompt).toBeTruthy();
+    expect(ir.systemPrompt.length).toBeGreaterThan(500);
+    expect(ir.guardrails.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // ========================================================================
+  // AC3: section ordering
+  // ========================================================================
+
+  it("AC3: description first, persona second", () => {
+    const descIdx = prompt.indexOf("# Role & Objective");
+    const personaIdx = prompt.indexOf("# Personality & Tone");
+    expect(descIdx).toBeGreaterThanOrEqual(0);
+    expect(personaIdx).toBeGreaterThan(descIdx);
+  });
+
+  it("AC26: persona block is present", () => {
+    expect(prompt).toContain("# Personality & Tone");
+    expect(prompt).toContain("You DRIVE the conversation");
+    expect(prompt).toContain("this is an outbound call");
+  });
+
+  // ========================================================================
+  // AC18: guardrail sandwich
+  // ========================================================================
+
+  it("AC18: all guardrails appear in both Rules and Reminders (sandwich)", () => {
+    const rulesIdx = prompt.indexOf("# Rules");
+    const remindersIdx = prompt.indexOf("# Reminders");
+    expect(rulesIdx).toBeGreaterThan(0);
+    expect(remindersIdx).toBeGreaterThan(rulesIdx);
+
+    const topContent = prompt.slice(rulesIdx, remindersIdx);
+    const bottomContent = prompt.slice(remindersIdx);
+
+    // Compensation guardrail present in both halves
+    expect(topContent).toContain("compensation");
+    expect(bottomContent).toContain("compensation");
+  });
+
+  // ========================================================================
+  // AC20: safety & escalation
+  // ========================================================================
+
+  it("AC20: safety & escalation compiled once at agent level", () => {
+    expect(prompt).toContain("# Safety & Escalation");
+    expect(prompt).toContain("hostile or abusive");
+  });
+
+  // ========================================================================
+  // Response rules, tools, vocal normalization
+  // ========================================================================
+
+  it("response rules present under Personality & Tone", () => {
+    expect(prompt).toContain("# Personality & Tone");
+    expect(prompt).toContain("2-3 sentences per turn");
+    expect(prompt).toContain("Do not repeat the same sentence twice");
+    expect(prompt).toContain("Do not use markdown");
+    expect(prompt).toContain("Use only the information provided");
+  });
+
+  it("AC26: vocal normalization block present", () => {
+    expect(prompt).toContain("# Reference Pronunciations");
+    expect(prompt).toContain("one hundred dollars");
+    expect(prompt).toContain("ten thirty A M");
+  });
+
+  // ========================================================================
+  // Metadata
+  // ========================================================================
+
+  it("metadata has valid token estimates", () => {
+    expect(ir.metadata.systemPromptTokens).toBeGreaterThan(0);
+    expect(ir.metadata.totalEstimatedTokens).toBeGreaterThan(0);
+    expect(ir.metadata.cacheablePrefix).toBeGreaterThan(0);
+    expect(ir.metadata.cacheablePrefix).toBeLessThanOrEqual(
+      ir.systemPrompt.length,
+    );
+  });
+});

--- a/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
+++ b/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
@@ -30,7 +30,7 @@ const agentConfig = {
     "You are a customer support agent for an e-commerce store handling inbound support emails. You process one email per run and send a single reply.",
   promptConfig: {},
   modelFamily: "generic" as const,
-  channel: "text" as const,
+  modality: "text" as const,
 };
 
 function makeInput(

--- a/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
+++ b/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
@@ -28,6 +28,9 @@ const agentConfig = {
   model: "anthropic/claude-haiku-4-5-20241022",
   description:
     "You are a customer support agent for an e-commerce store handling inbound support emails. You process one email per run and send a single reply.",
+  promptConfig: {},
+  modelFamily: "generic" as const,
+  channel: "text" as const,
 };
 
 function makeInput(

--- a/modelguide-api/tests/integration/sop-classification-flow.test.ts
+++ b/modelguide-api/tests/integration/sop-classification-flow.test.ts
@@ -192,6 +192,9 @@ describe("SOP classification full flow", () => {
           model: "anthropic/claude-haiku-4-5-20251001",
           description:
             "You are a customer support agent for an e-commerce store handling inbound support emails.",
+          promptConfig: {},
+          modelFamily: "generic" as const,
+          channel: "text" as const,
         },
         agentSops: [
           {

--- a/modelguide-api/tests/integration/sop-classification-flow.test.ts
+++ b/modelguide-api/tests/integration/sop-classification-flow.test.ts
@@ -194,7 +194,7 @@ describe("SOP classification full flow", () => {
             "You are a customer support agent for an e-commerce store handling inbound support emails.",
           promptConfig: {},
           modelFamily: "generic" as const,
-          channel: "text" as const,
+          modality: "text" as const,
         },
         agentSops: [
           {

--- a/modelguide-api/tests/unit/compiler/guardrail-matcher.test.ts
+++ b/modelguide-api/tests/unit/compiler/guardrail-matcher.test.ts
@@ -114,6 +114,7 @@ describe("matchGuardrails — Appendix A.3 verification", () => {
       {
         id: "gr-medium-test",
         name: "Medium Test",
+        description: null,
         content: "scope ticket refund replacement escalation helpdesk",
         config: { category: "operational", priority: "medium" },
       },

--- a/modelguide-api/tests/unit/compiler/prompt-builder.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-builder.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the prompt builder.
+ * Unit tests for prompt building — GenericStrategy and buildScopedPrompt.
  *
  * ACs covered: 6-8 (guardrail placement in prompts),
  * 10 (system prompt groups by priority), 12 (escalation triggers).
@@ -7,11 +7,12 @@
 
 import { describe, expect, it } from "bun:test";
 import { parseGuardrails } from "@features/compiler/core/parse";
-import {
-  buildScopedPrompt,
-  buildSystemPrompt,
-} from "@features/compiler/core/prompt-builder";
-import type { ResolvedTool } from "@features/compiler/core/types";
+import { buildScopedPrompt } from "@features/compiler/core/prompt-builder";
+import { GenericStrategy } from "@features/compiler/core/prompt-strategies/generic-strategy";
+import type {
+  ResolvedTool,
+  TransformResult,
+} from "@features/compiler/core/types";
 import type { SopStep } from "@features/sops/sops.types";
 import { emailOrderNotArrivedSop } from "../../fixtures/compiler/email-wismo-sop";
 import { sampleGuardrails } from "../../fixtures/compiler/sample-guardrails";
@@ -33,13 +34,32 @@ const sampleTools: ResolvedTool[] = [
   },
 ];
 
-describe("buildSystemPrompt", () => {
-  const prompt = buildSystemPrompt(
-    agentDescription,
-    emailOrderNotArrivedSop,
-    parsedGuardrails,
-    sampleTools,
-  );
+const makeIr = (toolsOverride?: ResolvedTool[]): TransformResult => ({
+  agentConfig: {
+    id: "test-agent",
+    name: "Test Agent",
+    model: "test-model",
+    description: agentDescription,
+    promptConfig: {},
+    modelFamily: "generic",
+    modality: "text",
+  },
+  sop: {
+    id: emailOrderNotArrivedSop.id,
+    name: emailOrderNotArrivedSop.name,
+    slug: emailOrderNotArrivedSop.slug,
+    description: emailOrderNotArrivedSop.description,
+    definition:
+      emailOrderNotArrivedSop.definition as TransformResult["sop"]["definition"],
+    steps: [],
+  },
+  tools: toolsOverride ?? sampleTools,
+  guardrails: parsedGuardrails,
+});
+
+describe("GenericStrategy.buildPrompt", () => {
+  const strategy = new GenericStrategy();
+  const { prompt } = strategy.buildPrompt(makeIr());
 
   it("starts with agentConfig.description as preamble", () => {
     expect(prompt.startsWith(agentDescription)).toBe(true);
@@ -59,8 +79,6 @@ describe("buildSystemPrompt", () => {
   it("appends tool name to steps that have tools", () => {
     expect(prompt).toContain("→ `store_look_up_order`");
     expect(prompt).toContain("→ `helpdesk_create_ticket`");
-    // Steps without tools should not have arrows
-    expect(prompt).toMatch(/1\. Determine if this email.*(?<!→)/);
   });
 
   it("includes tools section with resolved names", () => {
@@ -70,12 +88,7 @@ describe("buildSystemPrompt", () => {
   });
 
   it("omits tools section when no tools provided", () => {
-    const noToolsPrompt = buildSystemPrompt(
-      agentDescription,
-      emailOrderNotArrivedSop,
-      parsedGuardrails,
-      [],
-    );
+    const { prompt: noToolsPrompt } = strategy.buildPrompt(makeIr([]));
     expect(noToolsPrompt).not.toContain("## Tools");
   });
 
@@ -110,6 +123,11 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain(
       "**Brand Tone — Warm Professional:** Always greet the customer",
     );
+  });
+
+  it("cacheablePrefix equals prompt length (no dynamic sections)", () => {
+    const result = strategy.buildPrompt(makeIr());
+    expect(result.cacheablePrefix).toBe(result.prompt.length);
   });
 });
 

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -1,0 +1,590 @@
+/**
+ * Unit tests for prompt strategies — getStrategy(), GptVoiceStrategy, GenericStrategy.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { compile } from "@features/compiler/core/compile";
+import {
+  GenericStrategy,
+  GptVoiceStrategy,
+  getStrategy,
+} from "@features/compiler/core/prompt-strategies";
+import type {
+  CompilerInput,
+  KnowledgeBaseDetailResponse,
+  SopDetailResponse,
+} from "@features/compiler/core/types";
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+function makeAgentConfig(
+  overrides: Partial<CompilerInput["agentConfig"]> = {},
+) {
+  return {
+    id: "test-agent",
+    name: "Test Agent",
+    model: "openai:gpt-4o-realtime",
+    description: "a pre-screening voice agent for candidate recruitment",
+    promptConfig: {},
+    modelFamily: "generic" as const,
+    channel: "text" as const,
+    ...overrides,
+  };
+}
+
+const voiceAgentConfig = makeAgentConfig({
+  modelFamily: "gpt",
+  channel: "voice",
+  promptConfig: {
+    persona:
+      "Warm, efficient, respectful recruiter. You DRIVE the conversation.",
+    fillerPhrases: ["One sec.", "Checking now.", "Bear with me."],
+  },
+});
+
+const makeSop = (
+  overrides?: Partial<SopDetailResponse>,
+): SopDetailResponse => ({
+  id: "sop-001",
+  name: "Booking Pre-Screen",
+  slug: "booking-pre-screen",
+  description: "Pre-screening voice SOP",
+  status: "active",
+  version: "1.0",
+  assignedAgents: [],
+  sopTemplateId: null,
+  template: null,
+  definition: {
+    schemaVersion: 1,
+    trigger: { type: "manual", config: {} },
+    steps: [
+      {
+        id: "introduction",
+        order: 1,
+        instruction:
+          'Greet the candidate and set expectations: "I will ask a few questions about your background."',
+        required: true,
+        tool: {
+          connectorToolId: "a0000000-0000-0000-0000-000000000001",
+          connectorId: "a0000000-0000-0000-0000-000000000010",
+          resolvedName: "crm_lookup_candidate",
+        },
+      },
+      {
+        id: "background",
+        order: 2,
+        instruction:
+          'Ask: "Could you tell me about yourself and what drew you to this position?"',
+        required: true,
+      },
+      {
+        id: "closing",
+        order: 3,
+        instruction:
+          'Say: "Based on what you shared, this sounds like it could be a great fit."',
+        required: true,
+      },
+    ],
+    metadata: {
+      escalationTriggers: ["If the candidate becomes abusive, end the call."],
+    },
+  },
+  createdBy: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: null,
+  ...overrides,
+});
+
+const makeGuardrails = (
+  overrides?: Partial<KnowledgeBaseDetailResponse>[],
+): KnowledgeBaseDetailResponse[] => {
+  const defaults: KnowledgeBaseDetailResponse[] = [
+    {
+      id: "g1",
+      type: "guardrail",
+      name: "No salary info",
+      slug: "no-salary-info",
+      content:
+        "Compensation details are not available. If the candidate asks about salary, say: the recruiter will share the full compensation details in the next step. Do not invent, estimate, or state any figure.",
+      description: null,
+      config: {
+        priority: "critical",
+        critical: true,
+        reason: "Legal liability",
+      },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: null,
+    },
+    {
+      id: "g2",
+      type: "guardrail",
+      name: "Be polite",
+      slug: "be-polite",
+      content: "Always maintain a warm and professional tone.",
+      description: null,
+      config: { priority: "medium" },
+      isActive: true,
+      assignedAgents: [],
+      createdBy: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: null,
+    },
+  ];
+  if (overrides) {
+    return defaults.map((d, i) => ({ ...d, ...overrides[i] }));
+  }
+  return defaults;
+};
+
+function makeCompilerInput(overrides?: Partial<CompilerInput>): CompilerInput {
+  return {
+    sops: [makeSop()],
+    guardrails: makeGuardrails(),
+    agentConfig: voiceAgentConfig,
+    ...overrides,
+  };
+}
+
+function compileVoice(overrides?: Partial<CompilerInput>) {
+  return compile(makeCompilerInput(overrides));
+}
+
+// ============================================================================
+// getStrategy() selection tests
+// ============================================================================
+
+describe("getStrategy()", () => {
+  it("returns GptVoiceStrategy for (gpt, voice)", () => {
+    const strategy = getStrategy("gpt", "voice");
+    expect(strategy).toBeInstanceOf(GptVoiceStrategy);
+    expect(strategy.name).toBe("GptVoiceStrategy");
+  });
+
+  it("returns GenericStrategy for (gpt, text)", () => {
+    const strategy = getStrategy("gpt", "text");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+
+  it("returns GenericStrategy for (claude, voice)", () => {
+    const strategy = getStrategy("claude", "voice");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+
+  it("returns GenericStrategy for (claude, text)", () => {
+    const strategy = getStrategy("claude", "text");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+
+  it("returns GenericStrategy for (gemini, voice)", () => {
+    const strategy = getStrategy("gemini", "voice");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+
+  it("returns GenericStrategy for (generic, text)", () => {
+    const strategy = getStrategy("generic", "text");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+
+  it("returns GenericStrategy for (generic, voice)", () => {
+    const strategy = getStrategy("generic", "voice");
+    expect(strategy).toBeInstanceOf(GenericStrategy);
+  });
+});
+
+// ============================================================================
+// GptVoiceStrategy output format tests
+// ============================================================================
+
+describe("GptVoiceStrategy", () => {
+  const ir = compileVoice();
+  const prompt = ir.systemPrompt;
+
+  it("renders all guardrails uniformly in normal case", () => {
+    expect(prompt).toContain(
+      "Compensation details are not available. If the candidate asks about salary, say: the recruiter will share the full compensation details in the next step. Do not invent, estimate, or state any figure.",
+    );
+    expect(prompt).toContain("Always maintain a warm and professional tone.");
+    // No ALL CAPS — all guardrails rendered uniformly
+    expect(prompt).not.toContain("COMPENSATION DETAILS ARE NOT AVAILABLE");
+    expect(prompt).not.toContain(
+      "ALWAYS MAINTAIN A WARM AND PROFESSIONAL TONE",
+    );
+  });
+
+  it("AC10: includes vocal normalization block", () => {
+    expect(prompt).toContain("# Reference Pronunciations");
+    expect(prompt).toContain('"one hundred dollars"');
+    expect(prompt).toContain('"ten thirty A M"');
+    expect(prompt).toContain('"second" not "2nd"');
+  });
+
+  it("AC11: includes response length rule (2-3 sentences)", () => {
+    expect(prompt).toContain("2-3 sentences per turn");
+  });
+
+  it("AC12: includes variety rule", () => {
+    expect(prompt).toContain(
+      "Do not repeat the same sentence twice. Vary your responses.",
+    );
+  });
+
+  it("AC13: includes no-markdown instruction", () => {
+    expect(prompt).toContain("Do not use markdown, bullet points, lists");
+    expect(prompt).toContain("meant to be read aloud");
+  });
+
+  it("AC14: includes context reliance instruction", () => {
+    expect(prompt).toContain("Use only the information provided");
+    expect(prompt).toContain("do not supplement with general knowledge");
+  });
+
+  it("AC3: description first, persona second", () => {
+    const descIdx = prompt.indexOf("# Role & Objective");
+    const personaIdx = prompt.indexOf("# Personality & Tone");
+    expect(descIdx).toBeGreaterThanOrEqual(0);
+    expect(personaIdx).toBeGreaterThan(descIdx);
+    expect(prompt).toContain(
+      "You are a pre-screening voice agent for candidate recruitment.",
+    );
+    expect(prompt).toContain(
+      "Warm, efficient, respectful recruiter. You DRIVE the conversation.",
+    );
+  });
+
+  it("AC15: SOP steps in state blocks with labels and transitions", () => {
+    expect(prompt).toContain("## Step 1: introduction");
+    expect(prompt).toContain("## Step 2: background");
+    expect(prompt).toContain("## Step 3: closing");
+    // GOAL derived from step id (humanized)
+    expect(prompt).toContain("GOAL: Introduction");
+    expect(prompt).toContain("GOAL: Background");
+    expect(prompt).toContain("GOAL: Closing");
+    // EXIT prefix on transitions
+    expect(prompt).toContain("EXIT → Step 2");
+    expect(prompt).toContain("EXIT → Step 3");
+    expect(prompt).toContain("EXIT → End");
+  });
+
+  it("AC15: step instructions are preserved verbatim", () => {
+    expect(prompt).toContain(
+      'Greet the candidate and set expectations: "I will ask a few questions about your background."',
+    );
+    expect(prompt).toContain(
+      '"Could you tell me about yourself and what drew you to this position?"',
+    );
+    expect(prompt).toContain(
+      '"Based on what you shared, this sounds like it could be a great fit."',
+    );
+  });
+
+  it("rewrites symbolic operators to plain English in step instructions", () => {
+    const symbolicSop = makeSop({
+      definition: {
+        schemaVersion: 1,
+        trigger: { type: "manual", config: {} },
+        steps: [
+          {
+            id: "check-wait-time",
+            order: 1,
+            instruction:
+              'If hold time > 240 seconds, apologize. If attempts >= 3, escalate. If account == null, ask for details. If status != "active", flag the case.',
+            required: true,
+          },
+        ],
+        metadata: {},
+      },
+    });
+    const ir = compileVoice({ sops: [symbolicSop] });
+    const p = ir.systemPrompt;
+    expect(p).toContain("more than 240");
+    expect(p).toContain("at least 3");
+    expect(p).toContain("does not exist");
+    expect(p).toContain('is not "active"');
+    expect(p).not.toContain("> 240");
+    expect(p).not.toContain(">= 3");
+    expect(p).not.toContain("== null");
+    expect(p).not.toContain('!= "active"');
+  });
+
+  it("AC16: filler preamble uses promptConfig.fillerPhrases", () => {
+    expect(prompt).toContain('"One sec."');
+    expect(prompt).toContain('"Checking now."');
+    expect(prompt).toContain('"Bear with me."');
+    expect(prompt).toContain("Never use the same filler twice in a row");
+  });
+
+  it("AC16: falls back to default filler phrases when none configured", () => {
+    const noFillerIr = compileVoice({
+      agentConfig: makeAgentConfig({
+        modelFamily: "gpt",
+        channel: "voice",
+        promptConfig: { persona: "Test persona." },
+      }),
+    });
+    const p = noFillerIr.systemPrompt;
+    expect(p).toContain('"One moment."');
+    expect(p).toContain('"Let me check."');
+    expect(p).toContain('"Just a second."');
+  });
+
+  it("AC17: includes tool hallucination guard", () => {
+    expect(prompt).toContain(
+      "If you don't have enough information to call a tool, ask the user before calling it.",
+    );
+  });
+
+  it("AC18: all guardrails appear in both Rules and Reminders (sandwich)", () => {
+    const rulesSection = prompt.indexOf("# Rules");
+    const remindersSection = prompt.indexOf("# Reminders");
+    expect(rulesSection).toBeGreaterThan(0);
+    expect(remindersSection).toBeGreaterThan(rulesSection);
+
+    // All guardrails appear in both sections
+    const topContent = prompt.slice(rulesSection, remindersSection);
+    const bottomContent = prompt.slice(remindersSection);
+    expect(topContent).toContain("Compensation details are not available");
+    expect(bottomContent).toContain("Compensation details are not available");
+    expect(topContent).toContain(
+      "Always maintain a warm and professional tone",
+    );
+    expect(bottomContent).toContain(
+      "Always maintain a warm and professional tone",
+    );
+  });
+
+  it("AC19: no agentic boilerplate (persistence/tool-calling/planning)", () => {
+    expect(prompt).not.toContain("persistence");
+    expect(prompt).not.toContain("When you encounter a problem");
+    expect(prompt).not.toContain("When you are unsure");
+    expect(prompt).not.toContain("planning");
+    // tool-calling as an instruction, not the word in context
+    expect(prompt).not.toMatch(/always attempt to use.*tool/i);
+  });
+
+  it("AC20: safety & escalation in static prefix", () => {
+    const safetyIdx = prompt.indexOf("# Safety & Escalation");
+    const remindersIdx = prompt.indexOf("# Reminders");
+    expect(safetyIdx).toBeGreaterThan(0);
+    // Safety is before Reminders (in static prefix)
+    expect(safetyIdx).toBeLessThan(remindersIdx);
+    expect(prompt).toContain("If the candidate becomes abusive, end the call.");
+  });
+
+  it("AC6: CONFIRMATION_FIRST tag for tools with requiresConfirmation", () => {
+    const confirmedIr = compileVoice({
+      toolConfirmationMap: { crm_lookup_candidate: true },
+    });
+    const p = confirmedIr.systemPrompt;
+    expect(p).toContain("crm_lookup_candidate — CONFIRMATION_FIRST");
+    expect(p).toContain("Ask the user for confirmation before executing");
+  });
+
+  it("cache boundary is before # Reminders", () => {
+    const remindersIdx = prompt.indexOf("# Reminders");
+    // cacheablePrefix char offset should be right before # Reminders
+    expect(ir.metadata.cacheablePrefix).toBeLessThanOrEqual(remindersIdx);
+    expect(ir.metadata.cacheablePrefix).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// GenericStrategy backward compatibility
+// ============================================================================
+
+describe("GenericStrategy backward compatibility (AC21)", () => {
+  it("produces markdown format with ## headers", () => {
+    const genericIr = compile({
+      sops: [makeSop()],
+      guardrails: makeGuardrails(),
+      agentConfig: makeAgentConfig({
+        modelFamily: "generic",
+        channel: "text",
+      }),
+    });
+    const prompt = genericIr.systemPrompt;
+
+    // Should use markdown headers
+    expect(prompt).toContain("## Workflow:");
+    expect(prompt).toContain("## Tools");
+    expect(prompt).toContain("## Guardrails");
+  });
+
+  it("does NOT include voice-specific sections", () => {
+    const genericIr = compile({
+      sops: [makeSop()],
+      guardrails: makeGuardrails(),
+      agentConfig: makeAgentConfig({
+        modelFamily: "generic",
+        channel: "text",
+      }),
+    });
+    const prompt = genericIr.systemPrompt;
+
+    expect(prompt).not.toContain("# Reference Pronunciations");
+    expect(prompt).not.toContain("# Personality & Tone");
+    expect(prompt).not.toContain("# Reminders");
+  });
+
+  it("cacheablePrefix equals prompt length (no reminders section)", () => {
+    const genericIr = compile({
+      sops: [makeSop()],
+      guardrails: makeGuardrails(),
+      agentConfig: makeAgentConfig({
+        modelFamily: "generic",
+        channel: "text",
+      }),
+    });
+    expect(genericIr.metadata.cacheablePrefix).toBe(
+      genericIr.systemPrompt.length,
+    );
+  });
+});
+
+// ============================================================================
+// Output metadata — token estimates and warnings
+// ============================================================================
+
+describe("Output metadata (AC22, AC23)", () => {
+  it("AC22: computes systemPromptTokens as chars/4", () => {
+    const ir = compileVoice();
+    const expectedTokens = Math.ceil(ir.systemPrompt.length / 4);
+    expect(ir.metadata.systemPromptTokens).toBe(expectedTokens);
+  });
+
+  it("AC22: computes estimatedToolSchemaTokens as toolCount * 180", () => {
+    const ir = compileVoice();
+    expect(ir.metadata.estimatedToolSchemaTokens).toBe(ir.tools.length * 180);
+  });
+
+  it("AC22: totalEstimatedTokens is sum of system + tool", () => {
+    const ir = compileVoice();
+    expect(ir.metadata.totalEstimatedTokens).toBe(
+      ir.metadata.systemPromptTokens + ir.metadata.estimatedToolSchemaTokens,
+    );
+  });
+
+  it("AC22: cacheablePrefix is a positive number", () => {
+    const ir = compileVoice();
+    expect(ir.metadata.cacheablePrefix).toBeGreaterThan(0);
+  });
+
+  it("AC23: warns when voice budget exceeded", () => {
+    // Build a SOP with many steps to exceed 2,500 token budget (instruction max is 2000)
+    const longInstruction = "A".repeat(1900);
+    const steps = Array.from({ length: 8 }, (_, i) => ({
+      id: `long-step-${i}`,
+      order: i + 1,
+      instruction: longInstruction,
+      required: true,
+      tool: {
+        connectorToolId: "00000000-0000-0000-0000-000000000001",
+        connectorId: "00000000-0000-0000-0000-000000000010",
+        resolvedName: "crm_lookup_candidate",
+      },
+    }));
+    const ir = compileVoice({
+      sops: [
+        makeSop({
+          definition: {
+            schemaVersion: 1,
+            trigger: { type: "manual", config: {} },
+            steps,
+            metadata: {},
+          },
+        }),
+      ],
+    });
+
+    expect(ir.metadata.totalEstimatedTokens).toBeGreaterThan(2500);
+    expect(ir.metadata.warnings.length).toBeGreaterThan(0);
+    expect(ir.metadata.warnings[0].code).toBe("VOICE_BUDGET_EXCEEDED");
+  });
+
+  it("AC23: warns when text budget exceeded", () => {
+    const longInstruction = "A".repeat(1900);
+    const steps = Array.from({ length: 20 }, (_, i) => ({
+      id: `long-step-${i}`,
+      order: i + 1,
+      instruction: longInstruction,
+      required: true,
+      tool: {
+        connectorToolId: "00000000-0000-0000-0000-000000000001",
+        connectorId: "00000000-0000-0000-0000-000000000010",
+        resolvedName: "crm_lookup_candidate",
+      },
+    }));
+    const ir = compile({
+      sops: [
+        makeSop({
+          definition: {
+            schemaVersion: 1,
+            trigger: { type: "manual", config: {} },
+            steps,
+            metadata: {},
+          },
+        }),
+      ],
+      guardrails: [],
+      agentConfig: makeAgentConfig({
+        modelFamily: "generic",
+        channel: "text",
+      }),
+    });
+
+    expect(ir.metadata.totalEstimatedTokens).toBeGreaterThan(8000);
+    expect(ir.metadata.warnings.length).toBeGreaterThan(0);
+    expect(ir.metadata.warnings[0].code).toBe("TEXT_BUDGET_EXCEEDED");
+  });
+
+  it("AC23: no warning when under budget", () => {
+    const ir = compileVoice();
+    // With our small fixture SOP, should be well under budget
+    // (unless the fixture itself is very large)
+    if (ir.metadata.totalEstimatedTokens <= 2500) {
+      expect(ir.metadata.warnings).toEqual([]);
+    }
+  });
+
+  it("warns when a tool block exceeds per-tool token limit", () => {
+    const verboseSop = makeSop({
+      definition: {
+        schemaVersion: 1,
+        trigger: { type: "manual", config: {} },
+        steps: [
+          {
+            id: "step-with-tool",
+            order: 1,
+            instruction: "Use the tool.",
+            required: true,
+            tool: {
+              connectorToolId: "00000000-0000-0000-0000-000000000001",
+              connectorId: "00000000-0000-0000-0000-000000000010",
+              resolvedName:
+                "glowbox_store_extremely_verbose_tool_with_a_really_absurdly_long_name_that_eats_way_too_many_precious_voice_tokens_from_budget",
+            },
+          },
+        ],
+        metadata: {},
+      },
+    });
+    // Mark the tool as requires_confirmation to inflate the block further
+    const ir = compileVoice({
+      sops: [verboseSop],
+      toolConfirmationMap: {
+        glowbox_store_extremely_verbose_tool_with_a_really_absurdly_long_name_that_eats_way_too_many_precious_voice_tokens_from_budget: true,
+      },
+    });
+    const toolWarning = ir.metadata.warnings.find(
+      (w) => w.code === "TOOL_BLOCK_OVER_BUDGET",
+    );
+    expect(toolWarning).toBeDefined();
+    expect(toolWarning!.message).toContain(
+      "glowbox_store_extremely_verbose_tool",
+    );
+  });
+});

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -384,11 +384,24 @@ describe("GptVoiceStrategy", () => {
     expect(p).toContain("Ask the user for confirmation before executing");
   });
 
-  it("cache boundary is before # Reminders", () => {
-    const remindersIdx = prompt.indexOf("# Reminders");
-    // cacheablePrefix char offset should be right before # Reminders
-    expect(ir.metadata.cacheablePrefix).toBeLessThanOrEqual(remindersIdx);
-    expect(ir.metadata.cacheablePrefix).toBeGreaterThan(0);
+  it("cache boundary lands exactly at the Reminders section break", () => {
+    const prefix = ir.metadata.cacheablePrefix;
+    expect(prefix).toBeGreaterThan(0);
+    // The content after cacheablePrefix must start with the Reminders section
+    const tail = prompt.slice(prefix);
+    expect(tail.trimStart().startsWith("# Reminders")).toBe(true);
+    // Everything before cacheablePrefix must NOT contain Reminders
+    expect(prompt.slice(0, prefix)).not.toContain("# Reminders");
+  });
+
+  it("cacheablePrefix equals prompt length when no guardrails", () => {
+    const noGuardrailsIr = compileVoice({ guardrails: [] });
+    // No guardrails → no Reminders section → entire prompt is cacheable
+    expect(noGuardrailsIr.metadata.cacheablePrefix).toBe(
+      noGuardrailsIr.systemPrompt.length,
+    );
+    expect(noGuardrailsIr.systemPrompt).not.toContain("# Reminders");
+    expect(noGuardrailsIr.systemPrompt).not.toContain("# Rules");
   });
 });
 

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -581,11 +581,9 @@ describe("Output metadata (AC22, AC23)", () => {
 
   it("AC23: no warning when under budget", () => {
     const ir = compileVoice();
-    // With our small fixture SOP, should be well under budget
-    // (unless the fixture itself is very large)
-    if (ir.metadata.totalEstimatedTokens <= 2500) {
-      expect(ir.metadata.warnings).toEqual([]);
-    }
+    // Fixture must stay under budget for this test to be meaningful
+    expect(ir.metadata.totalEstimatedTokens).toBeLessThanOrEqual(2500);
+    expect(ir.metadata.warnings).toEqual([]);
   });
 
   it("warns when a tool block exceeds per-tool token limit", () => {

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -29,14 +29,14 @@ function makeAgentConfig(
     description: "a pre-screening voice agent for candidate recruitment",
     promptConfig: {},
     modelFamily: "generic" as const,
-    channel: "text" as const,
+    modality: "text" as const,
     ...overrides,
   };
 }
 
 const voiceAgentConfig = makeAgentConfig({
   modelFamily: "gpt",
-  channel: "voice",
+  modality: "voice",
   promptConfig: {
     persona:
       "Warm, efficient, respectful recruiter. You DRIVE the conversation.",
@@ -323,7 +323,7 @@ describe("GptVoiceStrategy", () => {
     const noFillerIr = compileVoice({
       agentConfig: makeAgentConfig({
         modelFamily: "gpt",
-        channel: "voice",
+        modality: "voice",
         promptConfig: { persona: "Test persona." },
       }),
     });
@@ -441,7 +441,7 @@ describe("GenericStrategy backward compatibility (AC21)", () => {
       guardrails: makeGuardrails(),
       agentConfig: makeAgentConfig({
         modelFamily: "generic",
-        channel: "text",
+        modality: "text",
       }),
     });
     const prompt = genericIr.systemPrompt;
@@ -458,7 +458,7 @@ describe("GenericStrategy backward compatibility (AC21)", () => {
       guardrails: makeGuardrails(),
       agentConfig: makeAgentConfig({
         modelFamily: "generic",
-        channel: "text",
+        modality: "text",
       }),
     });
     const prompt = genericIr.systemPrompt;
@@ -474,7 +474,7 @@ describe("GenericStrategy backward compatibility (AC21)", () => {
       guardrails: makeGuardrails(),
       agentConfig: makeAgentConfig({
         modelFamily: "generic",
-        channel: "text",
+        modality: "text",
       }),
     });
     expect(genericIr.metadata.cacheablePrefix).toBe(
@@ -570,7 +570,7 @@ describe("Output metadata (AC22, AC23)", () => {
       guardrails: [],
       agentConfig: makeAgentConfig({
         modelFamily: "generic",
-        channel: "text",
+        modality: "text",
       }),
     });
 

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -25,7 +25,7 @@ function makeAgentConfig(
   return {
     id: "test-agent",
     name: "Test Agent",
-    model: "openai:gpt-4o-realtime",
+    model: "openai:gpt-4.1-mini",
     description: "a pre-screening voice agent for candidate recruitment",
     promptConfig: {},
     modelFamily: "generic" as const,

--- a/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-strategies.test.ts
@@ -108,7 +108,7 @@ const makeGuardrails = (
       slug: "no-salary-info",
       content:
         "Compensation details are not available. If the candidate asks about salary, say: the recruiter will share the full compensation details in the next step. Do not invent, estimate, or state any figure.",
-      description: null,
+      description: "Never share salary information",
       config: {
         priority: "critical",
         critical: true,
@@ -125,8 +125,9 @@ const makeGuardrails = (
       type: "guardrail",
       name: "Be polite",
       slug: "be-polite",
-      content: "Always maintain a warm and professional tone.",
-      description: null,
+      content:
+        "Always maintain a warm and professional tone. Use the candidate's name, avoid jargon, and keep responses concise.",
+      description: "Stay warm and professional",
       config: { priority: "medium" },
       isActive: true,
       assignedAgents: [],
@@ -338,23 +339,19 @@ describe("GptVoiceStrategy", () => {
     );
   });
 
-  it("AC18: all guardrails appear in both Rules and Reminders (sandwich)", () => {
-    const rulesSection = prompt.indexOf("# Rules");
-    const remindersSection = prompt.indexOf("# Reminders");
-    expect(rulesSection).toBeGreaterThan(0);
-    expect(remindersSection).toBeGreaterThan(rulesSection);
+  it("AC18: all guardrail names appear in both Rules and Reminders (sandwich)", () => {
+    const rulesIdx = prompt.indexOf("# Rules");
+    const remindersIdx = prompt.indexOf("# Reminders");
+    expect(rulesIdx).toBeGreaterThan(0);
+    expect(remindersIdx).toBeGreaterThan(rulesIdx);
 
-    // All guardrails appear in both sections
-    const topContent = prompt.slice(rulesSection, remindersSection);
-    const bottomContent = prompt.slice(remindersSection);
-    expect(topContent).toContain("Compensation details are not available");
-    expect(bottomContent).toContain("Compensation details are not available");
-    expect(topContent).toContain(
-      "Always maintain a warm and professional tone",
-    );
-    expect(bottomContent).toContain(
-      "Always maintain a warm and professional tone",
-    );
+    // Guardrail headings appear in both sections
+    const rulesSection = prompt.slice(rulesIdx, remindersIdx);
+    const remindersSection = prompt.slice(remindersIdx);
+    expect(rulesSection).toContain("## No salary info");
+    expect(remindersSection).toContain("## No salary info");
+    expect(rulesSection).toContain("## Be polite");
+    expect(remindersSection).toContain("## Be polite");
   });
 
   it("AC19: no agentic boilerplate (persistence/tool-calling/planning)", () => {
@@ -402,6 +399,34 @@ describe("GptVoiceStrategy", () => {
     );
     expect(noGuardrailsIr.systemPrompt).not.toContain("# Reminders");
     expect(noGuardrailsIr.systemPrompt).not.toContain("# Rules");
+  });
+
+  it("sandwich technique: Rules has full content, Reminders has concise description", () => {
+    // Split prompt at the two sections
+    const rulesIdx = prompt.indexOf("# Rules");
+    const remindersIdx = prompt.indexOf("# Reminders");
+    expect(rulesIdx).toBeGreaterThan(-1);
+    expect(remindersIdx).toBeGreaterThan(rulesIdx);
+
+    const rulesSection = prompt.slice(rulesIdx, remindersIdx);
+    const remindersSection = prompt.slice(remindersIdx);
+
+    // Rules should contain the full content
+    expect(rulesSection).toContain("Compensation details are not available");
+    expect(rulesSection).toContain(
+      "Do not invent, estimate, or state any figure",
+    );
+    expect(rulesSection).toContain(
+      "Always maintain a warm and professional tone. Use the candidate",
+    );
+
+    // Reminders should contain the concise descriptions, NOT the full content
+    expect(remindersSection).toContain("Never share salary information");
+    expect(remindersSection).toContain("Stay warm and professional");
+    expect(remindersSection).not.toContain(
+      "Do not invent, estimate, or state any figure",
+    );
+    expect(remindersSection).not.toContain("Use the candidate");
   });
 });
 

--- a/modelguide-api/tests/unit/compiler/transform.test.ts
+++ b/modelguide-api/tests/unit/compiler/transform.test.ts
@@ -19,7 +19,7 @@ const agentConfig = {
   description: "Test agent description",
   promptConfig: {},
   modelFamily: "generic" as const,
-  channel: "text" as const,
+  modality: "text" as const,
 };
 
 const ir = transform(sop, tools, guardrails, agentConfig);

--- a/modelguide-api/tests/unit/compiler/transform.test.ts
+++ b/modelguide-api/tests/unit/compiler/transform.test.ts
@@ -73,13 +73,12 @@ describe("transform — enriched steps", () => {
   });
 });
 
-describe("transform — IR structure", () => {
-  it("IR has systemPrompt", () => {
-    expect(ir.systemPrompt).toBeTruthy();
-    expect(ir.systemPrompt).toContain("Test agent description");
+describe("transform — result structure", () => {
+  it("result has no systemPrompt (strategies build it)", () => {
+    expect("systemPrompt" in ir).toBe(false);
   });
 
-  it("IR has tools", () => {
+  it("result has tools", () => {
     expect(ir.tools).toHaveLength(2);
     expect(ir.tools.map((t) => t.resolvedName)).toEqual([
       "store_look_up_order",

--- a/modelguide-api/tests/unit/compiler/transform.test.ts
+++ b/modelguide-api/tests/unit/compiler/transform.test.ts
@@ -17,6 +17,9 @@ const agentConfig = {
   name: "Test Agent",
   model: "openai:gpt-4o-mini",
   description: "Test agent description",
+  promptConfig: {},
+  modelFamily: "generic" as const,
+  channel: "text" as const,
 };
 
 const ir = transform(sop, tools, guardrails, agentConfig);

--- a/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
+++ b/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
@@ -21,7 +21,7 @@ const input: CompilerInput = {
     description: "Test agent",
     promptConfig: {},
     modelFamily: "generic" as const,
-    channel: "text" as const,
+    modality: "text" as const,
   },
 };
 

--- a/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
+++ b/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
@@ -19,6 +19,9 @@ const input: CompilerInput = {
     name: "Test Agent",
     model: "openai:gpt-4o-mini",
     description: "Test agent",
+    promptConfig: {},
+    modelFamily: "generic" as const,
+    channel: "text" as const,
   },
 };
 


### PR DESCRIPTION
Closes #196

## Summary

Adds `GptVoiceStrategy` — the first model- and channel-aware prompt compiler for GPT-based voice agents (e.g. OpenAI Realtime).

Given a `(modelFamily=gpt, channel=voice)` pair the compiler selects `GptVoiceStrategy`; all other combinations fall back to `GenericStrategy` (backward-compatible). The interface is extensible — adding `ClaudeStrategy`, `GeminiStrategy`, etc. is additive.

**What `GptVoiceStrategy` produces** (follows the OpenAI Realtime Prompting Guide):

```
# Role & Objective        — agent description
# Personality & Tone      — persona + response rules + language
# Reference Pronunciations — vocal normalization (TTS-safe numbers/dates/currency)
# Tools                   — filler preamble, hallucination guard, per-tool blocks
# Rules                   — guardrail content (full text, ## subheader per guardrail)
# Conversation Flow       — SOP steps: ## Step N: id, GOAL, instruction, EXIT →
# Safety & Escalation     — escalation triggers from SOP metadata
# Reminders               — guardrail descriptions (sandwich technique)
```

**Key design decisions:**
- Guardrail sandwich: full content in `# Rules` (stable cached prefix), concise `description` in `# Reminders`
- Rules preamble prevents the model from treating inline examples as real data
- GOAL/EXIT structure on each step for reliable small-model turn tracking
- Symbolic operators rewritten to plain English (`> 240` → "more than 240") for TTS safety
- Token budget warnings: `VOICE_BUDGET_EXCEEDED` at >2,500 tokens, `TOOL_BLOCK_OVER_BUDGET` at >60 tokens per tool
- `cacheablePrefix` char offset in metadata for runtime prompt caching

**Data model additions:**
- `agents.modelFamily` — Postgres enum `model_family` (gpt/claude/gemini/generic, default generic)
- `agents.promptConfig` — JSONB `{ persona?, fillerPhrases?, language? }` (NOT NULL, default `{}`)

## Test plan

- [ ] 37 unit tests — `bun test tests/unit/compiler/prompt-strategies.test.ts`
- [ ] 9 integration tests — `bun test tests/integration/compiler/gpt-voice-strategy.test.ts`
- [ ] Generic seed smoke test (env-var driven, works with any seed directory):
  ```
  SEED_DIR=<path> AGENT_SLUG=<slug> SOP_SLUG=<slug> PROMPT_OUT=/tmp/out.txt \
    bun test tests/integration/compiler/demo-fixture.test.ts
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)