### PR TITLE
feat(compiler): support multiple SOPs per compilation (#209)

### DIFF
--- a/modelguide-api/drizzle/0034_migrate-compiled-from-to-multi-sop.sql
+++ b/modelguide-api/drizzle/0034_migrate-compiled-from-to-multi-sop.sql
@@ -1,0 +1,20 @@
+-- Migrate compiled_from JSONB from single-SOP shape to multi-SOP array shape.
+-- Old: { sopId, sopName, stepCount, guardrailIds, toolCount }
+-- New: { sops: [{ sopId, sopName, stepCount }], guardrailIds, toolCount }
+-- Idempotent: only touches rows with old shape (has "sopId" key, no "sops" key).
+
+UPDATE agents
+SET compiled_from = jsonb_build_object(
+  'sops', jsonb_build_array(
+    jsonb_build_object(
+      'sopId',     compiled_from->>'sopId',
+      'sopName',   compiled_from->>'sopName',
+      'stepCount', (compiled_from->>'stepCount')::int
+    )
+  ),
+  'guardrailIds', COALESCE(compiled_from->'guardrailIds', '[]'::jsonb),
+  'toolCount',    COALESCE((compiled_from->>'toolCount')::int, 0)
+)
+WHERE compiled_from IS NOT NULL
+  AND compiled_from ? 'sopId'
+  AND NOT compiled_from ? 'sops';

--- a/modelguide-api/drizzle/meta/_journal.json
+++ b/modelguide-api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1775736766520,
       "tag": "0033_add-model-family-prompt-config",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1776364800000,
+      "tag": "0034_migrate-compiled-from-to-multi-sop",
+      "breakpoints": true
     }
   ]
 }

--- a/modelguide-api/src/cli/commands/compile-agents.ts
+++ b/modelguide-api/src/cli/commands/compile-agents.ts
@@ -54,22 +54,22 @@ export async function handleCompileAgents(
       continue;
     }
 
-    // Compile against each active SOP assigned to this agent
-    for (const sop of agentSops) {
-      try {
-        await compileAgent({
-          orgId,
-          agentId: agent.id,
-          sopId: sop.id,
-        });
-        log.success(`Compiled agent: ${agent.name} (SOP: ${sop.name})`);
-        compiled++;
-      } catch (err) {
-        log.warn(
-          `Failed to compile ${agent.name} with SOP ${sop.name}: ${getErrorMessage(err)}`,
-        );
-        skipped++;
-      }
+    // Compile with all active SOPs in a single call
+    const sopIds = agentSops.map((s) => s.id);
+    const sopNames = agentSops.map((s) => s.name).join(", ");
+    try {
+      await compileAgent({
+        orgId,
+        agentId: agent.id,
+        sopIds,
+      });
+      log.success(`Compiled agent: ${agent.name} (SOPs: ${sopNames})`);
+      compiled++;
+    } catch (err) {
+      log.warn(
+        `Failed to compile ${agent.name} with SOPs [${sopNames}]: ${getErrorMessage(err)}`,
+      );
+      skipped++;
     }
   }
 

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -2,222 +2,90 @@
  * Seed step: compile active SOPs for demo agents.
  *
  * Populates compiled_instructions, compiled_at, and compiled_from on agents
- * that have an active SOP assigned. This is required for the eval suite runner
+ * that have active SOPs assigned. This is required for the eval suite runner
  * which gates on compiled_instructions being non-null.
  *
- * Uses the real compiler pipeline so the seed prompt stays in sync with
- * production output.
+ * Delegates to compiler.service.compileAgent so seed output stays aligned with
+ * the production compiler behavior.
  */
 
-import { compile } from "@features/compiler/core/compile";
-import type { CompilerInput } from "@features/compiler/core/types";
+import { compileAgent } from "@features/compiler/compiler.service";
 import { eq } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type * as schema from "../schema";
