### PR TITLE
fix(evals): expose real tool input schema on simulation MCP

### DIFF
--- a/modelguide-api/src/features/simulations/simulation-mcp.routes.ts
+++ b/modelguide-api/src/features/simulations/simulation-mcp.routes.ts
@@ -18,6 +18,8 @@ import { getAgentTools } from "@features/mcp/mcp.service";
 import { createMcpSession } from "@features/mcp/mcp.shared";
 import type { McpToolRegistration } from "@features/mcp/mcp.shared";
 import { mcpErrorResponse, mcpResponse } from "@features/mcp/mcp.types";
+import type { ResolvedTool } from "@features/mcp/mcp.types";
+import { jsonSchemaToZod } from "@features/mcp/schema-utils";
 import { verifySimulationJWT } from "@lib/jwt";
 import { getLogger } from "@lib/logger";
 import { eq } from "drizzle-orm";
@@ -29,22 +31,41 @@ const log = getLogger();
 /**
  * Build MCP tool registrations from mockToolResponses + agent tool list.
  *
- * - Configured tools (in mockToolResponses) → return the mock fixture
- * - Unconfigured tools (in agentTools but not mockToolResponses) → return
- *   "No mock configured for {toolName}" error
+ * - Configured tools (in mockToolResponses) → return the mock fixture.
+ *   Input shape is derived from the real connector tool's JSON schema when
+ *   available, so the agent sees production-accurate signatures and calls
+ *   tools with realistic args (name/PESEL/card_last4 for verify_customer,
+ *   etc.). Falls back to a permissive passthrough if the tool isn't in
+ *   the agent's connector set (standalone mock).
+ * - Unconfigured agent tools → return "No mock configured for {toolName}" error.
  */
 export function buildMockToolsWithFallbacks(
   mockToolResponses: Record<string, unknown>,
-  agentTools: Array<{ mcpName: string; description: string }> = [],
+  agentTools: ResolvedTool[] = [],
 ): McpToolRegistration[] {
   const tools: McpToolRegistration[] = [];
+  const toolByName = new Map(agentTools.map((t) => [t.mcpName, t]));
+
+  // Permissive fallback: accept any args when no schema is available.
+  const passthroughShape = { session_id: z.string().optional() };
 
   // Configured tools — return fixtures
   for (const [toolName, fixture] of Object.entries(mockToolResponses)) {
+    const realTool = toolByName.get(toolName);
+    const inputShape = realTool
+      ? (() => {
+          const shape = jsonSchemaToZod(realTool.inputSchema);
+          // Every connector tool gets session_id tacked on by production MCP,
+          // mirror that here so the simulation agent's call shape matches prod.
+          shape.session_id = z.string().describe("The current session ID");
+          return shape;
+        })()
+      : passthroughShape;
+
     tools.push({
       name: toolName,
-      description: `Mock: ${toolName}`,
-      inputShape: { session_id: z.string().optional() },
+      description: realTool?.description ?? `Mock: ${toolName}`,
+      inputShape,
       handler: async () => {
         log.debug({ tool: toolName }, "simulation mock tool called");
         return mcpResponse(fixture as Record<string, unknown>);
@@ -52,13 +73,16 @@ export function buildMockToolsWithFallbacks(
     });
   }
 
-  // Unconfigured agent tools — return error
+  // Unconfigured agent tools — return error. Use real schema so the agent
+  // still sees a realistic signature before it learns the mock is absent.
   for (const tool of agentTools) {
     if (!mockToolResponses[tool.mcpName]) {
+      const shape = jsonSchemaToZod(tool.inputSchema);
+      shape.session_id = z.string().describe("The current session ID");
       tools.push({
         name: tool.mcpName,
         description: tool.description,
-        inputShape: { session_id: z.string().optional() },
+        inputShape: shape,
         handler: async () => {
           log.debug({ tool: tool.mcpName }, "unconfigured mock tool called");
           return mcpErrorResponse(
@@ -137,10 +161,7 @@ export async function simulationMcpHandler(
       ? await getAgentTools(session.organizationId, session.agentId)
       : [];
 
-  const mockTools = buildMockToolsWithFallbacks(
-    mockToolResponses,
-    agentTools.map((t) => ({ mcpName: t.mcpName, description: t.description })),
-  );
+  const mockTools = buildMockToolsWithFallbacks(mockToolResponses, agentTools);
 
   if (mockTools.length === 0) {
     log.warn(

--- a/modelguide-api/tests/unit/simulations/simulation-mcp.test.ts
+++ b/modelguide-api/tests/unit/simulations/simulation-mcp.test.ts
@@ -8,7 +8,30 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { ResolvedTool } from "@features/mcp/mcp.types";
 import { buildMockToolsWithFallbacks } from "@features/simulations/simulation-mcp.routes";
+
+/** Helper to build a minimal ResolvedTool stub for tests. */
+function stubResolvedTool(
+  mcpName: string,
+  description: string,
+  inputSchema: Record<string, unknown> = {
+    type: "object",
+    properties: {},
+  },
+): ResolvedTool {
+  return {
+    mcpName,
+    description,
+    inputSchema,
+    requiresConfirmation: false,
+    connectorId: "conn-test",
+    connectorSlug: "test_conn",
+    catalogSlug: "test",
+    toolSlug: mcpName.replace(/^[^_]+_/, ""),
+    catalogToolName: mcpName,
+  };
+}
 
 describe("buildMockToolsWithFallbacks", () => {
   test("creates tool registrations from mockToolResponses", () => {
@@ -70,8 +93,8 @@ describe("buildMockToolsWithFallbacks", () => {
       wf_store_look_up_order: { order_id: "ORD-123", status: "shipped" },
     };
     const agentTools = [
-      { mcpName: "wf_store_look_up_order", description: "Look up order" },
-      { mcpName: "wf_helpdesk_create_ticket", description: "Create ticket" },
+      stubResolvedTool("wf_store_look_up_order", "Look up order"),
+      stubResolvedTool("wf_helpdesk_create_ticket", "Create ticket"),
     ];
 
     const tools = buildMockToolsWithFallbacks(mockResponses, agentTools);
@@ -100,14 +123,15 @@ describe("buildMockToolsWithFallbacks", () => {
       tool_b: { result: "b" },
     };
     const agentTools = [
-      { mcpName: "tool_a", description: "Tool A" },
-      { mcpName: "tool_b", description: "Tool B" },
+      stubResolvedTool("tool_a", "Tool A"),
+      stubResolvedTool("tool_b", "Tool B"),
     ];
 
     const tools = buildMockToolsWithFallbacks(mockResponses, agentTools);
     expect(tools).toHaveLength(2);
-    // Both should be configured (Mock: prefix), not fallbacks
-    expect(tools[0].description).toBe("Mock: tool_a");
-    expect(tools[1].description).toBe("Mock: tool_b");
+    // Both should be configured — description mirrors the real tool when
+    // available instead of falling back to the "Mock:" prefix.
+    expect(tools[0].description).toBe("Tool A");
+    expect(tools[1].description).toBe("Tool B");
   });
 });


### PR DESCRIPTION
## Summary
Mock tools in `simulate-and-run` were registered with a fixed
```ts
inputShape: { session_id: z.string().optional() }
```
so the agent could only ever send `{session_id}` as args. Real SOPs bind tools like `verify_customer(name, pesel, card_last4)` — the agent had no way to express the required arguments, so it called every tool with almost nothing and reasoned on the canned mock response as if the args had been correct.

## Symptom
Dashboard tool REQUEST blocks showed only:
```json
{"session_id": "jan.nowak@banknowa.pl"}
```
for every tool call, including ones that needed identity fields, card IDs, etc. Reported by Pablo looking at session `4995d6db-7a05-45a6-8ee4-d2d5164c4665` on demo.

## Fix
Derive each mock tool's input shape from the real connector tool's `inputSchema` (loaded via `getAgentTools`), mirroring what the production MCP handler does via `jsonSchemaToZod` + `session_id`. Mocks still ignore args and return the canned fixture — only the signature seen by the agent changes.

- `buildMockToolsWithFallbacks` now takes `ResolvedTool[]` instead of `{mcpName, description}[]`.
- Tools in the agent's connector set use the real input schema.
- Tools with a mock but no matching connector tool (standalone mock, e.g. a yaml fixture for a non-assigned tool) fall back to the permissive `session_id`-only shape.
- Unconfigured agent tools still return "No mock configured" but now with the real schema too.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint:check` clean
- [x] `bun test tests/unit/simulations/simulation-mcp.test.ts` — 6/6 pass (updated to pass `ResolvedTool[]` stubs)
- [ ] After merge + redeploy: rerun `Simulate & Run` on a bank-nowa full-flow case and confirm REQUEST blocks carry real args (name, pesel, card_last4 for `verify_customer`, etc.)

## Related
- **#229** — separately fixes agent memory, persona role flip, persona-driven end signal, transcript POV refactor. Either PR can merge first; they touch different files.