### PR TITLE
fix(evals): stabilize simulate-and-run shutdown

### DIFF
--- a/modelguide-api/src/features/evals/eval-suites.types.ts
+++ b/modelguide-api/src/features/evals/eval-suites.types.ts
@@ -8,6 +8,7 @@
 import type { evalSuiteRuns } from "@db/schema";
 import type { EvalRunScore, NewEvalRunScore } from "@db/schema";
 import type { PaginationParams } from "@lib/pagination";
+import type { SimulationHistoryMessage } from "@features/simulations/transcript";
 import type { InferSelectModel } from "drizzle-orm";
 
 /** Row shape for eval_suite_runs table. */
@@ -73,7 +74,7 @@ export interface SimulationTestCaseInput {
   message?: string;
   persona?: string;
   /** Prior conversation turns for replay tests — stored in session before the live turn. */
-  conversationHistory?: Array<{ role: string; content: string }>;
+  conversationHistory?: SimulationHistoryMessage[];
 }
 
 /** Expected shape of sessions.metadata for simulation sessions. */

--- a/modelguide-api/src/features/evals/eval-suites.types.ts
+++ b/modelguide-api/src/features/evals/eval-suites.types.ts
@@ -7,8 +7,8 @@
 
 import type { evalSuiteRuns } from "@db/schema";
 import type { EvalRunScore, NewEvalRunScore } from "@db/schema";
-import type { PaginationParams } from "@lib/pagination";
 import type { SimulationHistoryMessage } from "@features/simulations/transcript";
+import type { PaginationParams } from "@lib/pagination";
 import type { InferSelectModel } from "drizzle-orm";
 
 /** Row shape for eval_suite_runs table. */

--- a/modelguide-api/src/features/simulations/adapters/agent-adapter.ts
+++ b/modelguide-api/src/features/simulations/adapters/agent-adapter.ts
@@ -1,3 +1,5 @@
+import type { SimulationHistoryMessage } from "../transcript";
+
 /**
  * Agent adapter interface — abstraction between the orchestrator
  * and specific agent implementations (Mastra, LiveKit, etc.).
@@ -37,6 +39,6 @@ export interface AgentAdapter {
   sendMessage(
     sessionId: string,
     message: string,
-    conversationHistory?: Array<{ role: string; content: string }>,
+    conversationHistory?: SimulationHistoryMessage[],
   ): Promise<AgentAdapterResponse>;
 }

--- a/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
+++ b/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
@@ -15,6 +15,10 @@ import { Agent } from "@mastra/core/agent";
 import type { CoreMessage } from "@mastra/core/llm";
 import { MCPClient } from "@mastra/mcp";
 import type { AgentAdapter, AgentAdapterResponse } from "./agent-adapter";
+import {
+  toAgentCoreHistory,
+  type SimulationHistoryMessage,
+} from "../transcript";
 
 const log = getLogger();
 
@@ -73,7 +77,7 @@ export class MastraAdapter implements AgentAdapter {
   async sendMessage(
     sessionId: string,
     message: string,
-    conversationHistory?: Array<{ role: string; content: string }>,
+    conversationHistory?: SimulationHistoryMessage[],
   ): Promise<AgentAdapterResponse> {
     log.debug(
       {
@@ -87,9 +91,9 @@ export class MastraAdapter implements AgentAdapter {
 
     const toolsets = await this.mcpClient.listToolsets();
 
-    // When conversation history is provided (replay tests), build a structured
-    // CoreMessage[] so the model sees prior turns as proper user/assistant messages.
-    // Otherwise, pass the raw string (original single-turn behavior).
+    // When replay history is provided, project the stored transcript into the
+    // agent model's POV before calling Mastra. This keeps "customer" and
+    // "agent" semantics explicit instead of relying on raw chat-role labels.
     const generateOpts = {
       toolsets,
       maxSteps: this.config.maxSteps ?? 5,
@@ -99,10 +103,7 @@ export class MastraAdapter implements AgentAdapter {
       conversationHistory && conversationHistory.length > 0
         ? await this.agent.generate(
             [
-              ...conversationHistory.map((msg) => ({
-                role: msg.role as "user" | "assistant" | "system",
-                content: msg.content,
-              })),
+              ...toAgentCoreHistory(conversationHistory),
               { role: "user" as const, content: message },
             ] as CoreMessage[],
             generateOpts,

--- a/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
+++ b/modelguide-api/src/features/simulations/adapters/mastra-adapter.ts
@@ -14,11 +14,11 @@ import { getLogger } from "@lib/logger";
 import { Agent } from "@mastra/core/agent";
 import type { CoreMessage } from "@mastra/core/llm";
 import { MCPClient } from "@mastra/mcp";
-import type { AgentAdapter, AgentAdapterResponse } from "./agent-adapter";
 import {
-  toAgentCoreHistory,
   type SimulationHistoryMessage,
+  toAgentCoreHistory,
 } from "../transcript";
+import type { AgentAdapter, AgentAdapterResponse } from "./agent-adapter";
 
 const log = getLogger();
 

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -17,6 +17,10 @@ import { getLogger } from "@lib/logger";
 import type { AgentAdapter } from "./adapters/agent-adapter";
 import { generatePersonaMessage } from "./llm-client";
 import type { Persona } from "./personas";
+import {
+  toPersonaLlmHistory,
+  type SimulationHistoryMessage,
+} from "./transcript";
 
 const log = getLogger();
 
@@ -38,7 +42,7 @@ export interface EvalOrchestrationInput {
    * When provided, these are stored in the session as context messages
    * and passed to the adapter so the model sees full conversational history.
    */
-  conversationHistory?: Array<{ role: string; content: string }>;
+  conversationHistory?: SimulationHistoryMessage[];
   /** Timeout in ms (defaults to SIMULATION_TIMEOUT_MS env var). */
   timeoutMs?: number;
   /** Max conversation turns (defaults to SIMULATION_MAX_TURNS env var). */
