### PR TITLE
chore(cli): tighten SOP + guardrail import schemas; fix reference YAMLs and deploy docs

### DIFF
--- a/.claude/skills/build-agent/references/yaml-templates.md
+++ b/.claude/skills/build-agent/references/yaml-templates.md
@@ -155,8 +155,9 @@ sops:
     status: active
     agents: ["{{agentSlug}}"]
     trigger:
-      type: intent
-      config: { intent: "{{intentKey1}}" }   # e.g. "order_status"
+      type: intent_detected
+      config:
+        patterns: ["{{triggerPhrase1a}}", "{{triggerPhrase1b}}"]   # e.g. ["where is my order", "track my order"]
     steps:
       - id: greet
         instruction: "Greet the customer and ask how you can help."

--- a/.claude/skills/mg-cli/SKILL.md
+++ b/.claude/skills/mg-cli/SKILL.md
@@ -160,8 +160,9 @@ sops:
     status: active              # draft | active | archived (default: draft)
     agents: ["acme-voice-agent"]
     trigger:
-      type: intent
-      config: { intent: order_status }
+      type: intent_detected          # see references/schemas.md for all trigger types
+      config:
+        patterns: ["where is my order", "track my order", "order status"]
     steps:
       - id: greet
         instruction: "Greet and ask for order number"

--- a/.claude/skills/mg-cli/references/examples.md
+++ b/.claude/skills/mg-cli/references/examples.md
@@ -136,9 +136,12 @@ sops:
       - "acme-voice-agent"
       - "acme-chat-assistant"
     trigger:
-      type: intent
+      type: intent_detected
       config:
-        intent: order_status
+        patterns:
+          - "where is my order"
+          - "track my order"
+          - "order status"
     steps:
       - id: greet
         instruction: "Greet the customer and ask for their order number or email address"
@@ -164,9 +167,12 @@ sops:
     agents:
       - "acme-voice-agent"
     trigger:
-      type: intent
+      type: intent_detected
       config:
-        intent: return_request
+        patterns:
+          - "return"
+          - "refund"
+          - "send it back"
     steps:
       - id: identify
         instruction: "Ask the customer for their order number and the item they want to return"

--- a/.claude/skills/mg-cli/references/schemas.md
+++ b/.claude/skills/mg-cli/references/schemas.md
@@ -179,10 +179,17 @@ connectorMapping:
 
 ### Trigger object
 
-| Field | Type | Required |
-|-------|------|----------|
-| `type` | string | yes | any string, e.g., `"manual"`, `"intent"`, `"channel"`, `"tool_present"` |
-| `config` | object | no (default `{}`) | type-specific configuration |
+Discriminated union on `type`. Each type has its own required `config` shape:
+
+| `type` | Required `config` fields | Example |
+|---|---|---|
+| `manual` | `{}` | `{ type: manual, config: {} }` |
+| `intent_detected` | `patterns: string[]` (min 1) | `{ patterns: ["return my order", "refund"] }` |
+| `channel` | `channelTypes: ("voice"\|"chat"\|"email")[]` (min 1) | `{ channelTypes: ["voice"] }` |
+| `tool_present` | `toolSlugs: string[]` (min 1), `catalogSlug?: string` | `{ toolSlugs: ["get_order"] }` |
+| `campaign_start` | `campaign?: string` | `{ campaign: "insurance" }` |
+
+**Common mistakes:** using `type: intent` (invalid — use `intent_detected`) or `config.keywords` (invalid — use `config.patterns`). The compiler validates stored triggers on every run, so malformed triggers block `compile-agents`.
 
 ### Step object
 
@@ -214,8 +221,18 @@ Wrapper key: `guardrails` (array, min 1 item).
 | `slug` | string | no | — | auto-generated if omitted |
 | `content` | string | yes | — | the guardrail rule text (supports multiline) |
 | `description` | string | no | — | |
-| `config` | object | no | `{}` | arbitrary (e.g., `priority`, `category`) |
+| `config` | object | no | `{}` | must include `priority` (see below) for the guardrail to compile |
 | `agents` | string[] | no | `[]` | agent slugs to assign |
+
+### Guardrail config
+
+Although the CLI import schema is loose (`config: {}` passes), the compiler rejects guardrails without `config.priority`. Always set it:
+
+| Field | Type | Required | Values |
+|-------|------|----------|--------|
+| `priority` | string | yes (at compile time) | `critical` \| `high` \| `medium` \| `low` |
+| `category` | string | no | `compliance` \| `safety` \| `brand` \| `operational` |
+| `reason` | string | no | why this guardrail exists — surfaced in some prompt strategies |
 
 **Behavior:** Creates a knowledge base entry with type `"guardrail"`. Duplicates detected by slug.
 

--- a/.claude/skills/mg-railway-deploy-all/SKILL.md
+++ b/.claude/skills/mg-railway-deploy-all/SKILL.md
@@ -25,6 +25,18 @@ CRITICAL — each service MUST be deployed from its specific subdirectory:
 
 NEVER deploy from the monorepo root.
 
