### PR TITLE
feat(sync): NOT SECURE FOR DEMO PURPOSE ONLY - add session_init webhook tool to ElevenLabs agent

### DIFF
--- a/modelguide-api/src/features/agents/agents.sync.ts
+++ b/modelguide-api/src/features/agents/agents.sync.ts
@@ -371,10 +371,52 @@ async function _syncAgentToElevenLabs(
         }
       : {};
 
+    // Build session-init webhook tool (only when secretId exists)
+    const sessionInitTool = secretId
+      ? [
+          {
+            type: "webhook" as const,
+            name: "session_init",
+            description:
+              "Create a new session in ModelGuide. Call this once at the very start of every conversation to get a session_id. Pass the returned session_id to all subsequent tool calls.",
+            apiSchema: {
+              url: `${baseUrl}/api/sessions`,
+              method: "POST" as const,
+              requestHeaders: {
+                "x-mg-api-key": { secretId },
+              },
+              requestBodySchema: {
+                type: "object" as const,
+                properties: {
+                  channelType: {
+                    type: "string" as const,
+                    constantValue: "voice",
+                  },
+                  userIdentifier: {
+                    type: "string" as const,
+                    description:
+                      "Customer identifier (phone number, email, PESEL, etc.)",
+                  },
+                },
+                required: ["channelType", "userIdentifier"],
+              },
+            },
+            assignments: [
+              {
+                source: "response" as const,
+                dynamicVariable: "mg_session_id",
+                valuePath: "id",
+              },
+            ],
+          },
+        ]
+      : [];
+
     // Build prompt payload — llmModel is guaranteed set (guarded above)
     const promptPayload: Record<string, unknown> = {
       mcpServerIds: mergedMcpIds,
       llm: llmModel,
+      tools: sessionInitTool,
     };
     if (compiledPrompt) {
       promptPayload.prompt = compiledPrompt;
@@ -404,9 +446,14 @@ async function _syncAgentToElevenLabs(
     steps.push({
       step: "Agent configuration",
       status: "success",
-      message: compiledPrompt
-        ? `Applied compiled prompt + LLM model (${llmModel})`
-        : `Applied LLM model (${llmModel}) — no compiled prompt`,
+      message: [
+        compiledPrompt
+          ? `Applied compiled prompt + LLM model (${llmModel})`
+          : `Applied LLM model (${llmModel}) — no compiled prompt`,
+        sessionInitTool.length > 0 ? "+ session_init tool" : null,
+      ]
+        .filter(Boolean)
+        .join(" "),
     });
   } catch (err) {
     steps.push({

--- a/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
+++ b/modelguide-api/src/features/compiler/core/prompt-strategies/gpt-voice-strategy.ts
@@ -86,6 +86,7 @@ export class GptVoiceStrategy implements PromptStrategy {
     }
 
     const staticSections = [
+      "## MANDATORY FIRST ACTION\nBefore saying ANYTHING to the user — you MUST call the `session_init` tool to fetch the session id. Do not speak, do not greet, do not acknowledge the user until this tool has been called and returned a result. Call it exactly once per conversation. Store the result in {{mg_session_id}} and always pass this value as the session_id parameter when calling any tool. If it fails, raise a ticket silently.",
       this.renderRoleAndObjective(agentConfig.description),
       this.renderPersonalityAndTone(agentConfig.promptConfig),
       this.renderReferencePronunciations(),
@@ -178,6 +179,8 @@ export class GptVoiceStrategy implements PromptStrategy {
         ? promptConfig.fillerPhrases
         : DEFAULT_FILLER_PHRASES;
 
+    lines.push(`Every tool requires \`session_id\`: always pass {{mg_session_id}}. This is omitted from individual tool docs below.
+If any tool fails: acknowledge in plain language, retry ONCE, then offer to connect the customer with the team.`);
     lines.push(
       `Approved filler phrases while tools execute: ${fillers.map((f) => `"${f}"`).join(", ")}`,
     );

--- a/modelguide-api/src/lib/middleware/auth.ts
+++ b/modelguide-api/src/lib/middleware/auth.ts
@@ -107,7 +107,8 @@ export function authMiddleware(): MiddlewareHandler<AppBindings> {
     let authContext: AuthContext = { type: "none" };
     let organizationId: string | null = null;
 
-    const token = extractBearerToken(authHeader);
+    const token =
+      extractBearerToken(authHeader) ?? c.req.header("x-mg-api-key") ?? null;
 
     if (token) {
       if (isApiKey(token)) {


### PR DESCRIPTION
This is just for demo purpose only. It pushes agent to use session init tool from within a conversation - this should be done by a wrapper caller before initializing elevenlabs session

Sync now registers a session_init webhook tool that calls POST /api/sessions so the agent creates a ModelGuide session at conversation start. The compiled prompt enforces this as a mandatory first action and documents session_id passing for all tools. Auth middleware also accepts x-mg-api-key header as fallback for ElevenLabs webhook auth.