@@ -143,7 +147,7 @@ async function runConversationLoop(
   if (priorHistory && priorHistory.length > 0) {
     for (const msg of priorHistory) {
       await addMessage(orgId, sessionId, agentId, {
-        role: msg.role as "user" | "assistant",
+        role: msg.role,
         content: msg.content,
         occurredAt: new Date(),
       });
@@ -153,10 +157,7 @@ async function runConversationLoop(
   let currentMessage = inputMessage;
   let turnCount = 0;
   let stopAfterAgentReply = false;
-  const conversationHistory: Array<{
-    role: "user" | "assistant";
-    content: string;
-  }> = [];
+  const conversationHistory: SimulationHistoryMessage[] = [];
 
   for (let turn = 0; turn < maxTurns; turn++) {
     // Store user message
@@ -228,18 +229,12 @@ async function runConversationLoop(
       };
     }
 
-    // Generate persona follow-up with full conversation history.
-    // Role flip: from the persona LLM's POV it IS the customer, so the
-    // customer's prior turns are its own ("assistant") and the agent's
-    // turns are incoming ("user"). Without this flip the persona reads
-    // the agent's messages as its own past outputs and echoes them back.
-    const personaHistory = [
+    // Project the stored transcript into the customer's POV before asking
+    // the persona model for the next turn.
+    const personaHistory = toPersonaLlmHistory([
       ...(priorHistory ?? []),
       ...conversationHistory,
-    ].map((msg) => ({
-      role: msg.role === "user" ? ("assistant" as const) : ("user" as const),
-      content: msg.content,
-    }));
+    ]);
     const personaResponse = await generatePersonaMessage(
       personaHistory,
       persona.systemPrompt,

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -165,13 +165,16 @@ async function runConversationLoop(
       occurredAt: new Date(),
     });
 
-    // Send to agent via adapter — include prior history on the first turn
-    // so the model sees full conversational context for replay tests.
-    const historyForAdapter = turn === 0 ? priorHistory : undefined;
+    // Send to agent via adapter — pass the full running conversation each turn
+    // (priorHistory from replay yaml + everything we've accumulated so far).
+    // Mastra's Agent.generate() is stateless without memory config, so without
+    // this the agent has amnesia on turn 1+ and re-asks questions it already
+    // asked (re-verifies identity, etc.).
+    const historyForAdapter = [...(priorHistory ?? []), ...conversationHistory];
     const agentResponse = await adapter.sendMessage(
       sessionId,
       currentMessage,
-      historyForAdapter,
+      historyForAdapter.length > 0 ? historyForAdapter : undefined,
     );
 
     // Store agent response with tool calls
@@ -224,9 +227,20 @@ async function runConversationLoop(
       };
     }
 
-    // Generate persona follow-up with full conversation history
+    // Generate persona follow-up with full conversation history.
+    // Role flip: from the persona LLM's POV it IS the customer, so the
+    // customer's prior turns are its own ("assistant") and the agent's
+    // turns are incoming ("user"). Without this flip the persona reads
+    // the agent's messages as its own past outputs and echoes them back.
+    const personaHistory = [
+      ...(priorHistory ?? []),
+      ...conversationHistory,
+    ].map((msg) => ({
+      role: msg.role === "user" ? ("assistant" as const) : ("user" as const),
+      content: msg.content,
+    }));
     const personaResponse = await generatePersonaMessage(
-      conversationHistory,
+      personaHistory,
       persona.systemPrompt,
     );
 

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -152,10 +152,7 @@ async function runConversationLoop(
 
   let currentMessage = inputMessage;
   let turnCount = 0;
-  // Used to detect farewell loops: if the persona produces the same output
-  // two turns in a row, both sides are stuck in a goodbye echo and we should
-  // exit instead of burning maxTurns.
-  let previousPersonaMessage: string | undefined;
+  let stopAfterAgentReply = false;
   const conversationHistory: Array<{
     role: "user" | "assistant";
     content: string;
@@ -211,8 +208,8 @@ async function runConversationLoop(
 
     turnCount = turn + 1;
 
-    // If agent signals conversation ended, stop
-    if (agentResponse.conversationEnded) {
+    // Stop after the agent replies to a final persona turn.
+    if (agentResponse.conversationEnded || stopAfterAgentReply) {
       return {
         sessionId,
         turnCount,
@@ -249,28 +246,7 @@ async function runConversationLoop(
     );
 
     currentMessage = personaResponse.content;
-
-    // Farewell-loop guard: once the persona repeats the same short message
-    // two turns running, both sides are almost certainly stuck echoing
-    // goodbyes. Exit rather than wasting the remaining maxTurns.
-    const normalized = normalizeForLoopCompare(currentMessage);
-    if (
-      previousPersonaMessage !== undefined &&
-      normalized.length > 0 &&
-      normalized === normalizeForLoopCompare(previousPersonaMessage)
-    ) {
-      log.info(
-        { sessionId, turnCount, repeated: currentMessage.slice(0, 80) },
-        "persona repeated itself — ending simulation to avoid farewell loop",
-      );
-      return {
-        sessionId,
-        turnCount,
-        status: "completed",
-        durationMs: Date.now() - startTime,
-      };
-    }
-    previousPersonaMessage = currentMessage;
+    stopAfterAgentReply = personaResponse.done;
   }
 
   return {
@@ -285,17 +261,4 @@ function rejectAfterTimeout(ms: number): Promise<never> {
   return new Promise((_, reject) => {
     setTimeout(() => reject(new Error("Simulation timeout")), ms);
   });
-}
-
-/**
- * Normalize a message for loop detection: lowercase, trim, collapse whitespace
- * and strip trailing punctuation. Goal is "Do widzenia!" === "Do widzenia." ===
- * " do widzenia " — all treated as the same farewell.
- */
-function normalizeForLoopCompare(message: string): string {
-  return message
-    .trim()
-    .toLowerCase()
-    .replace(/[\s.,!?;:…]+/g, " ")
-    .trim();
 }

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -15,11 +15,14 @@ import { env } from "@/env";
 import { addMessage, updateSession } from "@features/sessions/sessions.service";
 import { getLogger } from "@lib/logger";
 import type { AgentAdapter } from "./adapters/agent-adapter";
-import { generatePersonaMessage } from "./llm-client";
+import {
+  MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES,
+  generatePersonaMessage,
+} from "./llm-client";
 import type { Persona } from "./personas";
 import {
-  toPersonaLlmHistory,
   type SimulationHistoryMessage,
+  toPersonaLlmHistory,
 } from "./transcript";
 
 const log = getLogger();
@@ -157,6 +160,7 @@ async function runConversationLoop(
   let currentMessage = inputMessage;
   let turnCount = 0;
   let stopAfterAgentReply = false;
+  let consecutivePersonaParseFailures = 0;
   const conversationHistory: SimulationHistoryMessage[] = [];
 
   for (let turn = 0; turn < maxTurns; turn++) {
@@ -240,8 +244,29 @@ async function runConversationLoop(
       persona.systemPrompt,
     );
 
+    // If the persona LLM keeps ignoring the JSON contract we lose the
+    // `done` signal. After N failures in a row, force-stop on the next turn
+    // rather than run until SIMULATION_MAX_TURNS.
+    if (personaResponse.parseFailed) {
+      consecutivePersonaParseFailures++;
+    } else {
+      consecutivePersonaParseFailures = 0;
+    }
+    const forceStop =
+      consecutivePersonaParseFailures >= MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES;
+    if (forceStop) {
+      log.warn(
+        {
+          sessionId,
+          personaId: persona.id,
+          failures: consecutivePersonaParseFailures,
+        },
+        "persona JSON contract broken repeatedly; forcing simulation stop",
+      );
+    }
+
     currentMessage = personaResponse.content;
-    stopAfterAgentReply = personaResponse.done;
+    stopAfterAgentReply = personaResponse.done || forceStop;
   }
 
   return {

--- a/modelguide-api/src/features/simulations/eval-orchestrator.ts
+++ b/modelguide-api/src/features/simulations/eval-orchestrator.ts
@@ -152,6 +152,10 @@ async function runConversationLoop(
 
   let currentMessage = inputMessage;
   let turnCount = 0;
+  // Used to detect farewell loops: if the persona produces the same output
+  // two turns in a row, both sides are stuck in a goodbye echo and we should
+  // exit instead of burning maxTurns.
+  let previousPersonaMessage: string | undefined;
   const conversationHistory: Array<{
     role: "user" | "assistant";
     content: string;
@@ -245,6 +249,28 @@ async function runConversationLoop(
     );
 
     currentMessage = personaResponse.content;
+
+    // Farewell-loop guard: once the persona repeats the same short message
+    // two turns running, both sides are almost certainly stuck echoing
+    // goodbyes. Exit rather than wasting the remaining maxTurns.
+    const normalized = normalizeForLoopCompare(currentMessage);
+    if (
+      previousPersonaMessage !== undefined &&
+      normalized.length > 0 &&
+      normalized === normalizeForLoopCompare(previousPersonaMessage)
+    ) {
+      log.info(
+        { sessionId, turnCount, repeated: currentMessage.slice(0, 80) },
+        "persona repeated itself — ending simulation to avoid farewell loop",
+      );
+      return {
+        sessionId,
+        turnCount,
+        status: "completed",
+        durationMs: Date.now() - startTime,
+      };
+    }
+    previousPersonaMessage = currentMessage;
   }
 
   return {
@@ -259,4 +285,17 @@ function rejectAfterTimeout(ms: number): Promise<never> {
   return new Promise((_, reject) => {
     setTimeout(() => reject(new Error("Simulation timeout")), ms);
   });
+}
+
+/**
+ * Normalize a message for loop detection: lowercase, trim, collapse whitespace
+ * and strip trailing punctuation. Goal is "Do widzenia!" === "Do widzenia." ===
+ * " do widzenia " — all treated as the same farewell.
+ */
+function normalizeForLoopCompare(message: string): string {
+  return message
+    .trim()
+    .toLowerCase()
+    .replace(/[\s.,!?;:…]+/g, " ")
+    .trim();
 }

--- a/modelguide-api/src/features/simulations/llm-client.ts
+++ b/modelguide-api/src/features/simulations/llm-client.ts
@@ -21,6 +21,13 @@ import type {
 const SIMULATION_MAX_TOKENS = 16_000;
 const logger = getLogger();
 
+/**
+ * How many consecutive prose fallbacks from the persona LLM we tolerate before
+ * force-stopping the simulation. Without the `done` signal we'd otherwise burn
+ * the whole max-turns budget every run.
+ */
+export const MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES = 3;
+
 let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
@@ -52,6 +59,13 @@ export interface LlmResponse {
 export interface PersonaMessageResponse {
   content: string;
   done: boolean;
+  /**
+   * True when the model ignored the JSON output contract and we fell back
+   * to treating raw text as the customer utterance. Orchestrators use this
+   * to force termination after several consecutive failures, since without
+   * a `done` signal we'd otherwise burn SIMULATION_MAX_TURNS on every run.
+   */
+  parseFailed?: boolean;
 }
 
 /**
@@ -181,13 +195,16 @@ function buildPersonaSystemPrompt(personaSystemPrompt: string): string {
   return `${personaSystemPrompt.trim()}
 
 Output contract:
-- Stay fully in character.
-- Stay engaged until the agent has fully answered and wrapped up.
-- Respond with valid JSON only.
+- Stay fully in character as the customer.
+- Respond with valid JSON only. No prose, no markdown, no code fences.
 - Use exactly this shape: {"message":"<customer utterance>","done":false}
-- Put only the customer's next utterance in "message" with no extra narration or markdown.
-- Set "done" to true only when this message is your final customer utterance and the simulation should stop after the agent replies to it.
-- Set "done" to false when the conversation should continue beyond the agent's next reply.`;
+- Put only the customer's next utterance in "message".
+
+How to set "done":
+- Classify the "message" you are about to send. If that message itself is a farewell, sign-off, or explicit "no more questions" ("thanks, that's all", "no further questions", "goodbye", "have a good day", or the same thing in any other language), set "done" to true.
+- Set "done" to true even when you are just echoing the agent's goodbye back — that is still a farewell.
+- Set "done" to false in every other case: open questions, confirmations, clarifications, or a thanks that still expects a reply.
+- Never set "done" to true on your very first message.`;
 }
 
 export function parsePersonaMessageResponse(
@@ -196,7 +213,7 @@ export function parsePersonaMessageResponse(
   const trimmed = rawContent?.trim() ?? "";
   if (!trimmed) {
     logger.warn("persona response returned empty content");
-    return { content: "", done: false };
+    return { content: "", done: false, parseFailed: true };
   }
 
   try {
@@ -231,7 +248,7 @@ export function parsePersonaMessageResponse(
     );
   }
 
-  return { content: trimmed, done: false };
+  return { content: trimmed, done: false, parseFailed: true };
 }
 
 function stripJsonCodeFence(content: string): string {

--- a/modelguide-api/src/features/simulations/llm-client.ts
+++ b/modelguide-api/src/features/simulations/llm-client.ts
@@ -49,6 +49,11 @@ export interface LlmResponse {
   toolCalls: LlmToolCall[];
 }
 
+export interface PersonaMessageResponse {
+  content: string;
+  done: boolean;
+}
+
 /**
  * Convert ResolvedTool[] from MCP to OpenAI function-calling format.
  */
@@ -110,20 +115,23 @@ Rules:
 export async function generatePersonaMessage(
   messages: ChatCompletionMessageParam[],
   personaSystemPrompt: string,
-): Promise<LlmResponse> {
+): Promise<PersonaMessageResponse> {
   const openai = getClient();
 
   const response = await openai.chat.completions.create({
     model: env.SIMULATION_LLM_MODEL,
     max_completion_tokens: SIMULATION_MAX_TOKENS,
-    messages: [{ role: "system", content: personaSystemPrompt }, ...messages],
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content: buildPersonaSystemPrompt(personaSystemPrompt),
+      },
+      ...messages,
+    ],
   });
 
-  const choice = response.choices[0];
-  return {
-    content: choice?.message?.content ?? "",
-    toolCalls: [],
-  };
+  return parsePersonaMessageResponse(response.choices[0]?.message?.content);
 }
 
 /**
@@ -167,4 +175,66 @@ export async function generateAgentResponse(
     content: msg?.content ?? "",
     toolCalls,
   };
+}
+
+function buildPersonaSystemPrompt(personaSystemPrompt: string): string {
+  return `${personaSystemPrompt.trim()}
+
+Output contract:
+- Stay fully in character.
+- Stay engaged until the agent has fully answered and wrapped up.
+- Respond with valid JSON only.
+- Use exactly this shape: {"message":"<customer utterance>","done":false}
+- Put only the customer's next utterance in "message" with no extra narration or markdown.
+- Set "done" to true only when this message is your final customer utterance and the simulation should stop after the agent replies to it.
+- Set "done" to false when the conversation should continue beyond the agent's next reply.`;
+}
+
+export function parsePersonaMessageResponse(
+  rawContent: string | null | undefined,
+): PersonaMessageResponse {
+  const trimmed = rawContent?.trim() ?? "";
+  if (!trimmed) {
+    logger.warn("persona response returned empty content");
+    return { content: "", done: false };
+  }
+
+  try {
+    const parsed = JSON.parse(stripJsonCodeFence(trimmed)) as {
+      message?: unknown;
+      content?: unknown;
+      done?: unknown;
+    } | null;
+
+    if (parsed && typeof parsed === "object") {
+      const content =
+        typeof parsed.message === "string"
+          ? parsed.message.trim()
+          : typeof parsed.content === "string"
+            ? parsed.content.trim()
+            : "";
+      const done = typeof parsed.done === "boolean" ? parsed.done : false;
+
+      if (content.length > 0) {
+        return { content, done };
+      }
+    }
+
+    logger.warn(
+      { rawContent: trimmed.slice(0, 200) },
+      "persona response JSON missing message field; falling back to raw text",
+    );
+  } catch {
+    logger.warn(
+      { rawContent: trimmed.slice(0, 200) },
+      "persona response was not valid JSON; falling back to raw text",
+    );
+  }
+
+  return { content: trimmed, done: false };
+}
+
+function stripJsonCodeFence(content: string): string {
+  const match = content.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match?.[1]?.trim() ?? content;
 }

--- a/modelguide-api/src/features/simulations/orchestrator.ts
+++ b/modelguide-api/src/features/simulations/orchestrator.ts
@@ -4,8 +4,6 @@
  */
 
 import { env } from "@/env";
-import { forOrg } from "@db/rls";
-import { sessions } from "@db/schema";
 import {
   executeTool,
   getAgentTools,
@@ -15,11 +13,13 @@ import type { ResolvedTool } from "@features/mcp/mcp.types";
 import {
   addMessage,
   createSession,
+  mergeSessionMetadata,
   updateSession,
 } from "@features/sessions/sessions.service";
-import { eq } from "drizzle-orm";
+import { getLogger } from "@lib/logger";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import {
+  MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES,
   generateAgentResponse,
   generatePersonaMessage,
   toOpenAiTools,
@@ -27,9 +27,11 @@ import {
 import { personaToIdentifier } from "./personas";
 import type { Persona } from "./personas";
 import {
-  toPersonaLlmHistory,
   type SimulationHistoryMessage,
+  toPersonaLlmHistory,
 } from "./transcript";
+
+const log = getLogger();
 
 export interface SimulationResult {
   sessionId: string;
@@ -99,6 +101,7 @@ export async function runSimulation(params: {
   let turnCount = 0;
   let status: SimulationResult["status"] = "completed";
   let error: string | undefined;
+  let consecutivePersonaParseFailures = 0;
 
   try {
     for (let turn = 0; turn < maxTurns; turn++) {
@@ -110,6 +113,28 @@ export async function runSimulation(params: {
         personaLlmHistory,
         persona.systemPrompt,
       );
+
+      // If the persona LLM keeps ignoring the JSON contract we lose the
+      // `done` signal. After N failures in a row, force-stop the simulation
+      // rather than run until SIMULATION_MAX_TURNS.
+      if (personaResponse.parseFailed) {
+        consecutivePersonaParseFailures++;
+      } else {
+        consecutivePersonaParseFailures = 0;
+      }
+      const forceStop =
+        consecutivePersonaParseFailures >=
+        MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES;
+      if (forceStop) {
+        log.warn(
+          {
+            sessionId: session.id,
+            personaId: persona.id,
+            failures: consecutivePersonaParseFailures,
+          },
+          "persona JSON contract broken repeatedly; forcing simulation stop",
+        );
+      }
 
       // Store user message
       await addMessage(orgId, session.id, agentId, {
@@ -203,14 +228,21 @@ export async function runSimulation(params: {
           [],
         );
 
-        await addMessage(orgId, session.id, agentId, {
-          role: "assistant",
-          content: followUp.content,
-          occurredAt: new Date(),
-        });
+        // Skip empty follow-ups — they'd project into empty `user` turns for
+        // the persona on the next loop and confuse it.
+        if (followUp.content.trim().length > 0) {
+          await addMessage(orgId, session.id, agentId, {
+            role: "assistant",
+            content: followUp.content,
+            occurredAt: new Date(),
+          });
 
-        agentHistory.push({ role: "assistant", content: followUp.content });
-        dialogueHistory.push({ role: "assistant", content: followUp.content });
+          agentHistory.push({ role: "assistant", content: followUp.content });
+          dialogueHistory.push({
+            role: "assistant",
+            content: followUp.content,
+          });
+        }
       } else {
         // No tool calls — store the agent's text response directly
         await addMessage(orgId, session.id, agentId, {
@@ -232,7 +264,7 @@ export async function runSimulation(params: {
       turnCount = turn + 1;
 
       // Stop after the agent replies to a persona turn marked final.
-      if (personaResponse.done) {
+      if (personaResponse.done || forceStop) {
         status = "completed";
         break;
       }
@@ -256,21 +288,14 @@ export async function runSimulation(params: {
     // Session may already be ended if error occurred during addMessage
   }
 
-  // Store simulation summary in session metadata
-  await forOrg(orgId, async (tx) => {
-    await tx
-      .update(sessions)
-      .set({
-        metadata: {
-          personaId: persona.id,
-          personaName: persona.name,
-          turnCount,
-          status,
-          durationMs: Date.now() - startTime,
-          ...(error && { error }),
-        },
-      })
-      .where(eq(sessions.id, session.id));
+  // Merge simulation summary into session metadata (preserves the
+  // personaId/personaName written at createSession and anything else a
+  // concurrent writer may have added).
+  await mergeSessionMetadata(orgId, session.id, {
+    turnCount,
+    status,
+    durationMs: Date.now() - startTime,
+    ...(error && { error }),
   });
 
   return {

--- a/modelguide-api/src/features/simulations/orchestrator.ts
+++ b/modelguide-api/src/features/simulations/orchestrator.ts
@@ -26,6 +26,10 @@ import {
 } from "./llm-client";
 import { personaToIdentifier } from "./personas";
 import type { Persona } from "./personas";
+import {
+  toPersonaLlmHistory,
+  type SimulationHistoryMessage,
+} from "./transcript";
 
 export interface SimulationResult {
   sessionId: string;
@@ -86,8 +90,10 @@ export async function runSimulation(params: {
     resolvedTools,
   );
 
-  // Conversation history for the LLM (not stored in DB — DB messages are the source of truth)
-  const personaHistory: ChatCompletionMessageParam[] = [];
+  // Dialogue history tracked in the app's stored transcript semantics:
+  // `user` = customer, `assistant` = agent. We project this into each model's
+  // POV at the boundary rather than relying on inline role inversions.
+  const dialogueHistory: SimulationHistoryMessage[] = [];
   const agentHistory: ChatCompletionMessageParam[] = [];
 
   let turnCount = 0;
@@ -97,16 +103,9 @@ export async function runSimulation(params: {
   try {
     for (let turn = 0; turn < maxTurns; turn++) {
       // --- Persona turn ---
-      // Invert roles for the persona LLM: persona's own messages become
-      // "assistant" (what the model generates), agent messages become "user"
-      // (the prompt). This lets the model naturally continue as the customer.
-      const personaLlmHistory: ChatCompletionMessageParam[] =
-        personaHistory.map(
-          (m): ChatCompletionMessageParam => ({
-            role: m.role === "user" ? "assistant" : "user",
-            content: typeof m.content === "string" ? m.content : "",
-          }),
-        );
+      // Convert the stored transcript into the customer's POV before asking
+      // the persona model for the next reply.
+      const personaLlmHistory = toPersonaLlmHistory(dialogueHistory);
       const personaResponse = await generatePersonaMessage(
         personaLlmHistory,
         persona.systemPrompt,
@@ -119,7 +118,7 @@ export async function runSimulation(params: {
         occurredAt: new Date(),
       });
 
-      personaHistory.push({ role: "user", content: personaResponse.content });
+      dialogueHistory.push({ role: "user", content: personaResponse.content });
       agentHistory.push({ role: "user", content: personaResponse.content });
 
       // --- Agent turn ---
@@ -211,7 +210,7 @@ export async function runSimulation(params: {
         });
 
         agentHistory.push({ role: "assistant", content: followUp.content });
-        personaHistory.push({ role: "assistant", content: followUp.content });
+        dialogueHistory.push({ role: "assistant", content: followUp.content });
       } else {
         // No tool calls — store the agent's text response directly
         await addMessage(orgId, session.id, agentId, {
@@ -224,7 +223,7 @@ export async function runSimulation(params: {
           role: "assistant",
           content: agentResponse.content,
         });
-        personaHistory.push({
+        dialogueHistory.push({
           role: "assistant",
           content: agentResponse.content,
         });

--- a/modelguide-api/src/features/simulations/orchestrator.ts
+++ b/modelguide-api/src/features/simulations/orchestrator.ts
@@ -232,8 +232,8 @@ export async function runSimulation(params: {
 
       turnCount = turn + 1;
 
-      // Check stop condition — persona signals end of conversation
-      if (isConversationEnding(personaResponse.content)) {
+      // Stop after the agent replies to a persona turn marked final.
+      if (personaResponse.done) {
         status = "completed";
         break;
       }
@@ -299,24 +299,4 @@ Guidelines:
 - Use tools when needed to look up information or perform actions
 - Provide clear, concise responses
 - If you can't help with something, explain why`;
-}
-
-/**
- * Simple heuristic to detect if the persona is ending the conversation.
- * Uses word-boundary matching to avoid false positives (e.g. "maybe" matching "bye").
- */
-export function isConversationEnding(content: string): boolean {
-  const lower = content.toLowerCase();
-  const endings = [
-    /\bgoodbye\b/,
-    /\bbye\b/,
-    /that's all\b/,
-    /thanks,?\s*that's all/,
-    /thank you,?\s*goodbye/,
-    /i'll think about it/,
-    /have a good day/,
-    /nothing else\b/,
-    /that's everything\b/,
-  ];
-  return endings.some((re) => re.test(lower));
 }

--- a/modelguide-api/src/features/simulations/transcript.ts
+++ b/modelguide-api/src/features/simulations/transcript.ts
@@ -1,0 +1,112 @@
+import type { CoreMessage } from "@mastra/core/llm";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+/**
+ * Stored/session-facing history shape.
+ *
+ * In app transcripts, `user` means the customer and `assistant` means the
+ * support agent. These labels are correct for storage, but they are *not*
+ * the same thing as "what the currently active model said". The helpers below
+ * project this neutral stored history into the POV each model needs.
+ */
+export interface SimulationHistoryMessage {
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+}
+
+/**
+ * Explicit domain speaker labels used only inside the simulation layer.
+ * This keeps the intent readable before we project into provider-specific
+ * chat roles like `user` / `assistant`.
+ */
+export interface SimulationTranscriptTurn {
+  speaker: "customer" | "agent" | "system" | "tool";
+  content: string;
+}
+
+export function toTranscriptTurns(
+  messages: SimulationHistoryMessage[],
+): SimulationTranscriptTurn[] {
+  return messages.map((message) => ({
+    speaker: historyRoleToSpeaker(message.role),
+    content: message.content,
+  }));
+}
+
+/**
+ * Convert stored transcript history into the persona model's point of view.
+ *
+ * For the persona LLM, `assistant` means "what I, the customer, already said"
+ * and `user` means "what the agent just said to me".
+ */
+export function toPersonaLlmHistory(
+  messages: SimulationHistoryMessage[],
+): ChatCompletionMessageParam[] {
+  const projected: ChatCompletionMessageParam[] = [];
+
+  for (const turn of toTranscriptTurns(messages)) {
+    switch (turn.speaker) {
+      case "customer":
+        projected.push({ role: "assistant", content: turn.content });
+        break;
+      case "agent":
+        projected.push({ role: "user", content: turn.content });
+        break;
+      case "system":
+        projected.push({ role: "system", content: turn.content });
+        break;
+      case "tool":
+        // Tool rows are internal execution details, not spoken dialogue.
+        break;
+    }
+  }
+
+  return projected;
+}
+
+/**
+ * Convert stored transcript history into the agent model's point of view.
+ *
+ * For the agent LLM, `user` remains the customer and `assistant` remains the
+ * agent. System messages are preserved. Tool rows are omitted here because
+ * replay fixtures only carry plain text content, not the structured tool-result
+ * objects that provider tool messages require.
+ */
+export function toAgentCoreHistory(
+  messages: SimulationHistoryMessage[],
+): CoreMessage[] {
+  const projected: CoreMessage[] = [];
+
+  for (const turn of toTranscriptTurns(messages)) {
+    switch (turn.speaker) {
+      case "customer":
+        projected.push({ role: "user", content: turn.content });
+        break;
+      case "agent":
+        projected.push({ role: "assistant", content: turn.content });
+        break;
+      case "system":
+        projected.push({ role: "system", content: turn.content });
+        break;
+      case "tool":
+        break;
+    }
+  }
+
+  return projected;
+}
+
+function historyRoleToSpeaker(
+  role: SimulationHistoryMessage["role"],
+): SimulationTranscriptTurn["speaker"] {
+  switch (role) {
+    case "user":
+      return "customer";
+    case "assistant":
+      return "agent";
+    case "system":
+      return "system";
+    case "tool":
+      return "tool";
+  }
+}

--- a/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
@@ -162,6 +162,64 @@ describe("runEvalSimulation", () => {
     expect(callCount).toBe(2);
   });
 
+  test("passes the full transcript back to the agent on turn 2", async () => {
+    const histories: Array<
+      Array<{ role: string; content: string }> | undefined
+    > = [];
+    let callCount = 0;
+    const adapter: AgentAdapter = {
+      sendMessage: async (_sessionId, _message, history) => {
+        histories.push(history);
+        callCount++;
+        return {
+          response: `Response ${callCount}`,
+          toolCalls: [],
+          conversationEnded: false,
+        };
+      },
+    };
+
+    let personaCallCount = 0;
+    mock.module("@features/simulations/llm-client", () => ({
+      generatePersonaMessage: async () => {
+        personaCallCount++;
+        return personaCallCount === 1
+          ? { content: "One more question.", done: false }
+          : { content: "Thanks, that's all.", done: true };
+      },
+    }));
+
+    const result = await runEvalSimulation({
+      orgId: "org-1",
+      agentId: "agent-1",
+      adapter,
+      inputMessage: "Hi",
+      persona: {
+        id: "test-persona",
+        name: "Test Customer",
+        description: "Test persona",
+        systemPrompt: "You are a customer",
+        traits: ["test"],
+      },
+      sessionId: "pre-created-session",
+      maxTurns: 10,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(callCount).toBe(3);
+    expect(histories[0]).toBeUndefined();
+    expect(histories[1]).toEqual([
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Response 1" },
+    ]);
+    expect(histories[2]).toEqual([
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Response 1" },
+      { role: "user", content: "One more question." },
+      { role: "assistant", content: "Response 2" },
+    ]);
+  });
+
   test("returns error status on adapter failure", async () => {
     const failingAdapter: AgentAdapter = {
       sendMessage: async () => {

--- a/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
@@ -220,6 +220,53 @@ describe("runEvalSimulation", () => {
     ]);
   });
 
+  test("force-stops after N consecutive persona parse failures", async () => {
+    let callCount = 0;
+    const adapter: AgentAdapter = {
+      sendMessage: async () => {
+        callCount++;
+        return {
+          response: `Response ${callCount}`,
+          toolCalls: [],
+          conversationEnded: false,
+        };
+      },
+    };
+
+    // Persona always falls back to raw text (parseFailed: true) — i.e. the
+    // LLM ignores the JSON contract every turn. Without the guard this would
+    // run until maxTurns.
+    mock.module("@features/simulations/llm-client", () => ({
+      MAX_CONSECUTIVE_PERSONA_PARSE_FAILURES: 3,
+      generatePersonaMessage: async () => ({
+        content: "some prose",
+        done: false,
+        parseFailed: true,
+      }),
+    }));
+
+    const result = await runEvalSimulation({
+      orgId: "org-1",
+      agentId: "agent-1",
+      adapter,
+      inputMessage: "Hi",
+      persona: {
+        id: "test-persona",
+        name: "Test Customer",
+        description: "Test persona",
+        systemPrompt: "You are a customer",
+        traits: ["test"],
+      },
+      sessionId: "pre-created-session",
+      maxTurns: 20,
+    });
+
+    // Loop stops after N consecutive failures + one more agent reply.
+    expect(result.status).toBe("completed");
+    expect(result.turnCount).toBeLessThan(20);
+    expect(result.turnCount).toBeLessThanOrEqual(5);
+  });
+
   test("returns error status on adapter failure", async () => {
     const failingAdapter: AgentAdapter = {
       sendMessage: async () => {

--- a/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/eval-orchestrator.test.ts
@@ -59,7 +59,10 @@ describe("runEvalSimulation", () => {
 
     // Mock persona to enable multi-turn
     mock.module("@features/simulations/llm-client", () => ({
-      generatePersonaMessage: async () => ({ content: "follow up" }),
+      generatePersonaMessage: async () => ({
+        content: "follow up",
+        done: false,
+      }),
     }));
 
     const result = await runEvalSimulation({
@@ -116,6 +119,47 @@ describe("runEvalSimulation", () => {
     expect(result.status).toBe("completed");
     expect(result.turnCount).toBe(1);
     expect(callCount).toBe(1);
+  });
+
+  test("lets the agent answer one final persona goodbye before stopping", async () => {
+    let callCount = 0;
+    const adapter: AgentAdapter = {
+      sendMessage: async () => {
+        callCount++;
+        return {
+          response: `Response ${callCount}`,
+          toolCalls: [],
+          conversationEnded: false,
+        };
+      },
+    };
+
+    mock.module("@features/simulations/llm-client", () => ({
+      generatePersonaMessage: async () => ({
+        content: "Thanks, that's all I needed.",
+        done: true,
+      }),
+    }));
+
+    const result = await runEvalSimulation({
+      orgId: "org-1",
+      agentId: "agent-1",
+      adapter,
+      inputMessage: "Hi",
+      persona: {
+        id: "test-persona",
+        name: "Test Customer",
+        description: "Test persona",
+        systemPrompt: "You are a customer",
+        traits: ["test"],
+      },
+      sessionId: "pre-created-session",
+      maxTurns: 10,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.turnCount).toBe(2);
+    expect(callCount).toBe(2);
   });
 
   test("returns error status on adapter failure", async () => {

--- a/modelguide-api/tests/unit/simulations/orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/orchestrator.test.ts
@@ -35,6 +35,15 @@ describe("parsePersonaMessageResponse", () => {
     expect(parsePersonaMessageResponse("Goodbye for now")).toEqual({
       content: "Goodbye for now",
       done: false,
+      parseFailed: true,
+    });
+  });
+
+  test("flags parseFailed on empty content", () => {
+    expect(parsePersonaMessageResponse("")).toEqual({
+      content: "",
+      done: false,
+      parseFailed: true,
     });
   });
 });
@@ -53,6 +62,7 @@ describe("runSimulation", () => {
       addMessage,
       createSession: async () => ({ id: "mock-session-id" }),
       updateSession: async () => ({}),
+      mergeSessionMetadata: async () => ({}),
     }));
 
     mock.module("@db/rls", () => ({
@@ -114,6 +124,7 @@ describe("runSimulation", () => {
       addMessage: async () => ({ id: "mock-message-id" }),
       createSession: async () => ({ id: "mock-session-id" }),
       updateSession: async () => ({}),
+      mergeSessionMetadata: async () => ({}),
     }));
 
     mock.module("@db/rls", () => ({

--- a/modelguide-api/tests/unit/simulations/orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/orchestrator.test.ts
@@ -100,6 +100,74 @@ describe("runSimulation", () => {
     expect(result.turnCount).toBe(1);
     expect(addMessage).toHaveBeenCalledTimes(2);
   });
+
+  test("projects prior dialogue into the persona's customer POV", async () => {
+    const personaHistories: unknown[] = [];
+
+    mock.module("@features/mcp/mcp.service", () => ({
+      executeTool: async () => ({}),
+      getAgentTools: async () => [],
+      resolveConnectorConfigById: async () => ({}),
+    }));
+
+    mock.module("@features/sessions/sessions.service", () => ({
+      addMessage: async () => ({ id: "mock-message-id" }),
+      createSession: async () => ({ id: "mock-session-id" }),
+      updateSession: async () => ({}),
+    }));
+
+    mock.module("@db/rls", () => ({
+      forOrg: async (_orgId: string, cb: (tx: unknown) => Promise<unknown>) =>
+        cb({
+          update: () => ({
+            set: () => ({
+              where: async () => ({}),
+            }),
+          }),
+        }),
+    }));
+
+    let personaCallCount = 0;
+    mock.module("@features/simulations/llm-client", () => ({
+      generateAgentResponse: async () => ({
+        content: "What's your order number?",
+        toolCalls: [],
+      }),
+      generatePersonaMessage: async (history: unknown) => {
+        personaHistories.push(history);
+        personaCallCount++;
+        return personaCallCount === 1
+          ? { content: "I need help with my order.", done: false }
+          : { content: "Thanks, that's all I needed.", done: true };
+      },
+      toOpenAiTools: () => [],
+    }));
+
+    const { runSimulation } = await import(
+      "@features/simulations/orchestrator"
+    );
+
+    const result = await runSimulation({
+      orgId: "org-1",
+      agentId: "agent-1",
+      agentName: "Test Agent",
+      persona: {
+        id: "test-persona",
+        name: "Test Persona",
+        description: "Test persona",
+        systemPrompt: "You are a customer",
+        traits: ["test"],
+      },
+      maxTurns: 5,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(personaHistories[0]).toEqual([]);
+    expect(personaHistories[1]).toEqual([
+      { role: "assistant", content: "I need help with my order." },
+      { role: "user", content: "What's your order number?" },
+    ]);
+  });
 });
 
 // ============================================================================

--- a/modelguide-api/tests/unit/simulations/orchestrator.test.ts
+++ b/modelguide-api/tests/unit/simulations/orchestrator.test.ts
@@ -1,38 +1,104 @@
-import { describe, expect, test } from "bun:test";
-import { isConversationEnding } from "@features/simulations/orchestrator";
+import { describe, expect, mock, test } from "bun:test";
+import { parsePersonaMessageResponse } from "@features/simulations/llm-client";
 import confusedBrowser from "../../fixtures/simulations/confused-browser.json";
 import impatientReturner from "../../fixtures/simulations/impatient-returner.json";
 import politeBuyer from "../../fixtures/simulations/polite-buyer.json";
 
 // ============================================================================
-// isConversationEnding
+// parsePersonaMessageResponse
 // ============================================================================
 
-describe("isConversationEnding", () => {
-  test("detects explicit goodbye phrases", () => {
-    expect(isConversationEnding("Goodbye!")).toBe(true);
-    expect(isConversationEnding("bye")).toBe(true);
-    expect(isConversationEnding("That's all I needed, thank you!")).toBe(true);
-    expect(isConversationEnding("Have a good day!")).toBe(true);
-    expect(isConversationEnding("Nothing else, thanks")).toBe(true);
-    expect(isConversationEnding("That's everything I needed.")).toBe(true);
+describe("parsePersonaMessageResponse", () => {
+  test("parses structured persona output", () => {
+    expect(
+      parsePersonaMessageResponse(
+        '{"message":"Thanks for your help.","done":true}',
+      ),
+    ).toEqual({
+      content: "Thanks for your help.",
+      done: true,
+    });
   });
 
-  test("does not false-positive on words containing ending substrings", () => {
-    expect(isConversationEnding("Maybe I should look at another option")).toBe(
-      false,
+  test("accepts json wrapped in code fences", () => {
+    expect(
+      parsePersonaMessageResponse(
+        '```json\n{"message":"I need one more detail.","done":false}\n```',
+      ),
+    ).toEqual({
+      content: "I need one more detail.",
+      done: false,
+    });
+  });
+
+  test("falls back to raw text when the model ignores the json contract", () => {
+    expect(parsePersonaMessageResponse("Goodbye for now")).toEqual({
+      content: "Goodbye for now",
+      done: false,
+    });
+  });
+});
+
+describe("runSimulation", () => {
+  test("stops after the agent replies to a persona turn marked done", async () => {
+    const addMessage = mock(async () => ({ id: "mock-message-id" }));
+
+    mock.module("@features/mcp/mcp.service", () => ({
+      executeTool: async () => ({}),
+      getAgentTools: async () => [],
+      resolveConnectorConfigById: async () => ({}),
+    }));
+
+    mock.module("@features/sessions/sessions.service", () => ({
+      addMessage,
+      createSession: async () => ({ id: "mock-session-id" }),
+      updateSession: async () => ({}),
+    }));
+
+    mock.module("@db/rls", () => ({
+      forOrg: async (_orgId: string, cb: (tx: unknown) => Promise<unknown>) =>
+        cb({
+          update: () => ({
+            set: () => ({
+              where: async () => ({}),
+            }),
+          }),
+        }),
+    }));
+
+    mock.module("@features/simulations/llm-client", () => ({
+      generateAgentResponse: async () => ({
+        content: "Happy to help. Goodbye!",
+        toolCalls: [],
+      }),
+      generatePersonaMessage: async () => ({
+        content: "Thanks, that's all I needed.",
+        done: true,
+      }),
+      toOpenAiTools: () => [],
+    }));
+
+    const { runSimulation } = await import(
+      "@features/simulations/orchestrator"
     );
-    expect(isConversationEnding("I'll buy it")).toBe(false);
-    expect(isConversationEnding("Can you help me?")).toBe(false);
-    expect(isConversationEnding("I need a bypass for this issue")).toBe(false);
-  });
 
-  test("detects endings in fixture conversations", () => {
-    const lastUserMessage = politeBuyer.messages
-      .filter((m) => m.role === "user")
-      .at(-1);
-    expect(lastUserMessage).toBeDefined();
-    expect(isConversationEnding(lastUserMessage!.content)).toBe(true);
+    const result = await runSimulation({
+      orgId: "org-1",
+      agentId: "agent-1",
+      agentName: "Test Agent",
+      persona: {
+        id: "test-persona",
+        name: "Test Persona",
+        description: "Test persona",
+        systemPrompt: "You are a customer",
+        traits: ["test"],
+      },
+      maxTurns: 5,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.turnCount).toBe(1);
+    expect(addMessage).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/modelguide-api/tests/unit/simulations/transcript.test.ts
+++ b/modelguide-api/tests/unit/simulations/transcript.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  toAgentCoreHistory,
+  toPersonaLlmHistory,
+  toTranscriptTurns,
+} from "@features/simulations/transcript";
+
+describe("simulation transcript projections", () => {
+  const storedHistory = [
+    { role: "system" as const, content: "Keep the customer calm." },
+    { role: "user" as const, content: "I need help with my order." },
+    { role: "assistant" as const, content: "What's your order number?" },
+    { role: "tool" as const, content: "lookup result" },
+  ];
+
+  test("makes customer and agent speakers explicit", () => {
+    expect(toTranscriptTurns(storedHistory)).toEqual([
+      { speaker: "system", content: "Keep the customer calm." },
+      { speaker: "customer", content: "I need help with my order." },
+      { speaker: "agent", content: "What's your order number?" },
+      { speaker: "tool", content: "lookup result" },
+    ]);
+  });
+
+  test("projects stored history into the persona model POV", () => {
+    expect(toPersonaLlmHistory(storedHistory)).toEqual([
+      { role: "system", content: "Keep the customer calm." },
+      { role: "assistant", content: "I need help with my order." },
+      { role: "user", content: "What's your order number?" },
+    ]);
+  });
+
+  test("projects stored history into the agent model POV", () => {
+    expect(toAgentCoreHistory(storedHistory)).toEqual([
+      { role: "system", content: "Keep the customer calm." },
+      { role: "user", content: "I need help with my order." },
+      { role: "assistant", content: "What's your order number?" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Fix three multi-turn simulation bugs in `simulate-and-run`:
- always pass the full running transcript to the adapter so the agent does not forget prior turns
- flip transcript roles before persona generation so the persona continues as the customer instead of echoing the agent
- replace the farewell repetition guard with an explicit persona `{ message, done }` signal so the conversation ends cleanly after the agent replies once to the customer's final goodbye

## Example of the bug
Session `4995d6db-7a05-45a6-8ee4-d2d5164c4665` on demo got stuck with the agent and persona saying goodbye to each other because shutdown was inferred from text patterns instead of an explicit completion signal.

## Root causes

**1. Agent amnesia.** Before:
```ts
const historyForAdapter = turn === 0 ? priorHistory : undefined;
```
Mastra's `Agent.generate()` is stateless without explicit memory config, so on turns 1+ the agent received only the latest user message.

Fix: always pass `[...priorHistory, ...conversationHistory]` so the agent sees the full running transcript.

**2. Persona role inversion.** Before:
```ts
generatePersonaMessage(conversationHistory, persona.systemPrompt);
```
The persona LLM is the customer, so its own prior turns must be `assistant` and the agent's turns must be `user`. Passing unflipped roles made the persona read the agent's messages as its own past outputs.

Fix: flip roles before calling `generatePersonaMessage`. Also include `priorHistory` (flipped) so the persona is aware of any replay seed.

**3. Shutdown was inferred instead of signaled.** Before:
```ts
if (isConversationEnding(personaResponse.content)) { ... }
```
and later a repeated-goodbye guard in `eval-orchestrator.ts`.

Fix: the persona now returns structured JSON with `{ "message": string, "done": boolean }`. The orchestrators stop only when `done === true`, and the eval flow still lets the agent answer that final customer message once before exiting.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test --preload ./tests/setup/unit-preload.ts tests/unit/simulations/orchestrator.test.ts tests/unit/simulations/eval-orchestrator.test.ts`
- [ ] After merge + redeploy: rerun the affected simulation and confirm the conversation exits immediately after the agent answers the persona's final goodbye