### PR TITLE
feat(cli): attach suite-level evaluators from yaml common_evaluators

### DIFF
--- a/modelguide-api/src/cli/commands/import-evals.ts
+++ b/modelguide-api/src/cli/commands/import-evals.ts
@@ -15,12 +15,14 @@ import path from "node:path";
 import { forOrg } from "@db/rls";
 import {
   evalConfigs,
+  evalSuiteEvaluators,
   evalSuiteTestCases,
   evalSuites,
   evalTestCaseEvaluators,
 } from "@db/schema";
 import { createEvalConfig } from "@features/eval-configs/eval-configs.service";
 import {
+  createEvaluator,
   createSuite,
   createTestCase,
 } from "@features/evals/eval-suites.service";
@@ -315,7 +317,40 @@ export async function handleImportEvals(
     // 6b. Load existing test cases for dedup / replace
     const existingTestCases = await loadExistingTestCases(orgId, suiteId);
 
-    // 6c. Create or replace test cases with per-case evaluator overrides
+    // 6c. Compute suite-level evaluators: the union of (a) `common_evaluators`
+    // declared at the top of the yaml (explicit generic evaluators, typically
+    // guardrail-style), and (b) the intersection of per-case evaluators (any
+    // evaluator every test case in this suite already lists). Everything else
+    // stays as a per-case `add` override. This matches the mental model:
+    // suite = baseline every case runs against, overrides = test-case-specific.
+    const caseEvaluatorLists = testCases
+      .filter((tc) => !existingTestCases.has(tc.id))
+      .map((tc) => tc.evaluatorNames);
+    const intersection =
+      caseEvaluatorLists.length > 0
+        ? caseEvaluatorLists.reduce<string[]>(
+            (acc, names) => acc.filter((n) => names.includes(n)),
+            [...new Set(caseEvaluatorLists[0])],
+          )
+        : [];
+    const suiteEvaluatorNames = [
+      ...new Set([...normalized.commonEvaluatorNames, ...intersection]),
+    ];
+
+    // 6d. Attach suite-level evaluators (idempotent: skip names already attached)
+    const alreadyAttached = await loadSuiteEvaluatorNames(orgId, suiteId);
+    for (const name of suiteEvaluatorNames) {
+      if (alreadyAttached.has(name)) continue;
+      const configId = evalConfigIdMap.get(name);
+      if (!configId) continue;
+      await createEvaluator(orgId, suiteId, {
+        evalConfigId: configId,
+        name,
+        required: true,
+      });
+    }
+
+    // 6e. Create or replace test cases with per-case evaluator overrides
     for (const tc of testCases) {
       // Build description from metadata
       const descParts: string[] = [];
@@ -357,8 +392,11 @@ export async function handleImportEvals(
         mockToolResponses: tc.mockToolResponses,
       });
 
-      // Insert per-case evaluator overrides (add type)
-      const overrideValues = tc.evaluatorNames
+      // Per-case `add` overrides only for evaluators NOT promoted to suite level.
+      const caseSpecificNames = tc.evaluatorNames.filter(
+        (name) => !suiteEvaluatorNames.includes(name),
+      );
+      const overrideValues = caseSpecificNames
         .map((name, i) => {
           const configId = evalConfigIdMap.get(name);
           if (!configId) return null;
@@ -386,6 +424,20 @@ export async function handleImportEvals(
   }
 
   return result;
+}
+
+/** Load the set of evaluator names already attached to a suite (for dedup). */
+async function loadSuiteEvaluatorNames(
+  orgId: string,
+  suiteId: string,
+): Promise<Set<string>> {
+  const rows = await forOrg(orgId, (tx) =>
+    tx
+      .select({ name: evalSuiteEvaluators.name })
+      .from(evalSuiteEvaluators)
+      .where(eq(evalSuiteEvaluators.suiteId, suiteId)),
+  );
+  return new Set(rows.map((r) => r.name));
 }
 
 // ============================================================================

--- a/modelguide-api/src/cli/commands/import-evals.ts
+++ b/modelguide-api/src/cli/commands/import-evals.ts
@@ -331,7 +331,8 @@ export async function handleImportEvals(
       evalConfigIdMap,
     );
 
-    // 6e. Create or replace test cases with per-case evaluator overrides
+    // 6d. Create or replace test cases with per-case evaluator overrides
+    const suiteEvaluatorSet = new Set(suiteEvaluatorNames);
     for (const tc of testCases) {
       // Build description from metadata
       const descParts: string[] = [];
@@ -375,7 +376,7 @@ export async function handleImportEvals(
 
       // Per-case `add` overrides only for evaluators NOT promoted to suite level.
       const caseSpecificNames = tc.evaluatorNames.filter(
-        (name) => !suiteEvaluatorNames.includes(name),
+        (name) => !suiteEvaluatorSet.has(name),
       );
       const overrideValues = caseSpecificNames
         .map((name, i) => {
@@ -450,18 +451,23 @@ async function reconcileSuiteEvaluators(
         .where(inArray(evalSuiteEvaluators.id, toRemove));
     }
 
-    // Insert missing target names (skip any already present as manual)
+    // Insert missing target names (skip any already present as manual).
+    // Index before filter so `order` reflects yaml position, not filtered-array position.
     const toInsert = targetNames
-      .filter((n) => !existingAuto.has(n) && !manualNames.has(n))
-      .map((name, i) => {
+      .map((name, order) => ({ name, order }))
+      .filter(({ name }) => !existingAuto.has(name) && !manualNames.has(name))
+      .map(({ name, order }) => {
         const configId = evalConfigIdMap.get(name);
-        if (!configId) return null;
+        if (!configId) {
+          log.warn(`common_evaluators: "${name}" has no eval config — skipped`);
+          return null;
+        }
         return {
           organizationId: orgId,
           suiteId,
           evalConfigId: configId,
           name,
-          order: i,
+          order,
           required: true,
           source: "auto" as const,
         };

--- a/modelguide-api/src/cli/commands/import-evals.ts
+++ b/modelguide-api/src/cli/commands/import-evals.ts
@@ -22,12 +22,11 @@ import {
 } from "@db/schema";
 import { createEvalConfig } from "@features/eval-configs/eval-configs.service";
 import {
-  createEvaluator,
   createSuite,
   createTestCase,
 } from "@features/evals/eval-suites.service";
 import type { Command } from "commander";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { getErrorMessage } from "../lib/errors";
 import type { IdRegistry } from "../lib/id-registry";
 import { log } from "../lib/logger";
@@ -317,38 +316,20 @@ export async function handleImportEvals(
     // 6b. Load existing test cases for dedup / replace
     const existingTestCases = await loadExistingTestCases(orgId, suiteId);
 
-    // 6c. Compute suite-level evaluators: the union of (a) `common_evaluators`
-    // declared at the top of the yaml (explicit generic evaluators, typically
-    // guardrail-style), and (b) the intersection of per-case evaluators (any
-    // evaluator every test case in this suite already lists). Everything else
-    // stays as a per-case `add` override. This matches the mental model:
-    // suite = baseline every case runs against, overrides = test-case-specific.
-    const caseEvaluatorLists = testCases
-      .filter((tc) => !existingTestCases.has(tc.id))
-      .map((tc) => tc.evaluatorNames);
-    const intersection =
-      caseEvaluatorLists.length > 0
-        ? caseEvaluatorLists.reduce<string[]>(
-            (acc, names) => acc.filter((n) => names.includes(n)),
-            [...new Set(caseEvaluatorLists[0])],
-          )
-        : [];
-    const suiteEvaluatorNames = [
-      ...new Set([...normalized.commonEvaluatorNames, ...intersection]),
-    ];
-
-    // 6d. Attach suite-level evaluators (idempotent: skip names already attached)
-    const alreadyAttached = await loadSuiteEvaluatorNames(orgId, suiteId);
-    for (const name of suiteEvaluatorNames) {
-      if (alreadyAttached.has(name)) continue;
-      const configId = evalConfigIdMap.get(name);
-      if (!configId) continue;
-      await createEvaluator(orgId, suiteId, {
-        evalConfigId: configId,
-        name,
-        required: true,
-      });
-    }
+    // 6c. Reconcile suite-level evaluators against `common_evaluators` yaml.
+    // Suite = "evaluators every case runs". Cases' own evaluator lists become
+    // per-case `add` overrides (excluding those already at suite level).
+    //
+    // Reconcile (not just attach): if a name was removed from common_evaluators,
+    // detach it. Only touch rows with source="auto" — dashboard-added manual
+    // evaluators are preserved.
+    const suiteEvaluatorNames = normalized.commonEvaluatorNames;
+    await reconcileSuiteEvaluators(
+      orgId,
+      suiteId,
+      suiteEvaluatorNames,
+      evalConfigIdMap,
+    );
 
     // 6e. Create or replace test cases with per-case evaluator overrides
     for (const tc of testCases) {
@@ -426,18 +407,71 @@ export async function handleImportEvals(
   return result;
 }
 
-/** Load the set of evaluator names already attached to a suite (for dedup). */
-async function loadSuiteEvaluatorNames(
+/**
+ * Reconcile suite-level evaluators against a target list of names.
+ *
+ * Only rows with source="auto" are touched — manual evaluators added from the
+ * dashboard survive reimports. Missing names are inserted; stale auto rows not
+ * in the target list are removed.
+ */
+async function reconcileSuiteEvaluators(
   orgId: string,
   suiteId: string,
-): Promise<Set<string>> {
-  const rows = await forOrg(orgId, (tx) =>
-    tx
-      .select({ name: evalSuiteEvaluators.name })
+  targetNames: string[],
+  evalConfigIdMap: Map<string, string>,
+): Promise<void> {
+  await forOrg(orgId, async (tx) => {
+    const existing = await tx
+      .select({
+        id: evalSuiteEvaluators.id,
+        name: evalSuiteEvaluators.name,
+        source: evalSuiteEvaluators.source,
+      })
       .from(evalSuiteEvaluators)
-      .where(eq(evalSuiteEvaluators.suiteId, suiteId)),
-  );
-  return new Set(rows.map((r) => r.name));
+      .where(eq(evalSuiteEvaluators.suiteId, suiteId));
+
+    const existingAuto = new Map(
+      existing
+        .filter((r) => r.source === "auto")
+        .map((r) => [r.name, r.id] as const),
+    );
+    const manualNames = new Set(
+      existing.filter((r) => r.source === "manual").map((r) => r.name),
+    );
+    const target = new Set(targetNames);
+
+    // Remove stale auto rows no longer in target
+    const toRemove = [...existingAuto.entries()]
+      .filter(([name]) => !target.has(name))
+      .map(([, id]) => id);
+    if (toRemove.length > 0) {
+      await tx
+        .delete(evalSuiteEvaluators)
+        .where(inArray(evalSuiteEvaluators.id, toRemove));
+    }
+
+    // Insert missing target names (skip any already present as manual)
+    const toInsert = targetNames
+      .filter((n) => !existingAuto.has(n) && !manualNames.has(n))
+      .map((name, i) => {
+        const configId = evalConfigIdMap.get(name);
+        if (!configId) return null;
+        return {
+          organizationId: orgId,
+          suiteId,
+          evalConfigId: configId,
+          name,
+          order: i,
+          required: true,
+          source: "auto" as const,
+        };
+      })
+      .filter((v) => v !== null);
+
+    if (toInsert.length > 0) {
+      await tx.insert(evalSuiteEvaluators).values(toInsert);
+    }
+  });
 }
 
 // ============================================================================

--- a/modelguide-api/src/cli/commands/import-sops.ts
+++ b/modelguide-api/src/cli/commands/import-sops.ts
@@ -13,6 +13,7 @@ import {
   findSopBySlug,
   forkFromTemplate,
   listTemplates,
+  updateSop,
 } from "@features/sops/sops.service";
 import type { SopSchema, SopTrigger } from "@features/sops/sops.types";
 import type { Command } from "commander";
@@ -129,6 +130,23 @@ async function importInlineSop(
   return sop.id;
 }
 
+async function replaceInlineSop(
+  orgId: string,
+  sopId: string,
+  item: SopItemInput,
+  agentIds: string[],
+): Promise<void> {
+  const definition = await buildInlineDefinition(orgId, item);
+
+  await updateSop(orgId, sopId, {
+    name: item.name,
+    description: item.description,
+    definition,
+    agentIds,
+  });
+  log.success(`Updated inline SOP in place: ${item.name}`);
+}
+
 export async function handleImportSops(
   orgId: string,
   items: SopItemInput[],
@@ -153,17 +171,32 @@ export async function handleImportSops(
         options?.registry,
       );
 
-      // If --replace, delete any existing SOP with the same slug first.
-      // Cascade drops sop_steps and agent_sops; the recreate below re-links agents
-      // from the yaml's `agents:` list, so yaml stays the source of truth.
+      // --replace: when an SOP with this slug already exists, update it in
+      // place instead of deleting and recreating. This preserves the SOP's
+      // UUID, so foreign keys pointing at it (eval_suites.sop_id, etc.)
+      // survive the refresh. Template forks fall back to delete+recreate
+      // because forkFromTemplate doesn't have an in-place variant — this
+      // still cascades to eval_suites, so we log that loudly.
       if (options?.replace && item.slug) {
         const existingSop = await findSopBySlug(orgId, item.slug);
         if (existingSop) {
-          await deleteSop(orgId, existingSop.id);
-          log.warn(
-            `Replaced existing SOP: ${existingSop.name} (${item.slug}) — dashboard-only agent links dropped`,
-          );
-          replaced++;
+          if (item.templateSlug) {
+            await deleteSop(orgId, existingSop.id);
+            log.warn(
+              `Re-forked template SOP: ${existingSop.name} (${item.slug}) — eval_suites linked to this SOP were cascade-deleted, re-run import-evals to restore them`,
+            );
+          } else {
+            await replaceInlineSop(orgId, existingSop.id, item, agentIds);
+            if (options.registry) {
+              options.registry.set("sop", item.slug, existingSop.id);
+            }
+            if (item.status === "active") {
+              await activateSop(orgId, existingSop.id);
+              activated++;
+            }
+            replaced++;
+            continue;
+          }
         }
       }
 

--- a/modelguide-api/src/cli/commands/import-sops.ts
+++ b/modelguide-api/src/cli/commands/import-sops.ts
@@ -185,6 +185,7 @@ export async function handleImportSops(
             log.warn(
               `Re-forked template SOP: ${existingSop.name} (${item.slug}) — eval_suites linked to this SOP were cascade-deleted, re-run import-evals to restore them`,
             );
+            replaced++;
           } else {
             await replaceInlineSop(orgId, existingSop.id, item, agentIds);
             if (options.registry) {

--- a/modelguide-api/src/cli/schemas/evals.schema.ts
+++ b/modelguide-api/src/cli/schemas/evals.schema.ts
@@ -63,18 +63,31 @@ export const evalsYamlFileSchema = z
   .object({
     agentSlug: z.string().min(1),
     evaluators: z.array(yamlEvaluatorSchema).min(1),
+    /**
+     * Evaluator names that should run on every test case in every suite for
+     * this agent — typically guardrail-style checks like `does-not-fabricate`
+     * that apply regardless of scenario. Attached at the suite level by the
+     * importer, so the dashboard's "Evaluators" tab shows them.
+     */
+    common_evaluators: z.array(z.string().min(1)).default([]),
     test_cases: z.array(yamlTestCaseSchema).min(1),
   })
   .refine(
     (data) => {
       const definedNames = new Set(data.evaluators.map((e) => e.name));
-      const referenced = data.test_cases.flatMap((tc) => tc.evaluators);
+      const referenced = [
+        ...data.test_cases.flatMap((tc) => tc.evaluators),
+        ...data.common_evaluators,
+      ];
       const missing = referenced.filter((name) => !definedNames.has(name));
       return missing.length === 0;
     },
     (data) => {
       const definedNames = new Set(data.evaluators.map((e) => e.name));
-      const referenced = data.test_cases.flatMap((tc) => tc.evaluators);
+      const referenced = [
+        ...data.test_cases.flatMap((tc) => tc.evaluators),
+        ...data.common_evaluators,
+      ];
       const missing = [
         ...new Set(referenced.filter((name) => !definedNames.has(name))),
       ];
@@ -133,6 +146,8 @@ export interface NormalizedTestCase {
 export interface NormalizedEvalsInput {
   agentSlug: string;
   evaluators: NormalizedEvaluator[];
+  /** Evaluator names to attach at the suite level of every suite (from yaml `common_evaluators`). */
+  commonEvaluatorNames: string[];
   testCases: NormalizedTestCase[];
 }
 
@@ -167,6 +182,7 @@ export function normalizeYaml(
       criterion: e.criterion,
       tags: e.tags,
     })),
+    commonEvaluatorNames: parsed.common_evaluators,
     testCases: parsed.test_cases.map((tc) => ({
       id: tc.id,
       sopSlug: tc.sop_slug,
@@ -219,6 +235,7 @@ export function normalizeJson(
   return {
     agentSlug,
     evaluators,
+    commonEvaluatorNames: [],
     testCases: scenarios.map((s) => ({
       id: s.id,
       sopSlug: s.sop_slug,

--- a/modelguide-api/tests/integration/cli/import-sops.test.ts
+++ b/modelguide-api/tests/integration/cli/import-sops.test.ts
@@ -257,7 +257,7 @@ describe("import-sops", () => {
     ).rejects.toThrow("must have at least one step");
   });
 
-  test("--replace deletes and recreates SOP with same slug", async () => {
+  test("--replace upserts inline SOP in place, preserving sop.id", async () => {
     const createResult = await handleImportSops(
       orgId,
       [
@@ -280,7 +280,7 @@ describe("import-sops", () => {
       orgId,
       [
         {
-          name: "Replaceable SOP",
+          name: "Replaceable SOP (renamed)",
           slug: "replaceable-sop",
           status: "active",
           agents: ["sop-test-agent"],
@@ -293,25 +293,31 @@ describe("import-sops", () => {
       { registry, replace: true },
     );
     expect(replaceResult.replaced).toBe(1);
-    expect(replaceResult.created).toBe(1);
+    // Replaced SOPs are not double-counted as "created"
+    expect(replaceResult.created).toBe(0);
     expect(replaceResult.existing).toBe(0);
+    expect(replaceResult.activated).toBe(1);
 
-    const newId = registry.get("sop", "replaceable-sop");
-    expect(newId).not.toBe(originalId);
+    // ID must be stable — this is what lets eval_suites.sop_id FKs survive
+    const idAfter = registry.get("sop", "replaceable-sop");
+    expect(idAfter).toBe(originalId);
 
+    // Steps fully replaced
     const steps = await forApp(async (tx) => {
-      return tx.select().from(sopSteps).where(eq(sopSteps.sopId, newId));
+      return tx.select().from(sopSteps).where(eq(sopSteps.sopId, originalId));
     });
     expect(steps.length).toBe(2);
     expect(steps.map((s) => s.stepId).sort()).toEqual(["new-a", "new-b"]);
 
-    const originalStillExists = await forApp(async (tx) => {
+    // Name picked up
+    const [sop] = await forApp(async (tx) => {
       return tx.select().from(sops).where(eq(sops.id, originalId));
     });
-    expect(originalStillExists.length).toBe(0);
+    expect(sop.name).toBe("Replaceable SOP (renamed)");
 
+    // Agent assignment survives
     const assignments = await forApp(async (tx) => {
-      return tx.select().from(agentSops).where(eq(agentSops.sopId, newId));
+      return tx.select().from(agentSops).where(eq(agentSops.sopId, originalId));
     });
     expect(assignments.length).toBe(1);
   });


### PR DESCRIPTION
## Summary
Stacked on top of #220.

Gives `import-evals` a way to populate `eval_suite_evaluators`, so the dashboard's "Evaluators" tab is no longer empty for imported suites.

- New optional `common_evaluators: [name, ...]` at the top of `evals.yaml`. Names listed there are attached at the suite level for every suite created for the agent.
- Reconciled on every import: missing names are inserted, stale rows removed. Only rows with `source="auto"` are touched — dashboard-added manual evaluators survive.
- Per-case `add` overrides are no longer created for evaluators already at suite level (no redundant rows).

## Motivation
Previously, `import-evals` treated every per-case evaluator as a `add` override on an empty suite. The dashboard reported "Evaluators (0)" and every test case showed "3 overrides", which hid the intended mental model (suite = generic baseline, overrides = test-case specific).

On bank-nowa Railway demo after this change: each of the 3 suites shows 3 generic evaluators (`does-not-fabricate`, `does-not-reveal-card-data`, `does-not-answer-out-of-scope`) at suite level.

## Design notes / open questions
Worth reviewing before merge — this is a semantic change:

1. **Scope of `common_evaluators`**: file-level (applies to every suite for the agent). Should it instead be per-SOP? (Seemed unnecessary for now — guardrail-style evaluators tend to apply broadly.)
2. **No implicit promotion.** An earlier version also auto-promoted the intersection of per-case evaluator lists; dropped it because the behavior was non-obvious (changed based on which test cases were new vs existing).
3. **Existing bank-nowa / ordinary yaml doesn't use the new key** — no migration needed; importing without `common_evaluators` keeps pre-change behavior (per-case `add` overrides only).
4. **Test case evaluator list semantics**: currently additive (suite + overrides). If a per-case list is `[A, B]` and `common_evaluators: [A, B, C]`, C still runs on that case. That's the existing override-based runtime, not something this PR changes.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint:check` clean
- [x] Manual on Railway demo: cleared + re-imported bank-nowa evals — 3 suites each got 3 auto-source evaluators; zero drift on second re-import.
- [ ] UI regression: dashboard Evaluators tab populates correctly
- [ ] Try removing a name from `common_evaluators:` and re-running — confirm the evaluator is detached from suites but eval_config row stays.