### PR TITLE
docs: correct /simulations/:id/mcp auth comment

### DIFF
--- a/modelguide-api/src/app.ts
+++ b/modelguide-api/src/app.ts
@@ -123,8 +123,11 @@ app.route("/webhooks/elevenlabs", elevenlabsWebhooks);
 // Agent ID in path for explicit routing; API key in header for auth verification.
 app.on(["POST", "GET", "DELETE"], "/mcp/:agentId", mcpHandler);
 
-// Simulation MCP endpoint — internal only, serves mock tools per simulation session.
-// No auth required — called by in-process Mastra agents during simulation runs.
+// Simulation MCP endpoint — serves mock tools per simulation session.
+// Publicly reachable via the LB today (simulation agent dials out via
+// API_EXTERNAL_ADDRESS) but authenticated: handler requires a short-lived
+// (5 min) simulation JWT whose sub matches :simulationId, and rejects
+// sessions not in mode "simulation". See simulation-mcp.routes.ts.
 app.on(
   ["POST", "GET", "DELETE"],
   "/simulations/:simulationId/mcp",

--- a/railway/DEPLOY.md
+++ b/railway/DEPLOY.md
@@ -145,12 +145,27 @@ Optional:
 - `SIMULATION_LLM_API_KEY` — OpenAI (or compatible) API key for persona simulation
 - `SIMULATION_LLM_BASE_URL` — custom base URL for OpenAI-compatible endpoint (defaults to OpenAI). For Claude, set to `https://api.anthropic.com/v1/`
 - `SIMULATION_LLM_MODEL` — model to use for simulation (defaults to `gpt-5-mini`). For Claude, use e.g. `claude-sonnet-4-6`
+- `SIMULATION_AGENT_MODEL` — LLM the **agent-under-test** runs on during `simulate-and-run` (format: `provider/model`, defaults to `anthropic/claude-haiku-4-5-20251001`). Distinct from `SIMULATION_LLM_MODEL` which drives the persona.
 - `EVAL_LLM_API_KEY` — OpenAI (or compatible) API key for eval LLM judge. Falls back to `SIMULATION_LLM_API_KEY`
 - `EVAL_LLM_BASE_URL` — custom base URL for eval LLM endpoint. Falls back to `SIMULATION_LLM_BASE_URL`
 - `EVAL_LLM_MODEL` — model for eval scoring. Falls back to `SIMULATION_LLM_MODEL`
 - `GENERATION_LLM_API_KEY` — API key for synthetic test case generation (Anthropic or OpenAI)
 - `GENERATION_DIMENSION_MODEL` — model for dimension derivation (format: `provider/model`, defaults to `openai/gpt-5.4-mini`)
 - `GENERATION_CASE_MODEL` — model for per-case generation + validation (format: `provider/model`, defaults to `openai/gpt-5.4-mini`)
+
+### Provider-level API keys (gotcha)
+
+`SIMULATION_AGENT_MODEL` is resolved by Mastra's `Agent`, which reads the **provider's standard env var** directly — `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. It does **not** reuse `SIMULATION_LLM_API_KEY` / `EVAL_LLM_API_KEY`. Set whichever of these matches the provider prefix in `SIMULATION_AGENT_MODEL`:
+
+```bash
+# If SIMULATION_AGENT_MODEL starts with "openai/":
+railway variables --set 'OPENAI_API_KEY=${{api.SIMULATION_LLM_API_KEY}}' --service api
+
+# If SIMULATION_AGENT_MODEL starts with "anthropic/":
+railway variables --set "ANTHROPIC_API_KEY=sk-ant-..." --service api
+```
+
+Symptoms if missing: `simulate-and-run` marks runs "failed" in ~1s, sessions are marked `abandoned`, and API logs show `Could not find API key process.env.OPENAI_API_KEY for model id openai/...`.
 
 ## 9. Verify
 


### PR DESCRIPTION
## Summary
The comment above the simulation MCP route registration says *"internal only, no auth required"*. Both parts are wrong in practice and came up in a security review:

- **Not internal.** The simulation agent dials out via `API_EXTERNAL_ADDRESS` (public LB URL) to reach the route — that's why the Caddyfile needed `/simulations/*` in its @backend matcher (#223).
- **Auth IS required.** `simulation-mcp.routes.ts` checks a bearer JWT signed with `JWT_SECRET`, validates `sub === :simulationId`, enforces a 5-min expiry, and rejects sessions not in `mode: "simulation"`.

Replacing the comment with an accurate one so no one reads this later and assumes the endpoint is unauthenticated.

## Security posture (unchanged by this PR — just documenting)
- Session-bound JWT, 5-min expiry → no pivot to other sessions, short replay window
- `mode: "simulation"` guard → production sessions rejected even with a forged token
- Mock tool responses are YAML-sourced test fixtures, not real data

## Possible follow-up (separate)
Switch the simulation MCP URL to an internal hostname (`api.railway.internal:8080` or `localhost:$PORT`) so the route doesn't need to be LB-exposed at all. Would remove #223's Caddyfile rule, but needs a closer look at the adapter and any DNS assumptions before changing.

## Test plan
- [x] Comment-only change, no behavioral impact.