+## Preflight
+
+Before calling any deploy tool, confirm the Railway link resolves to the repo root — not a parent directory or a service subdir. Run `railway status` and check `Project` is set.
+
+If it's empty or points to the wrong place, re-link from the repo root:
+
+```bash
+railway link --project <projectId> --environment <env>
+```
+
+A stale parent link (e.g. at `~/Projects/modelguide/` instead of `~/Projects/modelguide/modelguide/`) silently wins — the Railway CLI walks up the tree looking for the nearest link, then uploads sibling directories, and Railpack fails with "could not determine how to build the app". Fix the link, don't work around it by relinking at a subdir.
+
 ## Procedure
 
 1. **Link to the correct project and environment** using Railway MCP `link-environment` tool:

--- a/modelguide-api/src/cli/examples/acme/sops.yaml
+++ b/modelguide-api/src/cli/examples/acme/sops.yaml
@@ -7,9 +7,12 @@ sops:
       - "acme-voice-agent"
       - "acme-chat-assistant"
     trigger:
-      type: intent
+      type: intent_detected
       config:
-        intent: order_status
+        patterns:
+          - "where is my order"
+          - "track my order"
+          - "order status"
     steps:
       - id: greet
         instruction: "Greet the customer and ask for their order number or email address"
@@ -33,9 +36,12 @@ sops:
     agents:
       - "acme-voice-agent"
     trigger:
-      type: intent
+      type: intent_detected
       config:
-        intent: return_request
+        patterns:
+          - "return"
+          - "refund"
+          - "send it back"
     steps:
       - id: identify
         instruction: "Ask the customer for their order number and the item they want to return"

--- a/modelguide-api/src/cli/schemas/guardrails.schema.ts
+++ b/modelguide-api/src/cli/schemas/guardrails.schema.ts
@@ -1,11 +1,16 @@
+import { guardrailConfigSchema } from "@features/knowledge-base/knowledge-base.schemas";
 import { z } from "zod";
 
+// Reuse the service-layer guardrail config schema so CLI imports fail fast on
+// anything the compiler would later reject (e.g. missing `priority`, unknown
+// `category`). Historically the CLI accepted `config: {}`, which made
+// `mg import-guardrails` succeed on YAML that then broke `compile-agents`.
 export const guardrailItemSchema = z.object({
   name: z.string().min(1),
   slug: z.string().min(1).optional(),
   content: z.string().min(1),
   description: z.string().optional(),
-  config: z.record(z.unknown()).default({}),
+  config: guardrailConfigSchema,
   agents: z.array(z.string()).default([]),
 });
 

--- a/modelguide-api/src/cli/schemas/sops.schema.ts
+++ b/modelguide-api/src/cli/schemas/sops.schema.ts
@@ -1,3 +1,4 @@
+import { sopTriggerSchema as serviceSopTriggerSchema } from "@features/sops/sops.schemas";
 import { z } from "zod";
 
 const sopStatuses = ["draft", "active", "archived"] as const;
@@ -14,10 +15,10 @@ const sopStepSchema = z.object({
     .optional(),
 });
 