-import {
-  agentKnowledgeBase,
-  agentSops,
-  agents,
-  connectorTools,
-  connectors,
-  knowledgeBase,
-  sopSteps,
-  sops,
-} from "../schema";
+import { agentSops, agents, sops } from "../schema";
 
 type SeedDb = PostgresJsDatabase<typeof schema>;
 
 export async function seedCompileAgents(db: SeedDb): Promise<void> {
   console.log("\n--- Compiling agents from assigned SOPs ---");
 
-  // Find all agent→SOP assignments
   const assignments = await db
     .select({
-      agentId: agentSops.agentId,
-      sopId: agentSops.sopId,
+      agentId: agents.id,
+      agentName: agents.name,
+      orgId: agents.organizationId,
+      sopId: sops.id,
+      sopName: sops.name,
+      sopStatus: sops.status,
     })
-    .from(agentSops);
+    .from(agentSops)
+    .innerJoin(agents, eq(agentSops.agentId, agents.id))
+    .innerJoin(sops, eq(agentSops.sopId, sops.id));
 
   if (assignments.length === 0) {
     console.log("  No agent→SOP assignments found, skipping compilation");
     return;
   }
 
-  for (const { agentId, sopId } of assignments) {
-    // Load agent
-    const [agent] = await db
-      .select()
-      .from(agents)
-      .where(eq(agents.id, agentId));
-    if (!agent) continue;
+  const assignmentsByAgent = new Map<
+    string,
+    {
+      agentName: string;
+      orgId: string;
+      sopIds: string[];
+      sopNames: string[];
+    }
+  >();
 
-    // Load SOP (only compile active SOPs)
-    const [sop] = await db.select().from(sops).where(eq(sops.id, sopId));
-    if (!sop || sop.status !== "active") continue;
+  for (const row of assignments) {
+    if (row.sopStatus !== "active") continue;
 
-    // Load SOP steps
-    const steps = await db
-      .select()
-      .from(sopSteps)
-      .where(eq(sopSteps.sopId, sopId));
-
-    if (steps.length === 0) continue;
-
-    // Resolve connector tool names for steps
-    const toolIds = steps
-      .map((s) => s.connectorToolId)
-      .filter((id): id is string => id !== null);
-
-    const toolNameMap = new Map<
-      string,
-      { slug: string; connectorSlug: string }
-    >();
-    for (const toolId of toolIds) {
-      const [tool] = await db
-        .select({
-          id: connectorTools.id,
-          slug: connectorTools.slug,
-          connectorSlug: connectors.slug,
-        })
-        .from(connectorTools)
-        .innerJoin(connectors, eq(connectorTools.connectorId, connectors.id))
-        .where(eq(connectorTools.id, toolId));
-
-      if (tool) {
-        toolNameMap.set(toolId, {
-          slug: tool.slug,
-          connectorSlug: tool.connectorSlug,
-        });
-      }
+    const existing = assignmentsByAgent.get(row.agentId);
+    if (existing) {
+      existing.sopIds.push(row.sopId);
+      existing.sopNames.push(row.sopName);
+      continue;
     }
 
-    // Load guardrails assigned to this agent
-    const kbAssignments = await db
-      .select({ knowledgeBaseId: agentKnowledgeBase.knowledgeBaseId })
-      .from(agentKnowledgeBase)
-      .where(eq(agentKnowledgeBase.agentId, agentId));
+    assignmentsByAgent.set(row.agentId, {
+      agentName: row.agentName,
+      orgId: row.orgId,
+      sopIds: [row.sopId],
+      sopNames: [row.sopName],
+    });
+  }
 
-    const guardrailRows = [];
-    for (const { knowledgeBaseId } of kbAssignments) {
-      const [kb] = await db
-        .select()
-        .from(knowledgeBase)
-        .where(eq(knowledgeBase.id, knowledgeBaseId));
-      if (kb && kb.type === "guardrail" && kb.isActive) {
-        guardrailRows.push(kb);
-      }
-    }
+  if (assignmentsByAgent.size === 0) {
+    console.log("  No active agent→SOP assignments found, skipping compilation");
+    return;
+  }
 
-    // Build compiler input
-    const trigger = ((sop.trigger as unknown) ?? {
-      type: "intent_detected",
-      config: { patterns: [] },
-    }) as Record<string, unknown>;
-    const metadata = (sop.metadata as Record<string, unknown>) ?? {
-      tags: [],
-    };
-
-    const sopResponse = {
-      id: sop.id,
-      name: sop.name,
-      slug: sop.slug,
-      description: sop.description,
-      status: sop.status as "active",
-      version: sop.version,
-      assignedAgents: [
-        {
-          id: agent.id,
-          name: agent.name,
-          modality: (agent.modality ?? "text") as "voice" | "text",
-        },
-      ],
-      sopTemplateId: sop.sopTemplateId,
-      template: null,
-      definition: {
-        schemaVersion: 1 as const,
-        trigger,
-        metadata,
-        steps: steps.map((s) => {
-          const toolInfo = s.connectorToolId
-            ? toolNameMap.get(s.connectorToolId)
-            : undefined;
-          return {
-            id: s.stepId,
-            order: s.order,
-            instruction: s.instruction,
-            required: s.required,
-            ...(s.notes ? { notes: s.notes } : {}),
-            ...(s.evalConfigId ? { evalConfigId: s.evalConfigId } : {}),
-            tool: toolInfo
-              ? {
-                  connectorToolId: s.connectorToolId!,
-                  resolvedName: `${toolInfo.connectorSlug}_${toolInfo.slug}`,
-                }
-              : undefined,
-          };
-        }),
-      },
-      createdBy: sop.createdBy,
-      createdAt: sop.createdAt.toISOString(),
-      updatedAt: sop.updatedAt?.toISOString() ?? null,
-    };
-
-    const guardrailResponses = guardrailRows.map((g) => ({
-      id: g.id,
-      type: g.type as "guardrail",
-      name: g.name,
-      slug: g.slug,
-      content: g.content,
-      description: g.description,
-      config: (g.config ?? {}) as Record<string, unknown>,
-      isActive: g.isActive,
-      assignedAgents: [],
-      createdBy: g.createdBy,
-      createdAt: g.createdAt.toISOString(),
-      updatedAt: g.updatedAt?.toISOString() ?? null,
-    }));
-
-    const compilerInput: CompilerInput = {
-      sops: [sopResponse as CompilerInput["sops"][number]],
-      guardrails: guardrailResponses,
-      agentConfig: {
-        id: agent.id,
-        name: agent.name,
-        model: "anthropic/claude-haiku-4-5-20251001",
-        description: agent.description ?? "AI customer support agent",
-        promptConfig: agent.promptConfig ?? {},
-        modelFamily: agent.modelFamily ?? "generic",
-        modality:
-          agent.modality === "voice" ? ("voice" as const) : ("text" as const),
-      },
-    };
-
+  for (const [agentId, data] of assignmentsByAgent) {
     try {
-      const ir = compile(compilerInput);
-
-      await db
-        .update(agents)
-        .set({
-          compiledInstructions: ir.systemPrompt,
-          compiledAt: new Date(),
-          compiledFrom: {
-            sops: ir.sops.map((s) => ({
-              sopId: s.id,
-              sopName: s.name,
-              stepCount: s.steps.length,
-            })),
-            guardrailIds: guardrailRows.map((g) => g.id),
-            toolCount: ir.tools.length,
-          },
-        })
-        .where(eq(agents.id, agentId));
+      const result = await compileAgent({
+        orgId: data.orgId,
+        agentId,
+        sopIds: data.sopIds,
+      });
 
       console.log(
-        `  Compiled ${agent.name} from SOP "${sop.name}" (${ir.systemPrompt.length} chars, ${ir.tools.length} tools)`,
+        `  Compiled ${data.agentName} from SOPs "${data.sopNames.join('", "')}" ` +
+          `(${result.ir.systemPrompt.length} chars, ${result.ir.tools.length} tools)`,
       );
     } catch (err) {
       console.warn(
-        `  Failed to compile ${agent.name}: ${err instanceof Error ? err.message : err}`,
+        `  Failed to compile ${data.agentName}: ${err instanceof Error ? err.message : err}`,
       );
     }
   }

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -201,11 +201,13 @@ export async function seedCompileAgents(db: SeedDb): Promise<void> {
           compiledInstructions: ir.systemPrompt,
           compiledAt: new Date(),
           compiledFrom: {
-            sopId: sop.id,
-            sopName: sop.name,
+            sops: ir.sops.map((s) => ({
+              sopId: s.id,
+              sopName: s.name,
+              stepCount: s.steps.length,
+            })),
             guardrailIds: guardrailRows.map((g) => g.id),
             toolCount: ir.tools.length,
-            stepCount: ir.sop.steps.length,
           },
         })
         .where(eq(agents.id, agentId));

--- a/modelguide-api/src/db/seed/seed-compile-agents.ts
+++ b/modelguide-api/src/db/seed/seed-compile-agents.ts
@@ -67,7 +67,9 @@ export async function seedCompileAgents(db: SeedDb): Promise<void> {
   }
 
   if (assignmentsByAgent.size === 0) {
-    console.log("  No active agent→SOP assignments found, skipping compilation");
+    console.log(
+      "  No active agent→SOP assignments found, skipping compilation",
+    );
     return;
   }
 

--- a/modelguide-api/src/features/compiler/compiler.routes.ts
+++ b/modelguide-api/src/features/compiler/compiler.routes.ts
@@ -32,7 +32,10 @@ const compileAgentQuerySchema = z.object({
 });
 
 const compileAgentBodySchema = z.object({
-  sopId: z.string().uuid().openapi({ description: "SOP ID to compile from" }),
+  sopIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .openapi({ description: "SOP IDs to compile from" }),
   model: z
     .string()
     .max(100)
@@ -120,7 +123,7 @@ router.openapi(compileRoute, async (c) => {
   const result = await compileAgent({
     orgId,
     agentId,
-    sopId: body.sopId,
+    sopIds: body.sopIds,
     agentModel: body.model,
     agentDescription: body.description,
     dryRun: dryRun === true,

--- a/modelguide-api/src/features/compiler/compiler.service.ts
+++ b/modelguide-api/src/features/compiler/compiler.service.ts
@@ -46,7 +46,7 @@ const promptConfigSchema = z
 interface CompileAgentInput {
   orgId: string;
   agentId: string;
-  sopId: string;
+  sopIds: string[];
   agentModel?: string;
   agentDescription?: string;
   dryRun?: boolean;
@@ -65,7 +65,8 @@ interface CompileAgentInput {
  * 4. Persists compiled_instructions, compiled_at, compiled_from
  */
 export async function compileAgent(input: CompileAgentInput) {
-  const { orgId, agentId, sopId, agentModel, agentDescription, dryRun } = input;
+  const { orgId, agentId, sopIds, agentModel, agentDescription, dryRun } =
+    input;
 
   // 1. Load agent
   const agent = await forOrg(orgId, async (tx) => {
@@ -87,8 +88,10 @@ export async function compileAgent(input: CompileAgentInput) {
     return row;
   });
 
-  // 2. Load SOP detail
-  const sopDetail = await getSopById(orgId, sopId);
+  // 2. Load SOP details in parallel
+  const sopDetails = await Promise.all(
+    sopIds.map((id) => getSopById(orgId, id)),
+  );
 
   // 3. Load active guardrails assigned to the agent
   const guardrails = await forOrg(orgId, async (tx) => {
@@ -158,8 +161,8 @@ export async function compileAgent(input: CompileAgentInput) {
   // 5. Load all active SOPs assigned to the agent (for intent classification)
   const agentSopRows = await resolveAgentSops(orgId, agentId);
 
-  // 6. Convert SOP DB result to SopDetailResponse shape
-  const sopResponse = {
+  // 6. Convert SOP DB results to SopDetailResponse shape
+  const sopResponses = sopDetails.map((sopDetail) => ({
     id: sopDetail.id,
     name: sopDetail.name,
     slug: sopDetail.slug,
@@ -177,14 +180,14 @@ export async function compileAgent(input: CompileAgentInput) {
     createdBy: sopDetail.createdBy,
     createdAt: sopDetail.createdAt.toISOString(),
     updatedAt: sopDetail.updatedAt?.toISOString() ?? null,
-  };
+  }));
 
   // 7. Agent modality for strategy selection (AC4)
   const modality: Modality = agent.modality === "voice" ? "voice" : "text";
 
   // 8. Run compiler
   const compilerInput: CompilerInput = {
-    sops: [sopResponse],
+    sops: sopResponses,
     guardrails: guardrailResponses,
     agentConfig: {
       id: agent.id,
@@ -202,13 +205,18 @@ export async function compileAgent(input: CompileAgentInput) {
 
   const ir = compile(compilerInput);
 
-  // 9. Build provenance metadata
+  // 9. Build provenance metadata (multi-SOP shape)
   const compiledFrom = {
-    sopId,
-    sopName: sopDetail.name,
+    sops: sopDetails.map((s) => {
+      const enriched = ir.sops.find((e) => e.id === s.id);
+      return {
+        sopId: s.id,
+        sopName: s.name,
+        stepCount: enriched?.steps.length ?? s.definition.steps.length,
+      };
+    }),
     guardrailIds: guardrails.map((g) => g.id),
     toolCount: ir.tools.length,
-    stepCount: ir.sop.steps.length,
   };
 
   // 10. Dry-run: return result without persisting
@@ -216,7 +224,7 @@ export async function compileAgent(input: CompileAgentInput) {
     log.info(
       {
         agentId,
-        sopId,
+        sopIds,
         promptLength: ir.systemPrompt.length,
         toolCount: ir.tools.length,
         guardrailCount: guardrails.length,
@@ -249,7 +257,7 @@ export async function compileAgent(input: CompileAgentInput) {
   if (ir.metadata?.warnings?.length) {
     for (const w of ir.metadata.warnings) {
       log.warn(
-        { agentId, sopId, warningCode: w.code, tokens: w.tokens },
+        { agentId, sopIds, warningCode: w.code, tokens: w.tokens },
         `compiler warning: ${w.message}`,
       );
     }
@@ -258,7 +266,7 @@ export async function compileAgent(input: CompileAgentInput) {
   log.info(
     {
       agentId,
-      sopId,
+      sopIds,
       promptLength: ir.systemPrompt.length,
       toolCount: ir.tools.length,
       guardrailCount: guardrails.length,

--- a/modelguide-api/src/features/compiler/core/compile.ts
+++ b/modelguide-api/src/features/compiler/core/compile.ts
@@ -27,7 +27,7 @@ const TOKENS_PER_TOOL_SCHEMA = 180;
  * @throws CompilerError on validation failures
  */
 export function compile(input: CompilerInput): CompilerIR {
-  const { sop, tools: parsedTools, guardrails } = parse(input);
+  const { sops, tools: parsedTools, guardrails } = parse(input);
 
   // Enrich tools with requiresConfirmation from the input map (AC6)
   const confirmMap = input.toolConfirmationMap ?? {};
@@ -36,7 +36,7 @@ export function compile(input: CompilerInput): CompilerIR {
     requiresConfirmation: confirmMap[t.resolvedName] ?? t.requiresConfirmation,
   }));
 
-  const ir = transform(sop, tools, guardrails, input.agentConfig);
+  const ir = transform(sops, tools, guardrails, input.agentConfig);
 
   // Select strategy based on model family + modality
   const { modelFamily, modality } = input.agentConfig;

--- a/modelguide-api/src/features/compiler/core/parse.ts
+++ b/modelguide-api/src/features/compiler/core/parse.ts
@@ -30,61 +30,61 @@ export class CompilerError extends Error {
 // ============================================================================
 
 /**
- * Validate exactly one SOP is provided, validate its definition,
- * and collect unique tool references.
+ * Validate one or more SOPs, validate each definition,
+ * and collect unique tool references (deduped across all SOPs).
  */
-export function parseSop(sops: SopDetailResponse[]): {
-  sop: SopDetailResponse;
+export function parseSops(sops: SopDetailResponse[]): {
+  sops: SopDetailResponse[];
   tools: ResolvedTool[];
 } {
-  // Phase 1: exactly one SOP
-  if (sops.length !== 1) {
+  if (sops.length === 0) {
     throw new CompilerError(
-      `Phase 1 compiler requires exactly one SOP, received ${sops.length}`,
+      "Compiler requires at least one SOP, received 0",
       "INVALID_SOP_COUNT",
     );
   }
 
-  const sop = sops[0];
-  const definition = sop.definition;
-
-  // Validate definition against Zod schema (catches invalid schemaVersion, etc.)
-  const result = sopDefinitionSchema.safeParse(definition);
-  if (!result.success) {
-    const issues = result.error.issues
-      .map((i) => `${i.path.join(".")}: ${i.message}`)
-      .join("; ");
-    throw new CompilerError(
-      `Invalid SOP definition: ${issues}`,
-      "INVALID_SOP_DEFINITION",
-    );
-  }
-
-  // Validate tool references: steps with a tool must have resolvedName
   const tools: ResolvedTool[] = [];
   const seenTools = new Set<string>();
 
-  for (const step of definition.steps) {
-    if (step.tool) {
-      if (!step.tool.resolvedName) {
-        throw new CompilerError(
-          `Step "${step.id}" has a tool reference but no resolvedName`,
-          "MISSING_RESOLVED_NAME",
-        );
-      }
+  for (const sop of sops) {
+    const definition = sop.definition;
 
-      if (!seenTools.has(step.tool.resolvedName)) {
-        seenTools.add(step.tool.resolvedName);
-        tools.push({
-          resolvedName: step.tool.resolvedName,
-          connectorToolId: step.tool.connectorToolId,
-          connectorId: step.tool.connectorId,
-        });
+    // Validate definition against Zod schema (catches invalid schemaVersion, etc.)
+    const result = sopDefinitionSchema.safeParse(definition);
+    if (!result.success) {
+      const issues = result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      throw new CompilerError(
+        `Invalid SOP definition for "${sop.name}" (${sop.id}): ${issues}`,
+        "INVALID_SOP_DEFINITION",
+      );
+    }
+
+    // Validate tool references: steps with a tool must have resolvedName
+    for (const step of definition.steps) {
+      if (step.tool) {
+        if (!step.tool.resolvedName) {
+          throw new CompilerError(
+            `Step "${step.id}" in SOP "${sop.name}" (${sop.id}) has a tool reference but no resolvedName`,
+            "MISSING_RESOLVED_NAME",
+          );
+        }
+
+        if (!seenTools.has(step.tool.resolvedName)) {
+          seenTools.add(step.tool.resolvedName);
+          tools.push({
+            resolvedName: step.tool.resolvedName,
+            connectorToolId: step.tool.connectorToolId,
+            connectorId: step.tool.connectorId,
+          });
+        }
       }
     }
   }
 
-  return { sop, tools };
+  return { sops, tools };
 }
 
 // ============================================================================
@@ -124,7 +124,7 @@ export function parseGuardrails(
  * Run the full parse stage.
  */
 export function parse(input: CompilerInput) {
-  const { sop, tools } = parseSop(input.sops);
+  const { sops, tools } = parseSops(input.sops);
   const guardrails = parseGuardrails(input.guardrails);
-  return { sop, tools, guardrails };
+  return { sops, tools, guardrails };
 }

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/generic-strategy.ts
@@ -45,31 +45,33 @@ export class GenericStrategy implements PromptStrategy {
     // 1. Agent description (preamble)
     sections.push(ir.agentConfig.description);
 
-    // 2. SOP context
-    sections.push(`## Workflow: ${ir.sop.name}`);
-    if (ir.sop.description) {
-      sections.push(ir.sop.description);
+    // 2. SOP sections — one per SOP
+    for (const sop of ir.sops) {
+      sections.push(`## Workflow: ${sop.name}`);
+      if (sop.description) {
+        sections.push(sop.description);
+      }
+
+      // Steps
+      const steps = sop.definition.steps;
+      if (steps.length > 0) {
+        const stepLines = steps
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((s) => {
+            const toolSuffix = s.tool?.resolvedName
+              ? ` → \`${s.tool.resolvedName}\``
+              : "";
+            const requiredTag = s.required ? " *(required)*" : "";
+            return `${s.order}. ${s.instruction}${toolSuffix}${requiredTag}`;
+          });
+        const enforcement =
+          "Follow these steps in order. Every step must be reflected in your response — do not skip steps.";
+        sections.push(`### Steps\n${enforcement}\n${stepLines.join("\n")}`);
+      }
     }
 
-    // 2b. Steps
-    const steps = ir.sop.definition.steps;
-    if (steps.length > 0) {
-      const stepLines = steps
-        .slice()
-        .sort((a, b) => a.order - b.order)
-        .map((s) => {
-          const toolSuffix = s.tool?.resolvedName
-            ? ` → \`${s.tool.resolvedName}\``
-            : "";
-          const requiredTag = s.required ? " *(required)*" : "";
-          return `${s.order}. ${s.instruction}${toolSuffix}${requiredTag}`;
-        });
-      const enforcement =
-        "Follow these steps in order. Every step must be reflected in your response — do not skip steps.";
-      sections.push(`### Steps\n${enforcement}\n${stepLines.join("\n")}`);
-    }
-
-    // 3. Tools
+    // 3. Tools (deduped across all SOPs — already deduped at parse stage)
     if (ir.tools.length > 0) {
       sections.push("## Tools");
       sections.push(ir.tools.map((t) => `- ${t.resolvedName}`).join("\n"));
@@ -94,11 +96,19 @@ export class GenericStrategy implements PromptStrategy {
       sections.push(guardrailSections.join("\n\n"));
     }
 
-    // 5. Escalation triggers
-    const triggers = ir.sop.definition.metadata.escalationTriggers;
-    if (triggers && triggers.length > 0) {
+    // 5. Escalation triggers — merged and deduped across all SOPs
+    const allTriggers = new Set<string>();
+    for (const sop of ir.sops) {
+      const triggers = sop.definition.metadata.escalationTriggers;
+      if (triggers) {
+        for (const t of triggers) {
+          allTriggers.add(t);
+        }
+      }
+    }
+    if (allTriggers.size > 0) {
       sections.push("## Escalation Triggers");
-      sections.push(triggers.map((t) => `- ${t}`).join("\n"));
+      sections.push([...allTriggers].map((t) => `- ${t}`).join("\n"));
     }
 
     const prompt = sections.join("\n\n");

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -66,8 +66,24 @@ export class GptVoiceStrategy implements PromptStrategy {
   readonly name = "GptVoiceStrategy";
 
   buildPrompt(ir: TransformResult): StrategyOutput {
-    const { agentConfig, sop, guardrails, tools } = ir;
+    const { agentConfig, sops, guardrails, tools } = ir;
     const warnings: CompilerWarning[] = [];
+
+    // Render one Conversation Flow section per SOP
+    const flowSections = sops.map((sop) =>
+      this.renderConversationFlow(sop.steps, sop.name),
+    );
+
+    // Merge escalation triggers across all SOPs (deduped)
+    const allTriggers = new Set<string>();
+    for (const sop of sops) {
+      const triggers = sop.definition.metadata?.escalationTriggers;
+      if (triggers) {
+        for (const t of triggers) {
+          allTriggers.add(t);
+        }
+      }
+    }
 
     const staticSections = [
       this.renderRoleAndObjective(agentConfig.description),
@@ -75,9 +91,9 @@ export class GptVoiceStrategy implements PromptStrategy {
       this.renderReferencePronunciations(),
       this.renderTools(tools, agentConfig.promptConfig, warnings),
       this.renderRules(guardrails),
-      this.renderConversationFlow(sop.steps),
+      ...flowSections,
       this.renderSafetyAndEscalation(
-        sop.definition.metadata?.escalationTriggers,
+        allTriggers.size > 0 ? [...allTriggers] : undefined,
       ),
     ].filter(Boolean);
 
@@ -203,9 +219,15 @@ export class GptVoiceStrategy implements PromptStrategy {
     return lines.join("\n");
   }
 
-  /** 6. Conversation Flow — AC15: SOP steps with GOAL/EXIT */
-  private renderConversationFlow(steps: EnrichedStep[]): string {
-    const lines: string[] = ["# Conversation Flow"];
+  /** 6. Conversation Flow — one per SOP, with SOP name in header */
+  private renderConversationFlow(
+    steps: EnrichedStep[],
+    sopName?: string,
+  ): string {
+    const header = sopName
+      ? `# Conversation Flow: ${sopName}`
+      : "# Conversation Flow";
+    const lines: string[] = [header];
     const sorted = steps.slice().sort((a, b) => a.order - b.order);
 
     for (let i = 0; i < sorted.length; i++) {

--- a/modelguide-api/src/features/compiler/core/transform.ts
+++ b/modelguide-api/src/features/compiler/core/transform.ts
@@ -70,15 +70,12 @@ function enrichStep(
 // ============================================================================
 
 /**
- * Transform a parsed SOP + guardrails into a CompilerIR.
+ * Enrich a single SOP into an EnrichedSop.
  */
-export function transform(
+function enrichSop(
   sop: SopDetailResponse,
-  tools: ResolvedTool[],
   guardrails: ParsedGuardrail[],
-  agentConfig: CompilerInput["agentConfig"],
-): TransformResult {
-  // Normalize and enrich each step
+): EnrichedSop {
   const normalizedSteps = sop.definition.steps
     .slice()
     .sort((a, b) => a.order - b.order)
@@ -88,14 +85,12 @@ export function transform(
     enrichStep(step, guardrails),
   );
 
-  // Normalize the definition for the enriched SOP
   const normalizedDefinition = {
     ...sop.definition,
     steps: normalizedSteps,
   };
 
-  // Assemble enriched SOP
-  const enrichedSop: EnrichedSop = {
+  return {
     id: sop.id,
     name: sop.name,
     slug: sop.slug,
@@ -103,10 +98,22 @@ export function transform(
     definition: normalizedDefinition,
     steps: enrichedSteps,
   };
+}
+
+/**
+ * Transform parsed SOPs + guardrails into a TransformResult.
+ */
+export function transform(
+  sops: SopDetailResponse[],
+  tools: ResolvedTool[],
+  guardrails: ParsedGuardrail[],
+  agentConfig: CompilerInput["agentConfig"],
+): TransformResult {
+  const enrichedSops = sops.map((sop) => enrichSop(sop, guardrails));
 
   return {
     agentConfig,
-    sop: enrichedSop,
+    sops: enrichedSops,
     tools,
     guardrails,
   };

--- a/modelguide-api/src/features/compiler/core/types.ts
+++ b/modelguide-api/src/features/compiler/core/types.ts
@@ -159,7 +159,7 @@ export interface CompilerMetadata {
 /** Output of transform() — structured data for strategies to build prompts from. */
 export interface TransformResult {
   agentConfig: CompilerInput["agentConfig"];
-  sop: EnrichedSop;
+  sops: EnrichedSop[];
   tools: ResolvedTool[];
   guardrails: ParsedGuardrail[];
 }

--- a/modelguide-api/src/features/compiler/emitters/mastra/index.ts
+++ b/modelguide-api/src/features/compiler/emitters/mastra/index.ts
@@ -31,11 +31,14 @@ export interface MastraEmitterResult {
  */
 export function toMastra(ir: CompilerIR): MastraEmitterResult {
   const agent = buildAgent(ir);
-  const workflows = buildWorkflows(
-    ir.sop.slug,
-    ir.sop.steps,
-    ir.agentConfig.id,
-  );
+
+  // Build workflows for each SOP
+  let workflows: Record<string, unknown> = {};
+  for (const sop of ir.sops) {
+    const sopWorkflows = buildWorkflows(sop.slug, sop.steps, ir.agentConfig.id);
+    workflows = { ...workflows, ...sopWorkflows };
+  }
+
   const tools = buildTools(ir.tools);
 
   return { agent, workflows, tools };

--- a/modelguide-api/src/features/sops/sops.schemas.ts
+++ b/modelguide-api/src/features/sops/sops.schemas.ts
@@ -177,7 +177,8 @@ export const updateSopSchema = z
       data.name !== undefined ||
       data.description !== undefined ||
       data.definition !== undefined ||
-      data.version !== undefined,
+      data.version !== undefined ||
+      data.agentIds !== undefined,
     { message: "At least one field must be provided" },
   );
 

--- a/modelguide-api/src/features/sops/sops.schemas.ts
+++ b/modelguide-api/src/features/sops/sops.schemas.ts
@@ -169,6 +169,7 @@ export const updateSopSchema = z
     description: z.string().max(2000).optional(),
     definition: sopDefinitionWriteSchema.optional(),
     version: z.string().max(50).optional(),
+    agentIds: z.array(z.string().uuid()).optional(),
   })
   .strict()
   .refine(

--- a/modelguide-api/src/features/sops/sops.service.ts
+++ b/modelguide-api/src/features/sops/sops.service.ts
@@ -588,6 +588,7 @@ export async function updateSop(
   if (data.name !== undefined) updateData.name = data.name;
   if (data.description !== undefined) updateData.description = data.description;
   if (data.version !== undefined) updateData.version = data.version;
+  if (data.agentIds !== undefined) updateData.updatedAt = new Date();
 
   return forOrg(orgId, async (tx) => {
     await requireSopExists(tx, sopId);

--- a/modelguide-api/src/features/sops/sops.service.ts
+++ b/modelguide-api/src/features/sops/sops.service.ts
@@ -580,6 +580,7 @@ export async function updateSop(
     description?: string;
     definition?: SopSchema;
     version?: string;
+    agentIds?: string[];
   },
 ) {
   const updateData: Partial<NewSop> = {};
@@ -613,6 +614,10 @@ export async function updateSop(
 
     if (!updated) {
       throw Errors.sopNotFound(sopId);
+    }
+
+    if (data.agentIds !== undefined) {
+      await setAssignedAgentsInternal(tx, sopId, data.agentIds);
     }
 
     return updated;

--- a/modelguide-api/tests/integration/compiler/mastra/appointment-booking-e2e.test.ts
+++ b/modelguide-api/tests/integration/compiler/mastra/appointment-booking-e2e.test.ts
@@ -174,7 +174,7 @@ describe("Appointment Booking E2E: second SOP dry run", () => {
       const compileResult = await compileAgent({
         orgId,
         agentId,
-        sopId: sop.id,
+        sopIds: [sop.id],
         agentModel: "anthropic/claude-haiku-4-5-20251001",
         agentDescription:
           "You are a friendly receptionist handling appointment bookings over the phone.",

--- a/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
+++ b/modelguide-api/tests/integration/compiler/mastra/compile-to-mastra.test.ts
@@ -51,7 +51,7 @@ describe("compile() + toMastra() full pipeline", () => {
 
   it("AC 4: compile() returns a CompilerIR with all fields", () => {
     expect(ir.agentConfig).toBeDefined();
-    expect(ir.sop).toBeDefined();
+    expect(ir.sops).toBeDefined();
     expect(ir.systemPrompt).toBeTruthy();
     expect(ir.tools).toHaveLength(2);
     expect(ir.guardrails).toHaveLength(5);
@@ -84,12 +84,12 @@ describe("compile() + toMastra() full pipeline", () => {
   });
 
   it("IR has 5 enriched steps with correct types", () => {
-    expect(ir.sop.steps).toHaveLength(5);
-    expect(ir.sop.steps[0].type).toBe("llm"); // classify-intent
-    expect(ir.sop.steps[1].type).toBe("llm"); // extract-order-number
-    expect(ir.sop.steps[2].type).toBe("tool"); // lookup-order
-    expect(ir.sop.steps[3].type).toBe("llm"); // compose-reply
-    expect(ir.sop.steps[4].type).toBe("tool"); // escalate-if-needed
+    expect(ir.sops[0].steps).toHaveLength(5);
+    expect(ir.sops[0].steps[0].type).toBe("llm"); // classify-intent
+    expect(ir.sops[0].steps[1].type).toBe("llm"); // extract-order-number
+    expect(ir.sops[0].steps[2].type).toBe("tool"); // lookup-order
+    expect(ir.sops[0].steps[3].type).toBe("llm"); // compose-reply
+    expect(ir.sops[0].steps[4].type).toBe("tool"); // escalate-if-needed
   });
 
   it("system prompt contains all guardrails", () => {
@@ -137,13 +137,13 @@ describe("AC 21: recompile with modified guardrail", () => {
     expect(modifiedIr.systemPrompt).toContain("New Critical Rule");
 
     // All step scoped prompts should include the new critical guardrail
-    for (const step of modifiedIr.sop.steps) {
+    for (const step of modifiedIr.sops[0].steps) {
       expect(step.scopedPrompt).toContain("New Critical Rule");
       expect(step.matchedGuardrailIds).toContain("gr-new-critical");
     }
 
     // Original should NOT have it
-    for (const step of originalIr.sop.steps) {
+    for (const step of originalIr.sops[0].steps) {
       expect(step.scopedPrompt).not.toContain("New Critical Rule");
     }
   });
@@ -152,7 +152,7 @@ describe("AC 21: recompile with modified guardrail", () => {
 describe("AC 22: recompile with added/removed step", () => {
   it("adding a step produces more enriched steps", () => {
     const originalIr = compile(makeInput());
-    expect(originalIr.sop.steps).toHaveLength(5);
+    expect(originalIr.sops[0].steps).toHaveLength(5);
 
     // Clone SOP and add a step
     const modifiedSop: SopDetailResponse = JSON.parse(
@@ -166,9 +166,9 @@ describe("AC 22: recompile with added/removed step", () => {
     });
 
     const modifiedIr = compile(makeInput(modifiedSop));
-    expect(modifiedIr.sop.steps).toHaveLength(6);
-    expect(modifiedIr.sop.steps[5].id).toBe("confirm-reply");
-    expect(modifiedIr.sop.steps[5].type).toBe("llm");
+    expect(modifiedIr.sops[0].steps).toHaveLength(6);
+    expect(modifiedIr.sops[0].steps[5].id).toBe("confirm-reply");
+    expect(modifiedIr.sops[0].steps[5].type).toBe("llm");
   });
 
   it("removing a step produces fewer enriched steps", () => {
@@ -181,8 +181,8 @@ describe("AC 22: recompile with added/removed step", () => {
     );
 
     const modifiedIr = compile(makeInput(modifiedSop));
-    expect(modifiedIr.sop.steps).toHaveLength(4);
-    expect(modifiedIr.sop.steps.map((s) => s.id)).not.toContain(
+    expect(modifiedIr.sops[0].steps).toHaveLength(4);
+    expect(modifiedIr.sops[0].steps.map((s) => s.id)).not.toContain(
       "escalate-if-needed",
     );
     // Tools should only have store_look_up_order now
@@ -197,9 +197,9 @@ describe("AC 20: E2E compile email WISMO SOP → Mastra agent + workflow", () =>
   const result = toMastra(ir);
 
   it("compiles with correct SOP identity", () => {
-    expect(ir.sop.name).toBe("Email — Order Not Arrived");
-    expect(ir.sop.slug).toBe("email-order-not-arrived");
-    expect(ir.sop.steps).toHaveLength(5);
+    expect(ir.sops[0].name).toBe("Email — Order Not Arrived");
+    expect(ir.sops[0].slug).toBe("email-order-not-arrived");
+    expect(ir.sops[0].steps).toHaveLength(5);
     expect(ir.tools.map((t) => t.resolvedName)).toEqual([
       "store_look_up_order",
       "helpdesk_create_ticket",
@@ -208,7 +208,7 @@ describe("AC 20: E2E compile email WISMO SOP → Mastra agent + workflow", () =>
   });
 
   it("enriched steps have correct types and guardrail match counts", () => {
-    const stepDetails = ir.sop.steps.map((s) => ({
+    const stepDetails = ir.sops[0].steps.map((s) => ({
       id: s.id,
       type: s.type,
       matchCount: s.matchedGuardrailIds.length,
@@ -247,7 +247,7 @@ describe("AC 20: E2E compile email WISMO SOP → Mastra agent + workflow", () =>
   });
 
   it("compose-reply scoped prompt has correct structure", () => {
-    const composeStep = ir.sop.steps.find((s) => s.id === "compose-reply");
+    const composeStep = ir.sops[0].steps.find((s) => s.id === "compose-reply");
     expect(composeStep).toBeDefined();
 
     const prompt = composeStep!.scopedPrompt;

--- a/modelguide-api/tests/integration/compiler/mastra/compiler-eval-e2e.test.ts
+++ b/modelguide-api/tests/integration/compiler/mastra/compiler-eval-e2e.test.ts
@@ -208,7 +208,7 @@ describe("Compiler E2E: compile → run → store → eval", () => {
       const compileResult = await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId: sop.id,
+        sopIds: [sop.id],
         agentModel: "anthropic/claude-haiku-4-5-20251001",
         agentDescription: agentConfig.description,
       });

--- a/modelguide-api/tests/integration/evals/eval-suites-workflows.test.ts
+++ b/modelguide-api/tests/integration/evals/eval-suites-workflows.test.ts
@@ -384,7 +384,7 @@ describe("Workflow 3: Archive prevents execution", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
         agentModel: "anthropic/claude-haiku-4-5-20251001",
         agentDescription: agentConfig.description,
       });
@@ -499,7 +499,7 @@ describe("Workflow 4: Validation gauntlet", () => {
     await compileAgent({
       orgId: ctx.orgId,
       agentId: ctx.agentId,
-      sopId,
+      sopIds: [sopId],
       agentModel: "anthropic/claude-haiku-4-5-20251001",
       agentDescription: agentConfig.description,
     });
@@ -548,7 +548,7 @@ describe("Workflow 4: Validation gauntlet", () => {
     await compileAgent({
       orgId: ctx.orgId,
       agentId: ctx.agentId,
-      sopId,
+      sopIds: [sopId],
       agentModel: "anthropic/claude-haiku-4-5-20251001",
       agentDescription: agentConfig.description,
     });
@@ -653,7 +653,7 @@ describe("Workflow 5: Full lifecycle with cleanup", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
         agentModel: "anthropic/claude-haiku-4-5-20251001",
         agentDescription: agentConfig.description,
       });
@@ -728,7 +728,7 @@ describe("Workflow 6: Technical failure → completed_with_errors", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
         agentModel: "anthropic/claude-haiku-4-5-20251001",
         agentDescription: agentConfig.description,
       });

--- a/modelguide-api/tests/integration/evals/wismo-mastra-e2e.test.ts
+++ b/modelguide-api/tests/integration/evals/wismo-mastra-e2e.test.ts
@@ -233,7 +233,7 @@ describe("simulate-and-run validation", () => {
     await compileAgent({
       orgId: ctx.orgId,
       agentId: ctx.agentId,
-      sopId,
+      sopIds: [sopId],
     });
 
     const suite = await initSuiteFromSop(ctx.orgId, ctx.agentId, sopId);
@@ -275,7 +275,7 @@ describe("simulate-and-run E2E pipeline", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
       });
 
       // 2. Init eval suite from SOP (auto-generates evaluators)
@@ -410,7 +410,7 @@ describe("simulate-and-run E2E pipeline", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
       });
 
       // 2. Init eval suite from SOP
@@ -550,7 +550,7 @@ describe("simulate-and-run E2E pipeline", () => {
       await compileAgent({
         orgId: ctx.orgId,
         agentId: ctx.agentId,
-        sopId,
+        sopIds: [sopId],
       });
 
       // 2. Init eval suite from SOP

--- a/modelguide-api/tests/integration/sops.test.ts
+++ b/modelguide-api/tests/integration/sops.test.ts
@@ -363,6 +363,31 @@ describe("PATCH /api/sops/:id", () => {
     expect(body.definition.steps).toHaveLength(2);
   });
 
+  test("updates assigned agents with agentIds only (200)", async () => {
+    const createRes = await request("/api/sops", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({
+        name: "Patch Agent Assignments",
+        slug: `patch-agent-assignments-${Date.now()}`,
+        definition: validDefinition,
+        agentIds: [s.orgAAgentId],
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    createdSopIds.push(created.id);
+
+    const patchRes = await request(`/api/sops/${created.id}`, {
+      method: "PATCH",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ agentIds: [] }),
+    });
+    expect(patchRes.status).toBe(200);
+    const body = await patchRes.json();
+    expect(body.assignedAgents).toEqual([]);
+  });
+
   test("returns 404 for non-existent SOP when definition is provided", async () => {
     const fakeId = "00000000-0000-0000-0000-000000000000";
     const res = await request(`/api/sops/${fakeId}`, {

--- a/modelguide-api/tests/unit/compiler/parse.test.ts
+++ b/modelguide-api/tests/unit/compiler/parse.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "bun:test";
 import {
   CompilerError,
   parseGuardrails,
-  parseSop,
+  parseSops,
 } from "@features/compiler/core/parse";
 import type {
   KnowledgeBaseDetailResponse,
@@ -23,10 +23,10 @@ function cloneSop(sop: SopDetailResponse): SopDetailResponse {
   return JSON.parse(JSON.stringify(sop));
 }
 
-describe("parseSop", () => {
+describe("parseSops", () => {
   it("AC 4: accepts a valid SOP and returns tools", () => {
-    const { sop, tools } = parseSop([emailOrderNotArrivedSop]);
-    expect(sop.id).toBe("sop-email-order-not-arrived-001");
+    const { sops, tools } = parseSops([emailOrderNotArrivedSop]);
+    expect(sops[0].id).toBe("sop-email-order-not-arrived-001");
     expect(tools).toHaveLength(2);
     expect(tools.map((t) => t.resolvedName)).toEqual([
       "store_look_up_order",
@@ -34,23 +34,21 @@ describe("parseSop", () => {
     ]);
   });
 
-  it("AC 11: tools array has no duplicates", () => {
-    // Create a SOP with duplicate tool references
-    const sop = cloneSop(emailOrderNotArrivedSop);
-    // Add another step referencing the same tool
-    sop.definition.steps.push({
-      id: "extra-lookup",
-      order: 6,
-      instruction: "Look up the order again",
-      required: false,
-      tool: {
-        connectorToolId: "00000000-0000-0000-0000-000000000001",
-        connectorId: "00000000-0000-0000-0000-000000000010",
-        resolvedName: "store_look_up_order",
-      },
-    });
+  it("accepts multiple SOPs", () => {
+    const sop2 = cloneSop(emailOrderNotArrivedSop);
+    sop2.id = "sop-2";
+    sop2.name = "Second SOP";
+    const { sops } = parseSops([emailOrderNotArrivedSop, sop2]);
+    expect(sops).toHaveLength(2);
+  });
 
-    const { tools } = parseSop([sop]);
+  it("AC 11: tools array has no duplicates across SOPs", () => {
+    // Create a second SOP referencing the same tools
+    const sop2 = cloneSop(emailOrderNotArrivedSop);
+    sop2.id = "sop-dup";
+    sop2.name = "Dup SOP";
+
+    const { tools } = parseSops([emailOrderNotArrivedSop, sop2]);
     const resolvedNames = tools.map((t) => t.resolvedName);
     expect(resolvedNames).toEqual([
       "store_look_up_order",
@@ -65,17 +63,14 @@ describe("parseSop", () => {
       step.tool = undefined;
     }
 
-    const { sop: parsed, tools } = parseSop([sop]);
-    expect(parsed.id).toBe("sop-email-order-not-arrived-001");
+    const { sops, tools } = parseSops([sop]);
+    expect(sops[0].id).toBe("sop-email-order-not-arrived-001");
     expect(tools).toHaveLength(0);
   });
 
-  it("rejects when not exactly one SOP is provided", () => {
-    expect(() => parseSop([])).toThrow(CompilerError);
-    expect(() => parseSop([])).toThrow("exactly one SOP");
-    expect(() =>
-      parseSop([emailOrderNotArrivedSop, emailOrderNotArrivedSop]),
-    ).toThrow("exactly one SOP");
+  it("rejects when zero SOPs are provided", () => {
+    expect(() => parseSops([])).toThrow(CompilerError);
+    expect(() => parseSops([])).toThrow("at least one SOP");
   });
 
   it("AC 1: rejects an SOP with invalid schemaVersion", () => {
@@ -83,8 +78,8 @@ describe("parseSop", () => {
     // @ts-expect-error — intentionally invalid
     sop.definition.schemaVersion = 2;
 
-    expect(() => parseSop([sop])).toThrow(CompilerError);
-    expect(() => parseSop([sop])).toThrow("Invalid SOP definition");
+    expect(() => parseSops([sop])).toThrow(CompilerError);
+    expect(() => parseSops([sop])).toThrow("Invalid SOP definition");
   });
 
   it("AC 2: rejects a step with tool but no resolvedName", () => {
@@ -97,8 +92,8 @@ describe("parseSop", () => {
       (lookupStep.tool as Record<string, unknown>).resolvedName = undefined;
     }
 
-    expect(() => parseSop([sop])).toThrow(CompilerError);
-    expect(() => parseSop([sop])).toThrow("no resolvedName");
+    expect(() => parseSops([sop])).toThrow(CompilerError);
+    expect(() => parseSops([sop])).toThrow("no resolvedName");
   });
 });
 

--- a/modelguide-api/tests/unit/compiler/prompt-builder.test.ts
+++ b/modelguide-api/tests/unit/compiler/prompt-builder.test.ts
@@ -44,15 +44,17 @@ const makeIr = (toolsOverride?: ResolvedTool[]): TransformResult => ({
     modelFamily: "generic",
     modality: "text",
   },
-  sop: {
-    id: emailOrderNotArrivedSop.id,
-    name: emailOrderNotArrivedSop.name,
-    slug: emailOrderNotArrivedSop.slug,
-    description: emailOrderNotArrivedSop.description,
-    definition:
-      emailOrderNotArrivedSop.definition as TransformResult["sop"]["definition"],
-    steps: [],
-  },
+  sops: [
+    {
+      id: emailOrderNotArrivedSop.id,
+      name: emailOrderNotArrivedSop.name,
+      slug: emailOrderNotArrivedSop.slug,
+      description: emailOrderNotArrivedSop.description,
+      definition:
+        emailOrderNotArrivedSop.definition as TransformResult["sops"][number]["definition"],
+      steps: [],
+    },
+  ],
   tools: toolsOverride ?? sampleTools,
   guardrails: parsedGuardrails,
 });

--- a/modelguide-api/tests/unit/compiler/transform.test.ts
+++ b/modelguide-api/tests/unit/compiler/transform.test.ts
@@ -5,12 +5,12 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { parseGuardrails, parseSop } from "@features/compiler/core/parse";
+import { parseGuardrails, parseSops } from "@features/compiler/core/parse";
 import { transform } from "@features/compiler/core/transform";
 import { emailOrderNotArrivedSop } from "../../fixtures/compiler/email-wismo-sop";
 import { sampleGuardrails } from "../../fixtures/compiler/sample-guardrails";
 
-const { sop, tools } = parseSop([emailOrderNotArrivedSop]);
+const { sops, tools } = parseSops([emailOrderNotArrivedSop]);
 const guardrails = parseGuardrails(sampleGuardrails);
 const agentConfig = {
   id: "test-agent",
@@ -22,48 +22,52 @@ const agentConfig = {
   modality: "text" as const,
 };
 
-const ir = transform(sop, tools, guardrails, agentConfig);
+const ir = transform(sops, tools, guardrails, agentConfig);
 
 describe("transform — step types", () => {
   it("AC 5: step type is 'tool' when step has tool reference", () => {
-    const lookupStep = ir.sop.steps.find((s) => s.id === "lookup-order");
+    const lookupStep = ir.sops[0].steps.find((s) => s.id === "lookup-order");
     expect(lookupStep?.type).toBe("tool");
 
-    const escalateStep = ir.sop.steps.find(
+    const escalateStep = ir.sops[0].steps.find(
       (s) => s.id === "escalate-if-needed",
     );
     expect(escalateStep?.type).toBe("tool");
   });
 
   it("AC 5: step type is 'llm' when step has no tool reference", () => {
-    const classifyStep = ir.sop.steps.find((s) => s.id === "classify-intent");
+    const classifyStep = ir.sops[0].steps.find(
+      (s) => s.id === "classify-intent",
+    );
     expect(classifyStep?.type).toBe("llm");
 
-    const extractStep = ir.sop.steps.find(
+    const extractStep = ir.sops[0].steps.find(
       (s) => s.id === "extract-order-number",
     );
     expect(extractStep?.type).toBe("llm");
 
-    const composeStep = ir.sop.steps.find((s) => s.id === "compose-reply");
+    const composeStep = ir.sops[0].steps.find((s) => s.id === "compose-reply");
     expect(composeStep?.type).toBe("llm");
   });
 });
 
 describe("transform — enriched steps", () => {
   it("steps are ordered by `order` field", () => {
-    const orders = ir.sop.steps.map((s) => s.order);
+    const orders = ir.sops[0].steps.map((s) => s.order);
     expect(orders).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("each step has a scopedPrompt", () => {
-    for (const step of ir.sop.steps) {
+    for (const step of ir.sops[0].steps) {
       expect(step.scopedPrompt).toBeTruthy();
       expect(step.scopedPrompt).toContain(`## Current Step: ${step.id}`);
     }
   });
 
   it("AC 9: matchedGuardrailIds contains exactly the matched guardrail IDs", () => {
-    const classifyStep = ir.sop.steps.find((s) => s.id === "classify-intent");
+    const classifyStep = ir.sops[0].steps.find(
+      (s) => s.id === "classify-intent",
+    );
     // Critical guardrails always present
     expect(classifyStep?.matchedGuardrailIds).toContain("gr-tone-001");
     expect(classifyStep?.matchedGuardrailIds).toContain("gr-delivery-sla-001");
@@ -91,7 +95,7 @@ describe("transform — result structure", () => {
   });
 
   it("IR has sop metadata", () => {
-    expect(ir.sop.id).toBe("sop-email-order-not-arrived-001");
-    expect(ir.sop.slug).toBe("email-order-not-arrived");
+    expect(ir.sops[0].id).toBe("sop-email-order-not-arrived-001");
+    expect(ir.sops[0].slug).toBe("email-order-not-arrived");
   });
 });

--- a/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
+++ b/modelguide-api/tests/unit/compiler/workflow-builder.test.ts
@@ -29,8 +29,8 @@ const ir = compile(input);
 
 describe("buildWorkflows", () => {
   const workflows = buildWorkflows(
-    ir.sop.slug,
-    ir.sop.steps,
+    ir.sops[0].slug,
+    ir.sops[0].steps,
     ir.agentConfig.id,
   );
 
@@ -47,7 +47,7 @@ describe("buildWorkflows", () => {
   });
 
   it("handles single-step SOP", () => {
-    const singleStep = [ir.sop.steps[0]];
+    const singleStep = [ir.sops[0].steps[0]];
     const wfs = buildWorkflows("single-step", singleStep, "test-agent");
     expect(Object.keys(wfs)).toHaveLength(1);
     expect(wfs["single-step"]).toBeDefined();

--- a/modelguide-ui/src/features/prompt-compiler/components/compile-dialog.test.tsx
+++ b/modelguide-ui/src/features/prompt-compiler/components/compile-dialog.test.tsx
@@ -106,14 +106,8 @@ describe('CompileDialog', () => {
 
       expect(screen.getByText('Compile Prompt')).toBeInTheDocument()
       expect(
-        screen.getByText('Select an SOP and preview the compiled system prompt.'),
+        screen.getByText('Select SOPs and preview the compiled system prompt.'),
       ).toBeInTheDocument()
-    })
-
-    it('shows SOP select with placeholder', () => {
-      render(<CompileDialog {...defaultProps} />, { wrapper })
-
-      expect(screen.getByText('Select an SOP...')).toBeInTheDocument()
     })
 
     it('disables Apply button before preview', () => {
@@ -132,11 +126,11 @@ describe('CompileDialog', () => {
   })
 
   describe('SOP selection', () => {
-    it('shows only SOPs assigned to the current agent', async () => {
+    it('shows only SOPs assigned to the current agent as checkboxes', async () => {
       render(<CompileDialog {...defaultProps} />, { wrapper })
 
       await waitFor(() => {
-        expect(screen.getByText('WISMO Flow (active)')).toBeInTheDocument()
+        expect(screen.getByText('WISMO Flow')).toBeInTheDocument()
       })
 
       // SOP assigned to 'other-agent' should not appear
@@ -153,16 +147,18 @@ describe('CompileDialog', () => {
       })
     })
 
-    it('pre-selects SOP when preselectedSopId is provided', async () => {
+    it('pre-selects SOPs when preselectedSopIds is provided', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
-      // Wait for SOPs to load, then verify the select has the preselected value
       await waitFor(() => {
-        const select = screen.getByLabelText('SOP') as HTMLSelectElement
-        expect(select.value).toBe('00000000-0000-0000-0000-000000000050')
+        const checkbox = screen.getByText('WISMO Flow').closest('label')?.querySelector('input')
+        expect(checkbox).toBeChecked()
       })
     })
   })
@@ -170,7 +166,10 @@ describe('CompileDialog', () => {
   describe('preview flow', () => {
     it('calls dry-run compile when Preview is clicked', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
@@ -180,7 +179,7 @@ describe('CompileDialog', () => {
         expect(mockPost).toHaveBeenCalledWith(
           'agents/agent-1/compile',
           expect.objectContaining({
-            json: { sopId: '00000000-0000-0000-0000-000000000050' },
+            json: { sopIds: ['00000000-0000-0000-0000-000000000050'] },
             searchParams: { dryRun: 'true' },
           }),
         )
@@ -189,7 +188,10 @@ describe('CompileDialog', () => {
 
     it('shows summary bar after successful preview', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
@@ -202,7 +204,10 @@ describe('CompileDialog', () => {
 
     it('shows compiled prompt viewer after preview', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
@@ -215,7 +220,10 @@ describe('CompileDialog', () => {
 
     it('enables Apply button after successful preview', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
@@ -233,7 +241,7 @@ describe('CompileDialog', () => {
         <CompileDialog
           {...defaultProps}
           currentPrompt="Old prompt content"
-          preselectedSopId="00000000-0000-0000-0000-000000000050"
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
         />,
         { wrapper },
       )
@@ -255,7 +263,7 @@ describe('CompileDialog', () => {
         <CompileDialog
           {...defaultProps}
           currentPrompt={null}
-          preselectedSopId="00000000-0000-0000-0000-000000000050"
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
         />,
         { wrapper },
       )
@@ -276,7 +284,7 @@ describe('CompileDialog', () => {
         <CompileDialog
           {...defaultProps}
           currentPrompt="Same content"
-          preselectedSopId="00000000-0000-0000-0000-000000000050"
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
         />,
         { wrapper },
       )
@@ -299,7 +307,10 @@ describe('CompileDialog', () => {
   describe('apply flow', () => {
     it('calls compile without dryRun when Apply is clicked', async () => {
       render(
-        <CompileDialog {...defaultProps} preselectedSopId="00000000-0000-0000-0000-000000000050" />,
+        <CompileDialog
+          {...defaultProps}
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
+        />,
         { wrapper },
       )
 
@@ -317,7 +328,7 @@ describe('CompileDialog', () => {
         expect(mockPost).toHaveBeenCalledWith(
           'agents/agent-1/compile',
           expect.objectContaining({
-            json: { sopId: '00000000-0000-0000-0000-000000000050' },
+            json: { sopIds: ['00000000-0000-0000-0000-000000000050'] },
           }),
         )
       })
@@ -334,7 +345,7 @@ describe('CompileDialog', () => {
         <CompileDialog
           {...defaultProps}
           onClose={onClose}
-          preselectedSopId="00000000-0000-0000-0000-000000000050"
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
         />,
         { wrapper },
       )
@@ -353,22 +364,17 @@ describe('CompileDialog', () => {
   })
 
   describe('state reset on close', () => {
-    it('resets SOP selection to preselected value on close', () => {
+    it('resets state on close', () => {
       const onClose = vi.fn()
 
       render(
         <CompileDialog
           {...defaultProps}
           onClose={onClose}
-          preselectedSopId="00000000-0000-0000-0000-000000000050"
+          preselectedSopIds={['00000000-0000-0000-0000-000000000050']}
         />,
         { wrapper },
       )
-
-      // Change selection
-      const select = screen.getByLabelText('SOP') as HTMLSelectElement
-      fireEvent.change(select, { target: { value: '' } })
-      expect(select.value).toBe('')
 
       // Close dialog (via the X button, which triggers handleClose)
       fireEvent.click(screen.getByLabelText('Close dialog'))

--- a/modelguide-ui/src/features/prompt-compiler/components/compile-dialog.tsx
+++ b/modelguide-ui/src/features/prompt-compiler/components/compile-dialog.tsx
@@ -1,11 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { diffLines } from 'diff'
 import { AlertCircle, AlertTriangle, CheckCircle } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '~/components/ui/button'
 import { Dialog } from '~/components/ui/dialog'
-import { Select } from '~/components/ui/select'
 import { Spinner } from '~/components/ui/spinner'
 import { api } from '~/lib/api'
 import { cn } from '~/lib/cn'
@@ -21,7 +20,7 @@ interface CompileDialogProps {
   onClose: () => void
   agentId: string
   currentPrompt: string | null
-  preselectedSopId?: string
+  preselectedSopIds?: string[]
 }
 
 export function CompileDialog({
@@ -29,10 +28,12 @@ export function CompileDialog({
   onClose,
   agentId,
   currentPrompt,
-  preselectedSopId,
+  preselectedSopIds,
 }: CompileDialogProps) {
   const queryClient = useQueryClient()
-  const [selectedSopId, setSelectedSopId] = useState(preselectedSopId ?? '')
+  const [selectedSopIds, setSelectedSopIds] = useState<Set<string>>(
+    () => new Set(preselectedSopIds ?? []),
+  )
   const [previewResult, setPreviewResult] = useState<CompileResponse | null>(null)
   const [activeTab, setActiveTab] = useState<'prompt' | 'changes'>('prompt')
 
@@ -47,12 +48,27 @@ export function CompileDialog({
   const agentSops =
     sopsData?.data.filter((sop) => sop.assignedAgents.some((a) => a.id === agentId)) ?? []
 
+  const toggleSop = useCallback((sopId: string) => {
+    setSelectedSopIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(sopId)) {
+        next.delete(sopId)
+      } else {
+        next.add(sopId)
+      }
+      return next
+    })
+    setPreviewResult(null)
+  }, [])
+
+  const sopIdsArray = useMemo(() => [...selectedSopIds], [selectedSopIds])
+
   // Dry-run compile (preview)
   const previewMutation = useMutation({
-    mutationFn: (sopId: string) =>
+    mutationFn: (sopIds: string[]) =>
       api
         .post(`agents/${agentId}/compile`, {
-          json: { sopId },
+          json: { sopIds },
           searchParams: { dryRun: 'true' },
         })
         .json<CompileResponse>(),
@@ -64,8 +80,8 @@ export function CompileDialog({
 
   // Real compile (persist)
   const applyMutation = useMutation({
-    mutationFn: (sopId: string) =>
-      api.post(`agents/${agentId}/compile`, { json: { sopId } }).json<CompileResponse>(),
+    mutationFn: (sopIds: string[]) =>
+      api.post(`agents/${agentId}/compile`, { json: { sopIds } }).json<CompileResponse>(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', agentId] })
       toast.success('Prompt compiled successfully')
@@ -75,7 +91,7 @@ export function CompileDialog({
 
   function handleClose() {
     setPreviewResult(null)
-    setSelectedSopId(preselectedSopId ?? '')
+    setSelectedSopIds(new Set(preselectedSopIds ?? []))
     setActiveTab('prompt')
     previewMutation.reset()
     applyMutation.reset()
@@ -83,13 +99,13 @@ export function CompileDialog({
   }
 
   function handlePreview() {
-    if (!selectedSopId) return
-    previewMutation.mutate(selectedSopId)
+    if (sopIdsArray.length === 0) return
+    previewMutation.mutate(sopIdsArray)
   }
 
   function handleApply() {
-    if (!selectedSopId) return
-    applyMutation.mutate(selectedSopId)
+    if (sopIdsArray.length === 0) return
+    applyMutation.mutate(sopIdsArray)
   }
 
   const hasChanges =
@@ -119,39 +135,43 @@ export function CompileDialog({
       open={open}
       onClose={handleClose}
       title="Compile Prompt"
-      description="Select an SOP and preview the compiled system prompt."
+      description="Select SOPs and preview the compiled system prompt."
       className="max-w-4xl max-h-[85vh] overflow-hidden"
     >
       <div className="flex flex-col gap-4 min-h-0">
-        {/* Config bar */}
-        <div className="flex items-end gap-3 shrink-0">
-          <div className="flex-1">
-            <Select
-              label="SOP"
-              value={selectedSopId}
-              onChange={(e) => {
-                setSelectedSopId(e.target.value)
-                setPreviewResult(null)
-                previewMutation.reset()
-              }}
-              disabled={previewMutation.isPending || applyMutation.isPending}
-            >
-              <option value="">Select an SOP...</option>
-              {sopsLoading ? (
-                <option disabled>Loading...</option>
-              ) : (
-                agentSops.map((sop) => (
-                  <option key={sop.id} value={sop.id}>
-                    {sop.name} ({sop.status})
-                  </option>
-                ))
-              )}
-            </Select>
-          </div>
+        {/* SOP selection — checkbox list */}
+        <div className="shrink-0">
+          <p className="mb-2 text-sm font-medium text-fg-secondary">SOPs</p>
+          {sopsLoading ? (
+            <p className="text-xs text-fg-muted">Loading...</p>
+          ) : agentSops.length > 0 ? (
+            <div className="max-h-40 overflow-y-auto rounded-lg border border-fg-subtle/10 bg-bg-base">
+              {agentSops.map((sop) => (
+                <label
+                  key={sop.id}
+                  className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-bg-subtle transition-colors"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedSopIds.has(sop.id)}
+                    onChange={() => toggleSop(sop.id)}
+                    disabled={previewMutation.isPending || applyMutation.isPending}
+                    className="h-4 w-4 rounded border-fg-subtle/30 bg-bg-subtle text-brand-500 focus:ring-brand-500"
+                  />
+                  <span className="text-sm text-fg-primary">{sop.name}</span>
+                  <span className="text-xs text-fg-muted">({sop.status})</span>
+                </label>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-3 shrink-0">
           <Button
             variant="secondary"
             onClick={handlePreview}
-            disabled={!selectedSopId || previewMutation.isPending}
+            disabled={sopIdsArray.length === 0 || previewMutation.isPending}
             loading={previewMutation.isPending}
           >
             Preview
@@ -165,6 +185,11 @@ export function CompileDialog({
           >
             Apply
           </Button>
+          {sopIdsArray.length > 0 ? (
+            <span className="text-xs text-fg-muted">
+              {sopIdsArray.length} SOP{sopIdsArray.length !== 1 ? 's' : ''} selected
+            </span>
+          ) : null}
         </div>
 
         {/* No SOPs warning */}

--- a/modelguide-ui/src/features/prompt-compiler/components/compile-summary-bar.test.tsx
+++ b/modelguide-ui/src/features/prompt-compiler/components/compile-summary-bar.test.tsx
@@ -14,7 +14,11 @@ describe('CompileSummaryBar', () => {
   it('renders SOP name', () => {
     render(
       <CompileSummaryBar
-        compiledFrom={makeCompiledFrom({ sopName: 'WISMO Flow' })}
+        compiledFrom={makeCompiledFrom({
+          sops: [
+            { sopId: '00000000-0000-0000-0000-000000000050', sopName: 'WISMO Flow', stepCount: 6 },
+          ],
+        })}
         promptLength={2450}
       />,
     )
@@ -24,7 +28,18 @@ describe('CompileSummaryBar', () => {
 
   it('renders step count', () => {
     render(
-      <CompileSummaryBar compiledFrom={makeCompiledFrom({ stepCount: 8 })} promptLength={1000} />,
+      <CompileSummaryBar
+        compiledFrom={makeCompiledFrom({
+          sops: [
+            {
+              sopId: '00000000-0000-0000-0000-000000000050',
+              sopName: 'WISMO Email Flow',
+              stepCount: 8,
+            },
+          ],
+        })}
+        promptLength={1000}
+      />,
     )
 
     expect(screen.getByText('8')).toBeInTheDocument()

--- a/modelguide-ui/src/features/prompt-compiler/components/compile-summary-bar.tsx
+++ b/modelguide-ui/src/features/prompt-compiler/components/compile-summary-bar.tsx
@@ -2,10 +2,15 @@ import { Link } from '@tanstack/react-router'
 import { Zap } from 'lucide-react'
 import { cn } from '~/lib/cn'
 
-interface CompiledFromInfo {
+interface SopInfo {
   sopId: string
   sopName: string
   stepCount: number
+}
+
+interface CompiledFromInfo {
+  sops: SopInfo[]
+  guardrailIds: string[]
   toolCount: number
 }
 
@@ -38,32 +43,41 @@ export function CompileSummaryBar({
   className,
 }: CompileSummaryBarProps) {
   return (
-    <div className={cn('rounded-xl bg-bg-subtle border-t-2 border-brand-500/20 p-4', className)}>
-      <div className="flex items-center gap-4 flex-wrap">
-        <Link
-          to="/sops/$id"
-          params={{ id: compiledFrom.sopId }}
-          className="flex items-center gap-2 hover:underline"
+    <div className={cn('flex flex-col gap-2', className)}>
+      {/* One panel per SOP — shows per-SOP step count */}
+      {compiledFrom.sops.map((sop) => (
+        <div
+          key={sop.sopId}
+          className="rounded-xl bg-bg-subtle border-t-2 border-brand-500/20 px-4 py-3"
         >
-          <Zap className="h-3.5 w-3.5 text-brand-400" />
-          <span className="text-sm font-medium text-fg-primary">{compiledFrom.sopName}</span>
-        </Link>
-        <div className="h-4 w-px bg-fg-subtle/20" />
-        <div className="flex items-center gap-4 text-xs text-fg-muted">
-          <span>
-            <strong className="text-fg-secondary">{compiledFrom.stepCount}</strong> steps
-          </span>
-          <span>
-            <strong className="text-fg-secondary">{compiledFrom.toolCount}</strong> tools
-          </span>
-          <span>
-            <strong className="text-fg-secondary">{promptLength.toLocaleString()}</strong> chars
-          </span>
+          <div className="flex items-center gap-3">
+            <Zap className="h-3.5 w-3.5 shrink-0 text-brand-400" />
+            <Link
+              to="/sops/$id"
+              params={{ id: sop.sopId }}
+              className="text-sm font-medium text-fg-primary hover:underline truncate"
+            >
+              {sop.sopName}
+            </Link>
+            <span className="ml-auto shrink-0 text-xs text-fg-muted">
+              <strong className="text-fg-secondary">{sop.stepCount}</strong> steps
+            </span>
+          </div>
         </div>
+      ))}
+
+      {/* Totals row — aggregate for the compiled prompt */}
+      <div className="flex items-center gap-4 px-1 text-xs text-fg-muted">
+        <span>
+          <strong className="text-fg-secondary">{compiledFrom.toolCount}</strong> tools
+        </span>
+        <span>
+          <strong className="text-fg-secondary">{promptLength.toLocaleString()}</strong> chars
+        </span>
         {compiledAt ? (
           <>
-            <div className="h-4 w-px bg-fg-subtle/20" />
-            <span className="text-xs text-fg-muted">{formatRelativeDate(compiledAt)}</span>
+            <div className="h-3 w-px bg-fg-subtle/20" />
+            <span>{formatRelativeDate(compiledAt)}</span>
           </>
         ) : null}
       </div>

--- a/modelguide-ui/src/features/prompt-compiler/components/compiled-prompt-card.test.tsx
+++ b/modelguide-ui/src/features/prompt-compiler/components/compiled-prompt-card.test.tsx
@@ -111,7 +111,7 @@ describe('CompiledPromptCard', () => {
 
       // Dialog opens — verify its unique description text and controls are present
       expect(
-        screen.getByText('Select an SOP and preview the compiled system prompt.'),
+        screen.getByText('Select SOPs and preview the compiled system prompt.'),
       ).toBeInTheDocument()
       expect(screen.getByText('Preview')).toBeInTheDocument()
       expect(screen.getByText('Apply')).toBeInTheDocument()

--- a/modelguide-ui/src/features/sops/components/sop-agents-card.tsx
+++ b/modelguide-ui/src/features/sops/components/sop-agents-card.tsx
@@ -108,7 +108,7 @@ export function SopAgentsCard({ sopId, agents, canMutate }: SopAgentsCardProps) 
           onClose={() => setCompileTarget(null)}
           agentId={compileTarget.agentId}
           currentPrompt={compileTargetAgent?.compiledInstructions ?? null}
-          preselectedSopId={sopId}
+          preselectedSopIds={[sopId]}
         />
       ) : null}
     </Card>

--- a/modelguide-ui/src/features/sops/components/sop-form-trigger-tab.tsx
+++ b/modelguide-ui/src/features/sops/components/sop-form-trigger-tab.tsx
@@ -27,6 +27,7 @@ export function SopFormTriggerTab({ form }: SopFormTriggerTabProps) {
                 <option value="channel">Channel</option>
                 <option value="intent_detected">Intent Detected</option>
                 <option value="tool_present">Tool Present</option>
+                <option value="campaign_start">Campaign Start</option>
               </select>
             </dd>
           </div>

--- a/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
+++ b/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
@@ -243,6 +243,8 @@ export function useSopForm({
           type: 'tool_present',
           config: { toolSlugs: toolSlugs.map((t) => t.value).filter(Boolean) },
         }
+      case 'campaign_start':
+        return { type: 'campaign_start', config: {} }
       default:
         return { type: 'manual', config: {} }
     }
@@ -289,6 +291,7 @@ export function useSopForm({
 
   const isTriggerValid =
     triggerType === 'manual' ||
+    triggerType === 'campaign_start' ||
     (triggerType === 'channel' && channelTypes.length > 0) ||
     (triggerType === 'intent_detected' && patterns.some((p) => p.value.trim())) ||
     (triggerType === 'tool_present' && toolSlugs.some((t) => t.value.trim()))

--- a/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
+++ b/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
@@ -283,7 +283,11 @@ export function useSopForm({
           estimatedDuration: estimatedDuration || undefined,
         },
       },
-      agentIds: agentIds.length > 0 ? agentIds : undefined,
+      agentIds: isEditMode
+        ? agentIds
+        : agentIds.length > 0
+          ? agentIds
+          : undefined,
     })
   }
 

--- a/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
+++ b/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
@@ -283,7 +283,7 @@ export function useSopForm({
           estimatedDuration: estimatedDuration || undefined,
         },
       },
-      agentIds: isEditMode ? agentIds : agentIds.length > 0 ? agentIds : undefined,
+      agentIds: isEditMode || agentIds.length > 0 ? agentIds : undefined,
     })
   }
 

--- a/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
+++ b/modelguide-ui/src/features/sops/hooks/use-sop-form.ts
@@ -283,11 +283,7 @@ export function useSopForm({
           estimatedDuration: estimatedDuration || undefined,
         },
       },
-      agentIds: isEditMode
-        ? agentIds
-        : agentIds.length > 0
-          ? agentIds
-          : undefined,
+      agentIds: isEditMode ? agentIds : agentIds.length > 0 ? agentIds : undefined,
     })
   }
 

--- a/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.test.tsx
+++ b/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.test.tsx
@@ -327,7 +327,7 @@ describe('EditSopPage', () => {
     expect(chatCheckbox).not.toBeChecked()
   })
 
-  it('does not include agentIds in PATCH payload (managed via dedicated dialog)', async () => {
+  it('includes agentIds from assigned agents in PATCH payload', async () => {
     renderPage()
 
     await waitFor(() => {
@@ -341,7 +341,7 @@ describe('EditSopPage', () => {
     })
 
     const payload = mockPatch.mock.calls[0][1] as { json: Record<string, unknown> }
-    expect(payload.json).not.toHaveProperty('agentIds')
+    expect(payload.json).toHaveProperty('agentIds', ['00000000-0000-0000-0000-aaaaaaaaaaaa'])
   })
 
   it('does not send slug in PATCH payload', async () => {

--- a/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.test.tsx
+++ b/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.test.tsx
@@ -344,6 +344,34 @@ describe('EditSopPage', () => {
     expect(payload.json).toHaveProperty('agentIds', ['00000000-0000-0000-0000-aaaaaaaaaaaa'])
   })
 
+  it('sends an empty agentIds array when the last assigned agent is removed', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Edit SOP' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agents' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Voice Agent')).toBeInTheDocument()
+    })
+
+    const voiceCheckbox = screen.getByText('Voice Agent').closest('label')?.querySelector('input')
+    expect(voiceCheckbox).toBeChecked()
+
+    if (voiceCheckbox) fireEvent.click(voiceCheckbox)
+
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalled()
+    })
+
+    const payload = mockPatch.mock.calls[0][1] as { json: Record<string, unknown> }
+    expect(payload.json).toHaveProperty('agentIds', [])
+  })
+
   it('does not send slug in PATCH payload', async () => {
     renderPage()
 

--- a/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.tsx
+++ b/modelguide-ui/src/routes/_authenticated/sops.$id_.edit.tsx
@@ -57,6 +57,7 @@ function EditSopPage() {
       description: data.description,
       definition: data.definition,
       version: data.version,
+      agentIds: data.agentIds,
     }
     updateMutation.mutate(update)
   }

--- a/modelguide-ui/src/schemas/agents.ts
+++ b/modelguide-ui/src/schemas/agents.ts
@@ -18,11 +18,15 @@ export type PromptConfig = z.infer<typeof promptConfigSchema>
 
 export const compiledFromSchema = z
   .object({
-    sopId: z.string().uuid(),
-    sopName: z.string(),
+    sops: z.array(
+      z.object({
+        sopId: z.string().uuid(),
+        sopName: z.string(),
+        stepCount: z.number(),
+      }),
+    ),
     guardrailIds: z.array(z.string().uuid()),
     toolCount: z.number(),
-    stepCount: z.number(),
   })
   .nullable()
 

--- a/modelguide-ui/src/schemas/prompt-compiler.ts
+++ b/modelguide-ui/src/schemas/prompt-compiler.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const compileRequestSchema = z.object({
-  sopId: z.string().uuid(),
+  sopIds: z.array(z.string().uuid()).min(1),
   model: z.string().max(100).optional(),
   description: z.string().max(2000).optional(),
 })
@@ -20,11 +20,15 @@ export const compileResponseSchema = z.object({
   agentId: z.string().uuid(),
   compiledAt: z.string(),
   compiledFrom: z.object({
-    sopId: z.string().uuid(),
-    sopName: z.string(),
+    sops: z.array(
+      z.object({
+        sopId: z.string().uuid(),
+        sopName: z.string(),
+        stepCount: z.number(),
+      }),
+    ),
     guardrailIds: z.array(z.string().uuid()),
     toolCount: z.number(),
-    stepCount: z.number(),
   }),
   compiledPrompt: z.string(),
   promptLength: z.number(),

--- a/modelguide-ui/src/schemas/sops.ts
+++ b/modelguide-ui/src/schemas/sops.ts
@@ -29,11 +29,19 @@ const toolPresentTriggerSchema = z.object({
   }),
 })
 
+const campaignStartTriggerSchema = z.object({
+  type: z.literal('campaign_start'),
+  config: z.object({
+    campaign: z.string().optional(),
+  }),
+})
+
 export const sopTriggerSchema = z.discriminatedUnion('type', [
   manualTriggerSchema,
   channelTriggerSchema,
   intentDetectedTriggerSchema,
   toolPresentTriggerSchema,
+  campaignStartTriggerSchema,
 ])
 
 export type SopTrigger = z.infer<typeof sopTriggerSchema>
@@ -208,6 +216,7 @@ export const sopUpdateSchema = z.object({
     })
     .optional(),
   version: z.string().optional(),
+  agentIds: z.array(z.string().uuid()).optional(),
 })
 
 export type SopUpdate = z.infer<typeof sopUpdateSchema>
@@ -239,6 +248,7 @@ export const TRIGGER_LABELS: Record<SopTrigger['type'], string> = {
   channel: 'Channel',
   intent_detected: 'Intent Detected',
   tool_present: 'Tool Present',
+  campaign_start: 'Campaign Start',
 }
 
 // --- Status helpers ---

--- a/modelguide-ui/test/prompt-compiler-fixtures.ts
+++ b/modelguide-ui/test/prompt-compiler-fixtures.ts
@@ -6,14 +6,18 @@ import type { CompileResponse } from '~/schemas/prompt-compiler'
 // ---------------------------------------------------------------------------
 
 export function makeCompiledFrom(
-  overrides: Partial<CompiledFrom & object> = {},
+  overrides: Partial<NonNullable<CompiledFrom>> = {},
 ): NonNullable<CompiledFrom> {
   return {
-    sopId: '00000000-0000-0000-0000-000000000050',
-    sopName: 'WISMO Email Flow',
+    sops: [
+      {
+        sopId: '00000000-0000-0000-0000-000000000050',
+        sopName: 'WISMO Email Flow',
+        stepCount: 6,
+      },
+    ],
     guardrailIds: ['00000000-0000-0000-0000-000000000060'],
     toolCount: 3,
-    stepCount: 6,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- **Multi-SOP compiler pipeline** — `sopIds: string[]` replaces `sopId` in the compile request body; each SOP gets its own `## Workflow` / `# Conversation Flow` section in the compiled prompt
- **CLI fix** — `compile-agents` was calling `compileAgent()` per SOP (last-write-wins bug); now collects all active SOP IDs and makes a single call per agent
- **Data migration** — `0034_migrate-compiled-from-to-multi-sop.sql` reshapes existing `compiled_from` JSONB from `{ sopId, sopName, ... }` to `{ sops: [...], guardrailIds, toolCount }` (idempotent)
- **Compile dialog** — checkbox list replaces single Select; summary bar shows one panel per SOP with its step count, aggregate tools/chars in a totals row
- **Scout fixes** — SOP edit form now sends `agentIds` in PATCH (was silently dropped); `campaign_start` trigger type added to UI schema + validation (was causing Save button to stay disabled)

## Test plan

- [x] API unit tests: 825 pass
- [x] API typecheck: clean
- [x] UI tests: 261 pass
- [x] UI typecheck: clean
- [x] Migration applied and verified against local DB
- [ ] Integration tests (require running Postgres — `make api-test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)