### PR TITLE
feat(cli): --replace flag to re-import SOPs with same slug

### DIFF
--- a/modelguide-api/src/cli/commands/import-sops.ts
+++ b/modelguide-api/src/cli/commands/import-sops.ts
@@ -9,6 +9,8 @@
 import {
   activateSop,
   createSop,
+  deleteSop,
+  findSopBySlug,
   forkFromTemplate,
   listTemplates,
 } from "@features/sops/sops.service";
@@ -130,12 +132,18 @@ async function importInlineSop(
 export async function handleImportSops(
   orgId: string,
   items: SopItemInput[],
-  options?: { registry?: IdRegistry },
-): Promise<{ created: number; existing: number; activated: number }> {
+  options?: { registry?: IdRegistry; replace?: boolean },
+): Promise<{
+  created: number;
+  existing: number;
+  activated: number;
+  replaced: number;
+}> {
   const templates = await resolveTemplates();
   let created = 0;
   let existing = 0;
   let activated = 0;
+  let replaced = 0;
 
   for (const item of items) {
     try {
@@ -144,6 +152,20 @@ export async function handleImportSops(
         item.agents,
         options?.registry,
       );
+
+      // If --replace, delete any existing SOP with the same slug first.
+      // Cascade drops sop_steps and agent_sops; the recreate below re-links agents
+      // from the yaml's `agents:` list, so yaml stays the source of truth.
+      if (options?.replace && item.slug) {
+        const existingSop = await findSopBySlug(orgId, item.slug);
+        if (existingSop) {
+          await deleteSop(orgId, existingSop.id);
+          log.warn(
+            `Replaced existing SOP: ${existingSop.name} (${item.slug}) — dashboard-only agent links dropped`,
+          );
+          replaced++;
+        }
+      }
 
       const sopId = item.templateSlug
         ? await importTemplateSop(
@@ -175,7 +197,7 @@ export async function handleImportSops(
     }
   }
 
-  return { created, existing, activated };
+  return { created, existing, activated, replaced };
 }
 
 export function registerImportSopsCommand(program: Command): void {
@@ -183,15 +205,24 @@ export function registerImportSopsCommand(program: Command): void {
     .command("import-sops")
     .description("Import SOPs from YAML file")
     .requiredOption("--org <slug>", "Organization slug")
+    .option(
+      "--replace",
+      "Delete and recreate SOPs whose slugs already exist (drops manual agent links)",
+    )
     .argument("<file>", "YAML file path")
-    .action(async (file: string, opts: { org: string }) => {
+    .action(async (file: string, opts: { org: string; replace?: boolean }) => {
       const orgId = await resolveOrgId(opts.org);
       const data = loadYaml(file, sopsFileSchema);
 
       try {
-        const result = await handleImportSops(orgId, data.sops);
+        const result = await handleImportSops(orgId, data.sops, {
+          replace: opts.replace,
+        });
+        const replacedSuffix = result.replaced
+          ? `, ${result.replaced} replaced`
+          : "";
         log.success(
-          `SOPs: ${result.created} imported (${result.activated} active), ${result.existing} existing`,
+          `SOPs: ${result.created} imported (${result.activated} active), ${result.existing} existing${replacedSuffix}`,
         );
       } catch (err) {
         log.error(`Failed: ${getErrorMessage(err)}`);

--- a/modelguide-api/src/cli/commands/setup.ts
+++ b/modelguide-api/src/cli/commands/setup.ts
@@ -45,6 +45,7 @@ interface SetupOptions {
   skipCompile?: boolean;
   skipSessions?: boolean;
   skipEvals?: boolean;
+  replaceSops?: boolean;
 }
 
 interface SetupFiles {
@@ -241,9 +242,13 @@ export async function handleSetup(
     log.step("Importing SOPs...");
     const sopResult = await handleImportSops(orgId, files.sops.sops, {
       registry,
+      replace: options.replaceSops,
     });
+    const replacedSuffix = sopResult.replaced
+      ? `, ${sopResult.replaced} replaced`
+      : "";
     log.success(
-      `SOPs: ${sopResult.created} imported (${sopResult.activated} active)`,
+      `SOPs: ${sopResult.created} imported (${sopResult.activated} active)${replacedSuffix}`,
     );
   }
 
@@ -326,6 +331,10 @@ export function registerSetupCommand(program: Command): void {
     .option("--skip-compile", "Skip agent compilation")
     .option("--skip-sessions", "Skip session import")
     .option("--skip-evals", "Skip eval import")
+    .option(
+      "--replace-sops",
+      "Delete and recreate SOPs whose slugs already exist (drops manual agent links)",
+    )
     .action(async (dir: string, opts) => {
       try {
         await handleSetup(dir, {
@@ -334,6 +343,7 @@ export function registerSetupCommand(program: Command): void {
           skipCompile: opts.skipCompile,
           skipSessions: opts.skipSessions,
           skipEvals: opts.skipEvals,
+          replaceSops: opts.replaceSops,
         });
       } catch (err) {
         log.error(`Setup failed: ${getErrorMessage(err)}`);

--- a/modelguide-api/src/features/sops/index.ts
+++ b/modelguide-api/src/features/sops/index.ts
@@ -12,6 +12,7 @@ export {
   forkFromTemplate,
   updateSop,
   deleteSop,
+  findSopBySlug,
   activateSop,
   archiveSop,
   getAssignedAgents,

--- a/modelguide-api/src/features/sops/sops.service.ts
+++ b/modelguide-api/src/features/sops/sops.service.ts
@@ -635,6 +635,20 @@ export async function deleteSop(orgId: string, sopId: string): Promise<void> {
   }
 }
 
+export async function findSopBySlug(
+  orgId: string,
+  slug: string,
+): Promise<{ id: string; name: string } | null> {
+  const rows = await forOrg(orgId, (tx) =>
+    tx
+      .select({ id: sops.id, name: sops.name })
+      .from(sops)
+      .where(eq(sops.slug, slug))
+      .limit(1),
+  );
+  return rows[0] ?? null;
+}
+
 export async function activateSop(orgId: string, sopId: string) {
   return forOrg(orgId, async (tx) => {
     await requireSopExists(tx, sopId);

--- a/modelguide-api/tests/integration/cli/import-sops.test.ts
+++ b/modelguide-api/tests/integration/cli/import-sops.test.ts
@@ -257,6 +257,65 @@ describe("import-sops", () => {
     ).rejects.toThrow("must have at least one step");
   });
 
+  test("--replace deletes and recreates SOP with same slug", async () => {
+    const createResult = await handleImportSops(
+      orgId,
+      [
+        {
+          name: "Replaceable SOP",
+          slug: "replaceable-sop",
+          status: "active",
+          agents: ["sop-test-agent"],
+          steps: [
+            { id: "original", instruction: "Original step", required: true },
+          ],
+        },
+      ],
+      { registry },
+    );
+    expect(createResult.created).toBe(1);
+    const originalId = registry.get("sop", "replaceable-sop");
+
+    const replaceResult = await handleImportSops(
+      orgId,
+      [
+        {
+          name: "Replaceable SOP",
+          slug: "replaceable-sop",
+          status: "active",
+          agents: ["sop-test-agent"],
+          steps: [
+            { id: "new-a", instruction: "New step A", required: true },
+            { id: "new-b", instruction: "New step B", required: true },
+          ],
+        },
+      ],
+      { registry, replace: true },
+    );
+    expect(replaceResult.replaced).toBe(1);
+    expect(replaceResult.created).toBe(1);
+    expect(replaceResult.existing).toBe(0);
+
+    const newId = registry.get("sop", "replaceable-sop");
+    expect(newId).not.toBe(originalId);
+
+    const steps = await forApp(async (tx) => {
+      return tx.select().from(sopSteps).where(eq(sopSteps.sopId, newId));
+    });
+    expect(steps.length).toBe(2);
+    expect(steps.map((s) => s.stepId).sort()).toEqual(["new-a", "new-b"]);
+
+    const originalStillExists = await forApp(async (tx) => {
+      return tx.select().from(sops).where(eq(sops.id, originalId));
+    });
+    expect(originalStillExists.length).toBe(0);
+
+    const assignments = await forApp(async (tx) => {
+      return tx.select().from(agentSops).where(eq(agentSops.sopId, newId));
+    });
+    expect(assignments.length).toBe(1);
+  });
+
   test("resolves agents and connector tools without registry", async () => {
     const [tool] = await forApp(async (tx) => {
       return tx


### PR DESCRIPTION
## Summary
- Adds `--replace` to `mg import-sops` and `--replace-sops` to `mg setup`. When a SOP's slug already exists, the existing SOP is deleted (cascading `sop_steps` + `agent_sops`) and recreated from yaml, re-linking agents from the yaml's `agents:` list.
- Default behavior is unchanged — duplicates are still skipped. Replace is opt-in because it drops any dashboard-only agent links (yaml is source of truth).
- Exposes `findSopBySlug(orgId, slug)` from the SOPs service for slug-based lookup.

## Motivation
Previously, re-running `mg setup` against an org with existing SOPs would skip them entirely — editing `sops.yaml` (fixing a trigger config, updating steps, etc.) had no effect without manually deleting SOPs in the dashboard first. This came up while re-importing bank-nowa after fixing `trigger.config.keywords` → `patterns`.

## Test plan
- [x] `bun test tests/integration/cli/import-sops.test.ts` — 7/7 pass (new test: replace flow verifies new SOP id, new steps, agent re-link, original row gone)
- [x] `bun run typecheck` clean
- [x] `bun run lint:check` clean
- [x] `mg setup --help` and `mg import-sops --help` show new flags
- [ ] Manual: re-run `mg setup` against existing org with `--replace-sops` and confirm SOPs get fresh trigger/steps