-const sopTriggerSchema = z.object({
-  type: z.string().min(1),
-  config: z.record(z.unknown()).default({}),
-});
+// Reuse the service-layer discriminated union so CLI imports reject any trigger
+// shape that the compiler will later refuse (e.g. `type: intent` instead of
+// `intent_detected`, or `config.keywords` instead of `config.patterns`).
+const sopTriggerSchema = serviceSopTriggerSchema;
 
 /**
  * SOP: either fork from a template or define inline.

--- a/modelguide-api/tests/integration/cli/import-guardrails.test.ts
+++ b/modelguide-api/tests/integration/cli/import-guardrails.test.ts
@@ -111,7 +111,7 @@ describe("import-guardrails", () => {
         name: "No Medical Claims",
         slug: "no-medical-claims",
         content: "Never claim products cure diseases.",
-        config: {},
+        config: { priority: "critical" },
         agents: [],
       },
     ]);

--- a/modelguide-api/tests/unit/cli/schemas.test.ts
+++ b/modelguide-api/tests/unit/cli/schemas.test.ts
@@ -250,13 +250,55 @@ describe("sopItemSchema", () => {
     }
   });
 
-  test("validates inline SOP with steps", () => {
+  test("validates inline SOP with manual trigger", () => {
     const result = sopItemSchema.safeParse({
       name: "Return Process",
       steps: [{ id: "step-1", instruction: "Greet customer" }],
       trigger: { type: "manual", config: {} },
     });
     expect(result.success).toBe(true);
+  });
+
+  test("validates inline SOP with intent_detected trigger", () => {
+    const result = sopItemSchema.safeParse({
+      name: "Order Lookup",
+      steps: [{ id: "s1", instruction: "greet" }],
+      trigger: {
+        type: "intent_detected",
+        config: { patterns: ["where is my order"] },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects legacy `type: intent` trigger", () => {
+    const result = sopItemSchema.safeParse({
+      name: "SOP",
+      steps: [{ id: "s1", instruction: "greet" }],
+      trigger: { type: "intent", config: { intent: "order_status" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects intent_detected without patterns", () => {
+    const result = sopItemSchema.safeParse({
+      name: "SOP",
+      steps: [{ id: "s1", instruction: "greet" }],
+      trigger: { type: "intent_detected", config: {} },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects legacy `config.keywords` under intent_detected", () => {
+    const result = sopItemSchema.safeParse({
+      name: "SOP",
+      steps: [{ id: "s1", instruction: "greet" }],
+      trigger: {
+        type: "intent_detected",
+        config: { keywords: ["return"] },
+      },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("rejects invalid status", () => {
@@ -269,21 +311,49 @@ describe("sopItemSchema", () => {
 });
 
 describe("guardrailItemSchema", () => {
-  test("validates correct guardrail", () => {
+  test("validates guardrail with required priority", () => {
+    const result = guardrailItemSchema.safeParse({
+      name: "No Medical Claims",
+      content: "Never claim products cure diseases.",
+      config: { priority: "critical", category: "compliance" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.config.priority).toBe("critical");
+      expect(result.data.agents).toEqual([]);
+    }
+  });
+
+  test("rejects guardrail without config.priority", () => {
     const result = guardrailItemSchema.safeParse({
       name: "No Medical Claims",
       content: "Never claim products cure diseases.",
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.config).toEqual({});
-      expect(result.data.agents).toEqual([]);
-    }
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects guardrail with unknown priority value", () => {
+    const result = guardrailItemSchema.safeParse({
+      name: "No Medical Claims",
+      content: "Never claim products cure diseases.",
+      config: { priority: "urgent" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects guardrail with unknown category value", () => {
+    const result = guardrailItemSchema.safeParse({
+      name: "No Medical Claims",
+      content: "Never claim products cure diseases.",
+      config: { priority: "high", category: "business" },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("rejects missing content", () => {
     const result = guardrailItemSchema.safeParse({
       name: "Test",
+      config: { priority: "high" },
     });
     expect(result.success).toBe(false);
   });

--- a/railway/DEPLOY.md
+++ b/railway/DEPLOY.md
@@ -14,12 +14,13 @@ railway init
 railway link
 ```
 
-If the project and services already exist, link each one from its directory:
+Link from the **repo root** (e.g. `~/Projects/modelguide/modelguide`). `railway status` must resolve to the repo root before you run any `railway up` — the CLI walks parent directories looking for the nearest link, so a stale link at the monorepo's parent silently wins and `railway up` uploads sibling directories instead of the repo.
+
+If the project and services already exist, link the project once from the repo root — per-service linking isn't required; the service is chosen with `--service` on each command:
 
 ```bash
-(cd modelguide-api && railway link --service api)
-(cd modelguide-ui && railway link --service ui)
-(cd railway/lb && railway link --service lb)
+railway link --project <projectId> --environment <env>
+railway status    # confirm Project + Environment resolve correctly
 ```
 
 ## 2. Add services


### PR DESCRIPTION
## Summary
- `cli/schemas/sops.schema.ts` now reuses the service-layer discriminated-union trigger schema — `type: intent` and `config.keywords` now fail on YAML load instead of at compile time.
- `cli/schemas/guardrails.schema.ts` now reuses the service-layer guardrail config schema — `config.priority` is required at import time, with `category` constrained to the known enum.
- Fix reference YAMLs (`acme/sops.yaml`) and skill docs (`mg-cli/SKILL.md`, `examples.md`, `schemas.md`; `build-agent/yaml-templates.md`) that still used the invalid `type: intent` / `config.intent` shape — those examples imported fine but wouldn't compile.
- Add a preflight to the `mg-railway-deploy-all` skill and clarify `railway/DEPLOY.md`: link Railway at the repo root. A stale parent link silently wins and uploads sibling directories, which produces a confusing Railpack error.

## Why
An earlier `mg setup` against `bank-nowa` succeeded on import but then `compile-agents` failed twice:
1. SOP triggers stored `config.keywords` — compiler wanted `config.patterns`.
2. Guardrails stored `config: {}` — compiler wanted `config.priority`.

Both errors came too late to be useful. Moving validation to the CLI schemas means the same mistakes now fail in seconds during `loadYaml`, and the `--dry-run` output is now trustworthy.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint:check` clean
- [x] `bun test tests/unit/cli/schemas.test.ts` — 42/42 pass (added 5 new cases covering the new rejections)
- [x] `mg setup ~/Projects/modelguide/demos/bank-nowa/seed-modelguide/ --dry-run` — "All YAML files validated" (with the corrected yaml the user already has)
- [ ] Manual: retry onboarding a new demo org end-to-end with `mg setup` to confirm fast-fail on bad trigger/config