### PR TITLE
fix(lb): route /simulations/* to API service

### DIFF
--- a/railway/DEPLOY.md
+++ b/railway/DEPLOY.md
@@ -115,7 +115,7 @@ railway domain --service lb
 ```
 
 Only Caddy gets a public domain. It routes:
-- `/api/*`, `/docs`, `/docs/*`, `/openapi.json`, `/mcp/*`, `/webhooks/*` → `api.railway.internal:8080`
+- `/api/*`, `/docs`, `/docs/*`, `/openapi.json`, `/mcp/*`, `/webhooks/*`, `/simulations/*` → `api.railway.internal:8080`
 - Everything else → `ui.railway.internal:8080`
 
 The UI uses a relative `/api` prefix — no `VITE_API_URL` needed.

--- a/railway/lb/Caddyfile
+++ b/railway/lb/Caddyfile
@@ -1,5 +1,5 @@
 :{$PORT:80} {
-	@backend path /api/* /docs /docs/* /openapi.json /mcp/* /webhooks/*
+	@backend path /api/* /docs /docs/* /openapi.json /mcp/* /webhooks/* /simulations/*
 	@demo path /acme-demo /acme-demo/*
 
     handle @demo {


### PR DESCRIPTION
## Summary
The simulation MCP endpoint lives at the API root as `/simulations/:simulationId/mcp` (app.ts:130). It was falling through Caddy's `@backend` matcher and hitting the UI service, which returned HTML — so eval `simulate-and-run` failed with:

```
Failed to connect to MCP server simulation: ... Only HTML requests are supported here
```

Fix: add `/simulations/*` to the `@backend` matcher so Caddy proxies it to `api.railway.internal:8080`.

## Test plan
- [x] Verified the failing log message matches the hypothesis (LB returning UI's HTML index for `/simulations/:id/mcp`)
- [ ] After merge + lb redeploy: simulate-and-run on any bank-nowa suite should reach the sim MCP endpoint without the "Only HTML requests are supported here" error