### PR TITLE
feat(evals): support pinned conversation history in replay tests

### DIFF
--- a/modelguide-api/src/features/evals/eval-suites-simulate.service.ts
+++ b/modelguide-api/src/features/evals/eval-suites-simulate.service.ts
@@ -275,6 +275,7 @@ async function executeSimulateAndRunInner(
     const input = testCase.input as SimulationTestCaseInput;
     let inputMessage = input.message!; // validated in enqueueSimulateAndRun
     const personaId = input.persona;
+    const conversationHistory = input.conversationHistory;
     const mockToolResponses =
       (testCase.mockToolResponses as Record<string, unknown>) ?? {};
 
@@ -348,13 +349,14 @@ async function executeSimulateAndRunInner(
         userIdentifier,
       });
 
-      // 3. Run simulation (single-turn only — no persona follow-ups)
+      // 3. Run simulation — includes conversation history for replay tests
       const simResult = await runEvalSimulation({
         orgId,
         agentId: suiteData.agent.id,
         adapter,
         inputMessage,
         sessionId,
+        conversationHistory,
       });
 
       if (simResult.status === "error") {

--- a/modelguide-api/src/features/evals/eval-suites.types.ts
+++ b/modelguide-api/src/features/evals/eval-suites.types.ts
@@ -57,6 +57,8 @@ export interface CreateEvaluatorInput {
 export interface SimulationTestCaseInput {
   message?: string;
   persona?: string;
+  /** Prior conversation turns for replay tests — stored in session before the live turn. */
+  conversationHistory?: Array<{ role: string; content: string }>;
 }
 
 /** Expected shape of sessions.metadata for simulation sessions. */

--- a/modelguide-api/src/features/simulations/adapters/agent-adapter.ts
+++ b/modelguide-api/src/features/simulations/adapters/agent-adapter.ts
@@ -29,10 +29,14 @@ export interface AgentAdapter {
    *
    * @param sessionId - The simulation session ID (for tool calls that need it)
    * @param message - The user message to send
+   * @param conversationHistory - Optional prior conversation turns for replay tests.
+   *   When provided, the adapter passes these as structured messages to the model
+   *   so it sees full conversational context before generating a response.
    * @returns The agent's response including any tool calls
    */
   sendMessage(
     sessionId: string,
     message: string,
+    conversationHistory?: Array<{ role: string; content: string }>,
   ): Promise<AgentAdapterResponse>;
 }

--- a/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
+++ b/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
@@ -12,6 +12,7 @@
 
 import { getLogger } from "@lib/logger";
 import { Agent } from "@mastra/core/agent";
+import type { CoreMessage } from "@mastra/core/llm";
 import { MCPClient } from "@mastra/mcp";
 import type { AgentAdapter, AgentAdapterResponse } from "./agent-adapter";
 
@@ -72,22 +73,41 @@ export class MastraAdapter implements AgentAdapter {
   async sendMessage(
     sessionId: string,
     message: string,
+    conversationHistory?: Array<{ role: string; content: string }>,
   ): Promise<AgentAdapterResponse> {
     log.debug(
       {
         agentId: this.config.agentId,
         sessionId,
         messageLength: message.length,
+        historyTurns: conversationHistory?.length ?? 0,
       },
       "MastraAdapter sending message",
     );
 
     const toolsets = await this.mcpClient.listToolsets();
 
-    const result = await this.agent.generate(message, {
+    // When conversation history is provided (replay tests), build a structured
+    // CoreMessage[] so the model sees prior turns as proper user/assistant messages.
+    // Otherwise, pass the raw string (original single-turn behavior).
+    const generateOpts = {
       toolsets,
       maxSteps: this.config.maxSteps ?? 5,
-    });
+    };
+
+    const result =
+      conversationHistory && conversationHistory.length > 0
+        ? await this.agent.generate(
+            [
+              ...conversationHistory.map((msg) => ({
+                role: msg.role as "user" | "assistant" | "system",
+                content: msg.content,
+              })),
+              { role: "user" as const, content: message },
+            ] as CoreMessage[],
+            generateOpts,
+          )
+        : await this.agent.generate(message, generateOpts);
     // Extract tool calls from the generation steps
     const toolCalls: AgentAdapterResponse["toolCalls"] = [];
     for (const step of result.steps ?? []) {

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -33,6 +33,12 @@ export interface EvalOrchestrationInput {
   inputMessage: string;
   /** Optional persona for generating follow-up messages after the agent responds. */
   persona?: Persona;
+  /**
+   * Optional prior conversation turns for replay tests.
+   * When provided, these are stored in the session as context messages
+   * and passed to the adapter so the model sees full conversational history.
+   */
+  conversationHistory?: Array<{ role: string; content: string }>;
   /** Timeout in ms (defaults to SIMULATION_TIMEOUT_MS env var). */
   timeoutMs?: number;
   /** Max conversation turns (defaults to SIMULATION_MAX_TURNS env var). */
@@ -121,8 +127,28 @@ async function runConversationLoop(
   input: EvalOrchestrationInput,
   startTime: number,
 ): Promise<EvalOrchestrationResult> {
-  const { orgId, agentId, sessionId, adapter, inputMessage, persona } = input;
+  const {
+    orgId,
+    agentId,
+    sessionId,
+    adapter,
+    inputMessage,
+    persona,
+    conversationHistory: priorHistory,
+  } = input;
   const maxTurns = input.maxTurns ?? env.SIMULATION_MAX_TURNS;
+
+  // Store prior conversation history in the session so evaluators
+  // (especially llm_judge) see the full transcript when scoring.
+  if (priorHistory && priorHistory.length > 0) {
+    for (const msg of priorHistory) {
+      await addMessage(orgId, sessionId, agentId, {
+        role: msg.role as "user" | "assistant",
+        content: msg.content,
+        occurredAt: new Date(),
+      });
+    }
+  }
 
   let currentMessage = inputMessage;
   let turnCount = 0;
@@ -139,8 +165,14 @@ async function runConversationLoop(
       occurredAt: new Date(),
     });
 
-    // Send to agent via adapter
-    const agentResponse = await adapter.sendMessage(sessionId, currentMessage);
+    // Send to agent via adapter — include prior history on the first turn
+    // so the model sees full conversational context for replay tests.
+    const historyForAdapter = turn === 0 ? priorHistory : undefined;
+    const agentResponse = await adapter.sendMessage(
+      sessionId,
+      currentMessage,
+      historyForAdapter,
+    );
 
     // Store agent response with tool calls
     if (agentResponse.toolCalls.length > 0) {

--- a/modelguide-api/tests/integration/evals/wismo-mastra-e2e.test.ts
+++ b/modelguide-api/tests/integration/evals/wismo-mastra-e2e.test.ts
@@ -398,4 +398,261 @@ describe("simulate-and-run E2E pipeline", () => {
     },
     120_000, // 2 min timeout for LLM calls
   );
+
+  it.skipIf(!HAS_API_KEY)(
+    "replay test: conversationHistory is stored and scored",
+    async () => {
+      // Tests that a test case with conversationHistory produces a session
+      // containing N history messages + 1 user message + 1 assistant response,
+      // and evaluators score the final response with full context.
+
+      // 1. Compile agent
+      await compileAgent({
+        orgId: ctx.orgId,
+        agentId: ctx.agentId,
+        sopId,
+      });
+
+      // 2. Init eval suite from SOP
+      const suite = await initSuiteFromSop(ctx.orgId, ctx.agentId, sopId);
+      const autoTc = suite.testCases.find((tc) => tc.source === "auto");
+      expect(autoTc).toBeDefined();
+
+      // 3. Populate test case with conversationHistory + input message + mocks
+      //    The history sets up a prior exchange where the customer already
+      //    mentioned an order, and the agent asked for details. The new message
+      //    provides the order number — the agent should look it up.
+      const conversationHistory = [
+        {
+          role: "user",
+          content: "I need help with my order. It hasn't arrived yet.",
+        },
+        {
+          role: "assistant",
+          content:
+            "I'm sorry to hear that! Could you please provide me with your order number so I can look it up for you?",
+        },
+      ];
+
+      await forOrg(ctx.orgId, (tx) =>
+        tx
+          .update(evalSuiteTestCases)
+          .set({
+            input: {
+              message: "Sure, it's ORD-777.",
+              conversationHistory,
+            },
+            mockToolResponses: {
+              sim_store_look_up_order: {
+                order_id: "ORD-777",
+                status: "in_transit",
+                shipping_date: "2026-04-05",
+                estimated_delivery: "2026-04-12",
+                carrier: "UPS",
+                tracking_number: "UPS-12345",
+              },
+            },
+          })
+          .where(eq(evalSuiteTestCases.id, autoTc!.id)),
+      );
+
+      // 4. Run simulate-and-run
+      const result = await enqueueSimulateAndRun(
+        ctx.orgId,
+        suite.id,
+        "compiled",
+      );
+      expect(result.suiteRunId).toBeDefined();
+
+      // 5. Poll for completion
+      let runDetail: Awaited<ReturnType<typeof getEvalSuiteRunById>> | null =
+        null;
+
+      for (let i = 0; i < 45; i++) {
+        await new Promise((r) => setTimeout(r, 2000));
+        runDetail = await getEvalSuiteRunById(
+          ctx.orgId,
+          suite.id,
+          result.suiteRunId,
+        );
+        if (runDetail.status !== "running") break;
+      }
+
+      expect(runDetail).toBeDefined();
+      expect(runDetail!.status).toBe("completed");
+
+      // 6. Verify test case has eval scores
+      const tcResults = runDetail!.testCaseResults;
+      expect(tcResults).toHaveLength(1);
+      expect(tcResults[0].scores.length).toBeGreaterThan(0);
+
+      // 7. Find the simulation session and verify message count
+      //    Expected: 2 history messages + 1 user message + 1+ assistant response
+      const simSessions = await forApp((tx) =>
+        tx
+          .select({ id: sessions.id, startedAt: sessions.startedAt })
+          .from(sessions)
+          .where(
+            and(
+              eq(sessions.organizationId, ctx.orgId),
+              eq(sessions.mode, "simulation"),
+              eq(sessions.agentId, ctx.agentId),
+            ),
+          ),
+      );
+      // Sort by createdAt desc to get the most recent session (from this test)
+      simSessions.sort(
+        (a, b) =>
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+      );
+      const latestSessionId = simSessions[0].id;
+
+      const messages = await forApp((tx) =>
+        tx
+          .select({
+            id: sessionMessages.id,
+            role: sessionMessages.role,
+            content: sessionMessages.content,
+          })
+          .from(sessionMessages)
+          .where(eq(sessionMessages.sessionId, latestSessionId)),
+      );
+
+      // 2 history messages + 1 user message + at least 1 assistant response = 4+
+      expect(messages.length).toBeGreaterThanOrEqual(4);
+
+      // Verify the history messages are present
+      const userMessages = messages.filter((m) => m.role === "user");
+      const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+      // At least 2 user messages (1 from history + 1 live) and 2 assistant (1 from history + 1 live)
+      expect(userMessages.length).toBeGreaterThanOrEqual(2);
+      expect(assistantMessages.length).toBeGreaterThanOrEqual(2);
+
+      // Verify the history content is preserved in the session
+      const allContent = messages.map((m) => m.content).join(" ");
+      expect(allContent).toContain("hasn't arrived yet");
+      expect(allContent).toContain("order number");
+
+      // Cleanup
+      await deleteEvalSuite(ctx.orgId, suite.id);
+    },
+    120_000,
+  );
+
+  it.skipIf(!HAS_API_KEY)(
+    "regression: test case without conversationHistory behaves identically",
+    async () => {
+      // Verifies that test cases without conversationHistory still work
+      // as before — single message, no history messages in session.
+
+      // 1. Compile agent
+      await compileAgent({
+        orgId: ctx.orgId,
+        agentId: ctx.agentId,
+        sopId,
+      });
+
+      // 2. Init eval suite from SOP
+      const suite = await initSuiteFromSop(ctx.orgId, ctx.agentId, sopId);
+      const autoTc = suite.testCases.find((tc) => tc.source === "auto");
+      expect(autoTc).toBeDefined();
+
+      // 3. Populate test case with input but NO conversationHistory
+      await forOrg(ctx.orgId, (tx) =>
+        tx
+          .update(evalSuiteTestCases)
+          .set({
+            input: {
+              message: "Where is my order ORD-888?",
+              // No conversationHistory field
+            },
+            mockToolResponses: {
+              sim_store_look_up_order: {
+                order_id: "ORD-888",
+                status: "delivered",
+                shipping_date: "2026-04-01",
+                estimated_delivery: "2026-04-05",
+                carrier: "USPS",
+                tracking_number: "USPS-99999",
+              },
+            },
+          })
+          .where(eq(evalSuiteTestCases.id, autoTc!.id)),
+      );
+
+      // 4. Run simulate-and-run
+      const result = await enqueueSimulateAndRun(
+        ctx.orgId,
+        suite.id,
+        "compiled",
+      );
+      expect(result.suiteRunId).toBeDefined();
+
+      // 5. Poll for completion
+      let runDetail: Awaited<ReturnType<typeof getEvalSuiteRunById>> | null =
+        null;
+
+      for (let i = 0; i < 45; i++) {
+        await new Promise((r) => setTimeout(r, 2000));
+        runDetail = await getEvalSuiteRunById(
+          ctx.orgId,
+          suite.id,
+          result.suiteRunId,
+        );
+        if (runDetail.status !== "running") break;
+      }
+
+      expect(runDetail).toBeDefined();
+      expect(runDetail!.status).toBe("completed");
+
+      // 6. Verify test case results
+      const tcResults = runDetail!.testCaseResults;
+      expect(tcResults).toHaveLength(1);
+      expect(tcResults[0].scores.length).toBeGreaterThan(0);
+
+      // 7. Find the most recent simulation session and verify message count
+      const simSessions = await forApp((tx) =>
+        tx
+          .select({ id: sessions.id, startedAt: sessions.startedAt })
+          .from(sessions)
+          .where(
+            and(
+              eq(sessions.organizationId, ctx.orgId),
+              eq(sessions.mode, "simulation"),
+              eq(sessions.agentId, ctx.agentId),
+            ),
+          ),
+      );
+      simSessions.sort(
+        (a, b) =>
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+      );
+      const latestSessionId = simSessions[0].id;
+
+      const messages = await forApp((tx) =>
+        tx
+          .select({ id: sessionMessages.id, role: sessionMessages.role })
+          .from(sessionMessages)
+          .where(eq(sessionMessages.sessionId, latestSessionId)),
+      );
+
+      // Without history: exactly 1 user message + at least 1 assistant response
+      const userMessages = messages.filter((m) => m.role === "user");
+      const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+      expect(userMessages.length).toBe(1);
+      expect(assistantMessages.length).toBeGreaterThanOrEqual(1);
+
+      // Total: no history overhead — just the live turn
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      // But not 4+ (which would indicate history was injected)
+      // Note: tool call messages might bump the count, so we check user count specifically
+      expect(userMessages.length).toBe(1);
+
+      // Cleanup
+      await deleteEvalSuite(ctx.orgId, suite.id);
+    },
+    120_000,
+  );
 });


### PR DESCRIPTION
## Summary

- Thread `conversationHistory` from test case JSONB input through the simulate-and-run pipeline into `MastraAdapter`, enabling replay tests where N turns are fixed and only the agent's response to turn N+1 is generated and scored
- Store prior history messages in the simulation session so evaluators (especially `llm_judge`) see the full transcript when scoring
- Backward compatible: absent/empty `conversationHistory` falls back to existing string-based `agent.generate()` call

Closes #200

## Changes

| File | What |
|------|------|
| `agent-adapter.ts` | Add optional `conversationHistory` param to `sendMessage()` interface |
| `mastra-adapter.ts` | Build `CoreMessage[]` from history + current message when history provided |
| `eval-orchestrator.ts` | Store history in session via `addMessage()`, pass to adapter on first turn |
| `eval-suites-simulate.service.ts` | Extract `conversationHistory` from test case JSONB input |
| `eval-suites.types.ts` | Add `conversationHistory` to `SimulationTestCaseInput` |
| `wismo-mastra-e2e.test.ts` | 2 new integration tests: replay with history + regression without |

## Test plan

- [x] Integration: replay test case with `conversationHistory` — session contains N history + 1 user + 1 assistant, evaluators score final response
- [x] Integration: test case without `conversationHistory` — identical to existing behavior, no regression
- [x] All 7 wismo-mastra-e2e tests pass (including 5 pre-existing)
- [x] `api-typecheck` passes (only pre-existing livekit-server-sdk error)
- [x] `api-lint` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)