### PR TITLE
feat(cli): suite-level evaluators on eval suite import

### DIFF
--- a/modelguide-api/drizzle/0038_add-recorded-test-case-source.sql
+++ b/modelguide-api/drizzle/0038_add-recorded-test-case-source.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."eval_suite_test_case_source" ADD VALUE 'recorded';

--- a/modelguide-api/drizzle/0039_add-eval-suite-evaluators-suite-name-unique.sql
+++ b/modelguide-api/drizzle/0039_add-eval-suite-evaluators-suite-name-unique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "eval_suite_evaluators_suite_name_uidx" ON "eval_suite_evaluators" USING btree ("suite_id","name");

--- a/modelguide-api/drizzle/meta/0036_snapshot.json
+++ b/modelguide-api/drizzle/meta/0036_snapshot.json
@@ -4443,7 +4443,8 @@
         "pending",
         "running",
         "completed",
-        "failed"
+        "failed",
+        "error"
       ]
     },
     "public.eval_suite_run_status": {
@@ -4469,8 +4470,7 @@
       "schema": "public",
       "values": [
         "auto",
-        "manual",
-        "recorded"
+        "manual"
       ]
     },
     "public.eval_suite_test_case_evaluator_override_type": {

--- a/modelguide-api/drizzle/meta/0038_snapshot.json
+++ b/modelguide-api/drizzle/meta/0038_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "851b202d-8e3e-4e80-ae78-58ff2f1856e5",
-  "prevId": "f122be9e-232f-5be4-c56f-2dd86427f17b",
+  "id": "743786fa-e253-4e18-9654-93aa06beb474",
+  "prevId": "851b202d-8e3e-4e80-ae78-58ff2f1856e5",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -4591,7 +4591,8 @@
       "schema": "public",
       "values": [
         "auto",
-        "manual"
+        "manual",
+        "recorded"
       ]
     },
     "public.eval_suite_test_case_evaluator_override_type": {

--- a/modelguide-api/drizzle/meta/0039_snapshot.json
+++ b/modelguide-api/drizzle/meta/0039_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "851b202d-8e3e-4e80-ae78-58ff2f1856e5",
-  "prevId": "f122be9e-232f-5be4-c56f-2dd86427f17b",
+  "id": "a7dc052a-0ee7-4a7d-b3b5-c115ad192829",
+  "prevId": "743786fa-e253-4e18-9654-93aa06beb474",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -3673,6 +3673,27 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "eval_suite_evaluators_suite_name_uidx": {
+          "name": "eval_suite_evaluators_suite_name_uidx",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -4591,7 +4612,8 @@
       "schema": "public",
       "values": [
         "auto",
-        "manual"
+        "manual",
+        "recorded"
       ]
     },
     "public.eval_suite_test_case_evaluator_override_type": {

--- a/modelguide-api/drizzle/meta/_journal.json
+++ b/modelguide-api/drizzle/meta/_journal.json
@@ -272,7 +272,14 @@
       "idx": 38,
       "version": "7",
       "when": 1776450000000,
-      "tag": "0036_add-recorded-test-case-source",
+      "tag": "0038_add-recorded-test-case-source",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1776461934883,
+      "tag": "0039_add-eval-suite-evaluators-suite-name-unique",
       "breakpoints": true
     }
   ]

--- a/modelguide-api/src/cli/commands/import-evals.ts
+++ b/modelguide-api/src/cli/commands/import-evals.ts
@@ -436,9 +436,6 @@ async function reconcileSuiteEvaluators(
         .filter((r) => r.source === "auto")
         .map((r) => [r.name, r.id] as const),
     );
-    const manualNames = new Set(
-      existing.filter((r) => r.source === "manual").map((r) => r.name),
-    );
     const target = new Set(targetNames);
 
     // Remove stale auto rows no longer in target
@@ -451,12 +448,10 @@ async function reconcileSuiteEvaluators(
         .where(inArray(evalSuiteEvaluators.id, toRemove));
     }
 
-    // Insert missing target names (skip any already present as manual).
-    // Index before filter so `order` reflects yaml position, not filtered-array position.
+    // Insert targets; unique constraint on (suiteId, name) prevents duplicates from
+    // concurrent imports and skips names already present as manual rows.
     const toInsert = targetNames
-      .map((name, order) => ({ name, order }))
-      .filter(({ name }) => !existingAuto.has(name) && !manualNames.has(name))
-      .map(({ name, order }) => {
+      .map((name, order) => {
         const configId = evalConfigIdMap.get(name);
         if (!configId) {
           log.warn(`common_evaluators: "${name}" has no eval config — skipped`);
@@ -472,10 +467,15 @@ async function reconcileSuiteEvaluators(
           source: "auto" as const,
         };
       })
-      .filter((v) => v !== null);
+      .filter((v): v is NonNullable<typeof v> => v !== null);
 
     if (toInsert.length > 0) {
-      await tx.insert(evalSuiteEvaluators).values(toInsert);
+      await tx
+        .insert(evalSuiteEvaluators)
+        .values(toInsert)
+        .onConflictDoNothing({
+          target: [evalSuiteEvaluators.suiteId, evalSuiteEvaluators.name],
+        });
     }
   });
 }

--- a/modelguide-api/src/db/schema/eval-suites.ts
+++ b/modelguide-api/src/db/schema/eval-suites.ts
@@ -20,6 +20,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
@@ -180,6 +181,10 @@ export const evalSuiteEvaluators = pgTable(
     index("eval_suite_evaluators_suite_idx").on(table.suiteId),
     index("eval_suite_evaluators_config_idx").on(table.evalConfigId),
     index("eval_suite_evaluators_org_idx").on(table.organizationId),
+    uniqueIndex("eval_suite_evaluators_suite_name_uidx").on(
+      table.suiteId,
+      table.name,
+    ),
   ],
 ).enableRLS();
 

--- a/modelguide-api/tests/integration/cli/import-evals.test.ts
+++ b/modelguide-api/tests/integration/cli/import-evals.test.ts
@@ -279,6 +279,7 @@ afterAll(async () => {
 // Tests: suite-level evaluator reconciliation
 // ============================================================================
 
+// Tests 1–6 run sequentially — each builds on the DB state left by the previous test.
 describe("import-evals — suite-level evaluator reconciliation", () => {
   test("Test 1: first import creates suite and attaches common evaluators as auto rows", async () => {
     const result = await handleImportEvals(
@@ -325,9 +326,13 @@ describe("import-evals — suite-level evaluator reconciliation", () => {
 
   test("Test 3: re-import with same names is idempotent — no duplicates", async () => {
     // Re-import with identical input (suite already exists)
-    await handleImportEvals(orgId, makeInput(SOP_SLUG_RECONCILE, ["e-suite"]), {
-      registry,
-    });
+    const reimportResult = await handleImportEvals(
+      orgId,
+      makeInput(SOP_SLUG_RECONCILE, ["e-suite"]),
+      { registry },
+    );
+    expect(reimportResult.suitesExisting).toBe(1);
+    expect(reimportResult.suitesCreated).toBe(0);
 
     const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
     const rows = await getSuiteEvaluators(suiteId);
@@ -348,6 +353,7 @@ describe("import-evals — suite-level evaluator reconciliation", () => {
     const rows = await getSuiteEvaluators(suiteId);
 
     expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.name).sort()).toEqual(["e-case", "e-suite"]);
   });
 
   test("Test 5: removing a name from common_evaluators deletes its auto row", async () => {

--- a/modelguide-api/tests/integration/cli/import-evals.test.ts
+++ b/modelguide-api/tests/integration/cli/import-evals.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Integration tests for mg import-evals command.
+ *
+ * Tests suite-level evaluator reconciliation behaviour introduced in PR #233:
+ * - commonEvaluatorNames are attached as source="auto" rows in eval_suite_evaluators
+ * - Re-import reconciles: stale auto rows are deleted, missing ones inserted
+ * - Manual rows (source="manual") are never touched
+ * - onConflictDoNothing prevents duplicates on idempotent re-import
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { forApp, forOrg } from "@db/rls";
+import {
+  agents,
+  apiKeys,
+  evalConfigs,
+  evalSuiteEvaluators,
+  evalSuiteTestCases,
+  evalSuites,
+  evalTestCaseEvaluators,
+  organizations,
+  sopSteps,
+  sops,
+  users,
+} from "@db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { handleAddAgents } from "../../../src/cli/commands/add-agents";
+import { handleAddUsers } from "../../../src/cli/commands/add-users";
+import { handleCreateOrg } from "../../../src/cli/commands/create-org";
+import { handleImportEvals } from "../../../src/cli/commands/import-evals";
+import { handleImportSops } from "../../../src/cli/commands/import-sops";
+import { IdRegistry } from "../../../src/cli/lib/id-registry";
+import type { NormalizedEvalsInput } from "../../../src/cli/schemas/evals.schema";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const TEST_SLUG = `cli-evals-test-${Date.now()}`;
+const AGENT_SLUG = "evals-test-agent";
+const SOP_SLUG_RECONCILE = "evals-test-sop-reconcile";
+const SOP_SLUG_EMPTY = "evals-test-sop-empty";
+
+// ============================================================================
+// Shared state
+// ============================================================================
+
+let orgId: string;
+let registry: IdRegistry;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a NormalizedEvalsInput with 2 evaluators (e-suite and e-case),
+ * one test case referencing both evaluators for the given SOP slug,
+ * and the given names promoted to suite level via commonEvaluatorNames.
+ */
+function makeInput(
+  sopSlug: string,
+  commonEvaluatorNames: string[],
+): NormalizedEvalsInput {
+  return {
+    agentSlug: AGENT_SLUG,
+    evaluators: [
+      {
+        name: "e-suite",
+        criterion: "The agent stays polite at all times.",
+        tags: [],
+      },
+      {
+        name: "e-case",
+        criterion: "The agent correctly resolves the customer's issue.",
+        tags: [],
+      },
+    ],
+    commonEvaluatorNames,
+    testCases: [
+      {
+        id: `tc-${sopSlug}-001`,
+        sopSlug,
+        tags: [],
+        guardrailsTested: [],
+        evaluatorNames: ["e-suite", "e-case"],
+        input: {
+          message: "Hello, I need help with my order.",
+        },
+      },
+    ],
+  };
+}
+
+/** Read evalSuiteEvaluators rows for a suite via forOrg. */
+async function getSuiteEvaluators(suiteId: string) {
+  return forOrg(orgId, (tx) =>
+    tx
+      .select()
+      .from(evalSuiteEvaluators)
+      .where(eq(evalSuiteEvaluators.suiteId, suiteId)),
+  );
+}
+
+/** Find the eval suite for (agentId, sopId) via the registry. */
+async function getEvalSuiteId(sopSlug: string): Promise<string> {
+  const sopId = registry.get("sop", sopSlug);
+  const agentId = registry.get("agent", AGENT_SLUG);
+
+  const rows = await forOrg(orgId, (tx) =>
+    tx
+      .select({ id: evalSuites.id })
+      .from(evalSuites)
+      .where(and(eq(evalSuites.agentId, agentId), eq(evalSuites.sopId, sopId))),
+  );
+
+  if (!rows[0]) {
+    throw new Error(
+      `No eval suite found for agent "${AGENT_SLUG}" + SOP "${sopSlug}"`,
+    );
+  }
+  return rows[0].id;
+}
+
+// ============================================================================
+// Setup / teardown
+// ============================================================================
+
+beforeAll(async () => {
+  registry = new IdRegistry();
+
+  const org = await handleCreateOrg({
+    name: "CLI Evals Test",
+    slug: TEST_SLUG,
+    demoEnabled: false,
+  });
+  orgId = org.id;
+
+  await handleAddUsers(orgId, [
+    {
+      email: "evals-admin@test.com",
+      name: "Evals Admin",
+      role: "admin",
+    },
+  ]);
+
+  await handleAddAgents(
+    orgId,
+    [
+      {
+        name: "Evals Test Agent",
+        slug: AGENT_SLUG,
+        modality: "voice",
+        platform: "custom",
+        active: false,
+        tools: [],
+        secrets: [],
+      },
+    ],
+    { registry },
+  );
+
+  // Create the two SOPs that test cases will reference
+  await handleImportSops(
+    orgId,
+    [
+      {
+        name: "Evals Test SOP Reconcile",
+        slug: SOP_SLUG_RECONCILE,
+        agents: [AGENT_SLUG],
+        steps: [
+          {
+            id: "step-1",
+            instruction: "Greet the customer.",
+            required: true,
+          },
+        ],
+      },
+      {
+        name: "Evals Test SOP Empty",
+        slug: SOP_SLUG_EMPTY,
+        agents: [AGENT_SLUG],
+        steps: [
+          {
+            id: "step-1",
+            instruction: "Resolve the customer issue.",
+            required: true,
+          },
+        ],
+      },
+    ],
+    { registry },
+  );
+});
+
+afterAll(async () => {
+  // NOTE: eval suite tables (eval_suites, eval_suite_test_cases, etc.) have RLS
+  // policies that require app.organization_id to be set — they lack bypass_rls_policy.
+  // Use forOrg for those tables, forApp for the rest.
+
+  // 1-6: Clean up eval suite data via forOrg (RLS requires org context)
+  const orgSuites = await forOrg(orgId, (tx) =>
+    tx
+      .select({ id: evalSuites.id })
+      .from(evalSuites)
+      .where(eq(evalSuites.organizationId, orgId)),
+  );
+
+  const suiteIds = orgSuites.map((s) => s.id);
+
+  if (suiteIds.length > 0) {
+    const orgTestCases = await forOrg(orgId, (tx) =>
+      tx
+        .select({ id: evalSuiteTestCases.id })
+        .from(evalSuiteTestCases)
+        .where(inArray(evalSuiteTestCases.suiteId, suiteIds)),
+    );
+
+    const testCaseIds = orgTestCases.map((tc) => tc.id);
+
+    if (testCaseIds.length > 0) {
+      await forOrg(orgId, (tx) =>
+        tx
+          .delete(evalTestCaseEvaluators)
+          .where(inArray(evalTestCaseEvaluators.testCaseId, testCaseIds)),
+      );
+    }
+
+    await forOrg(orgId, (tx) =>
+      tx
+        .delete(evalSuiteTestCases)
+        .where(inArray(evalSuiteTestCases.suiteId, suiteIds)),
+    );
+
+    await forOrg(orgId, (tx) =>
+      tx
+        .delete(evalSuiteEvaluators)
+        .where(inArray(evalSuiteEvaluators.suiteId, suiteIds)),
+    );
+
+    await forOrg(orgId, (tx) =>
+      tx.delete(evalSuites).where(eq(evalSuites.organizationId, orgId)),
+    );
+  }
+
+  // 7-10: Clean up the rest via forApp (these tables have bypass_rls_policy)
+  await forApp(async (tx) => {
+    // 7. Delete evalConfigs (has bypass_rls_policy)
+    await tx.delete(evalConfigs).where(eq(evalConfigs.organizationId, orgId));
+
+    // 8. Clean up SOPs
+    const orgSops = await tx
+      .select({ id: sops.id })
+      .from(sops)
+      .where(eq(sops.organizationId, orgId));
+
+    for (const sop of orgSops) {
+      await tx.delete(sopSteps).where(eq(sopSteps.sopId, sop.id));
+    }
+    await tx.delete(sops).where(eq(sops.organizationId, orgId));
+
+    // 9. Delete agents and their API keys
+    const orgAgents = await tx
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.organizationId, orgId));
+
+    for (const agent of orgAgents) {
+      await tx.delete(apiKeys).where(eq(apiKeys.agentId, agent.id));
+    }
+    await tx.delete(agents).where(eq(agents.organizationId, orgId));
+
+    // 10. Delete users and organization
+    await tx.delete(users).where(eq(users.organizationId, orgId));
+    await tx.delete(organizations).where(eq(organizations.id, orgId));
+  });
+});
+
+// ============================================================================
+// Tests: suite-level evaluator reconciliation
+// ============================================================================
+
+describe("import-evals — suite-level evaluator reconciliation", () => {
+  test("Test 1: first import creates suite and attaches common evaluators as auto rows", async () => {
+    const result = await handleImportEvals(
+      orgId,
+      makeInput(SOP_SLUG_RECONCILE, ["e-suite"]),
+      { registry },
+    );
+
+    expect(result.suitesCreated).toBe(1);
+    expect(result.evalConfigsCreated).toBe(2);
+
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+    const rows = await getSuiteEvaluators(suiteId);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("e-suite");
+    expect(rows[0]!.source).toBe("auto");
+    expect(rows[0]!.order).toBe(0);
+  });
+
+  test("Test 2: per-case override only contains names NOT at suite level", async () => {
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+
+    const testCases = await forOrg(orgId, (tx) =>
+      tx
+        .select({ id: evalSuiteTestCases.id })
+        .from(evalSuiteTestCases)
+        .where(eq(evalSuiteTestCases.suiteId, suiteId)),
+    );
+
+    expect(testCases).toHaveLength(1);
+
+    const overrides = await forOrg(orgId, (tx) =>
+      tx
+        .select()
+        .from(evalTestCaseEvaluators)
+        .where(eq(evalTestCaseEvaluators.testCaseId, testCases[0]!.id)),
+    );
+
+    // e-suite is at suite level so only e-case should be a per-case override
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0]!.name).toBe("e-case");
+  });
+
+  test("Test 3: re-import with same names is idempotent — no duplicates", async () => {
+    // Re-import with identical input (suite already exists)
+    await handleImportEvals(orgId, makeInput(SOP_SLUG_RECONCILE, ["e-suite"]), {
+      registry,
+    });
+
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+    const rows = await getSuiteEvaluators(suiteId);
+
+    // unique constraint + onConflictDoNothing prevents duplicate; still exactly 1
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("e-suite");
+  });
+
+  test("Test 4: adding a name to common_evaluators inserts a new auto row", async () => {
+    await handleImportEvals(
+      orgId,
+      makeInput(SOP_SLUG_RECONCILE, ["e-suite", "e-case"]),
+      { registry },
+    );
+
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+    const rows = await getSuiteEvaluators(suiteId);
+
+    expect(rows).toHaveLength(2);
+  });
+
+  test("Test 5: removing a name from common_evaluators deletes its auto row", async () => {
+    await handleImportEvals(orgId, makeInput(SOP_SLUG_RECONCILE, ["e-suite"]), {
+      registry,
+    });
+
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+    const rows = await getSuiteEvaluators(suiteId);
+
+    // e-case auto row should be removed; only e-suite remains
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("e-suite");
+  });
+
+  test("Test 6: manual rows survive reconcile", async () => {
+    const suiteId = await getEvalSuiteId(SOP_SLUG_RECONCILE);
+
+    // Look up the e-case config ID from the registry (populated in Test 1)
+    const eCaseConfigId = registry.get("evalConfig", "e-case");
+
+    // Manually insert a row with source="manual" for e-case
+    await forOrg(orgId, (tx) =>
+      tx.insert(evalSuiteEvaluators).values({
+        organizationId: orgId,
+        suiteId,
+        evalConfigId: eCaseConfigId,
+        name: "e-case",
+        order: 99,
+        required: true,
+        source: "manual",
+      }),
+    );
+
+    // Re-import with only e-suite in common_evaluators (e-case not in common list)
+    await handleImportEvals(orgId, makeInput(SOP_SLUG_RECONCILE, ["e-suite"]), {
+      registry,
+    });
+
+    const rows = await getSuiteEvaluators(suiteId);
+
+    // manual e-case row should survive; e-suite auto row should still be there
+    expect(rows).toHaveLength(2);
+    const manual = rows.find((r) => r.source === "manual");
+    expect(manual).toBeDefined();
+    expect(manual!.name).toBe("e-case");
+  });
+});
+
+// ============================================================================
+// Tests: empty common_evaluators
+// ============================================================================
+
+describe("import-evals — empty common_evaluators", () => {
+  test("Test 7: empty common_evaluators yields no suite evaluator rows", async () => {
+    const result = await handleImportEvals(
+      orgId,
+      makeInput(SOP_SLUG_EMPTY, []),
+      { registry },
+    );
+
+    expect(result.suitesCreated).toBe(1);
+
+    const suiteId = await getEvalSuiteId(SOP_SLUG_EMPTY);
+    const rows = await getSuiteEvaluators(suiteId);
+
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/modelguide-api/tests/integration/cli/import-evals.test.ts
+++ b/modelguide-api/tests/integration/cli/import-evals.test.ts
@@ -166,6 +166,7 @@ beforeAll(async () => {
       {
         name: "Evals Test SOP Reconcile",
         slug: SOP_SLUG_RECONCILE,
+        status: "active" as const,
         agents: [AGENT_SLUG],
         steps: [
           {
@@ -178,6 +179,7 @@ beforeAll(async () => {
       {
         name: "Evals Test SOP Empty",
         slug: SOP_SLUG_EMPTY,
+        status: "active" as const,
         agents: [AGENT_SLUG],
         steps: [
           {

--- a/modelguide-api/tests/unit/cli/evals-schema.test.ts
+++ b/modelguide-api/tests/unit/cli/evals-schema.test.ts
@@ -145,6 +145,53 @@ describe("evalsYamlFileSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("common_evaluators defaults to empty array", () => {
+    const result = evalsYamlFileSchema.safeParse({
+      agentSlug: "test-agent",
+      evaluators: [
+        { name: "checks-order", criterion: "Agent checks the order" },
+        { name: "no-fabrication", criterion: "Agent does not fabricate" },
+      ],
+      test_cases: [
+        {
+          id: "tc-01",
+          sop_slug: "order-lookup",
+          evaluators: ["checks-order", "no-fabrication"],
+          input: { customer_message: "Where is my order?" },
+        },
+      ],
+      // no common_evaluators key
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.common_evaluators).toEqual([]);
+    }
+  });
+
+  test("rejects common_evaluators referencing undefined evaluator name", () => {
+    const result = evalsYamlFileSchema.safeParse({
+      agentSlug: "test-agent",
+      evaluators: [
+        { name: "checks-order", criterion: "Agent checks the order" },
+      ],
+      common_evaluators: ["nonexistent-evaluator"],
+      test_cases: [
+        {
+          id: "tc-01",
+          sop_slug: "order-lookup",
+          evaluators: ["checks-order"],
+          input: { customer_message: "Where is my order?" },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain(
+        "undefined evaluators: nonexistent-evaluator",
+      );
+    }
+  });
 });
 
 // ============================================================================
@@ -248,6 +295,33 @@ describe("normalizeYaml", () => {
     const result = normalizeYaml(parsed);
     expect(result.testCases[0].input.message).toBe("Hello");
   });
+
+  test("passes common_evaluators through as commonEvaluatorNames", () => {
+    const parsed = evalsYamlFileSchema.parse({
+      agentSlug: "agent",
+      evaluators: [
+        { name: "guardrail-a", criterion: "Agent does not lie" },
+        { name: "guardrail-b", criterion: "Agent stays on topic" },
+      ],
+      common_evaluators: ["guardrail-a"],
+      test_cases: [
+        {
+          id: "tc-1",
+          sop_slug: "sop",
+          evaluators: ["guardrail-a", "guardrail-b"],
+          input: { customer_message: "Hello" },
+        },
+      ],
+    });
+
+    const result = normalizeYaml(parsed);
+
+    expect(result.commonEvaluatorNames).toEqual(["guardrail-a"]);
+    expect(result.testCases[0].evaluatorNames).toEqual([
+      "guardrail-a",
+      "guardrail-b",
+    ]);
+  });
 });
 
 // ============================================================================
@@ -314,5 +388,19 @@ describe("normalizeJson", () => {
     // Names should be unique
     const names = result.evaluators.map((e) => e.name);
     expect(new Set(names).size).toBe(2);
+  });
+
+  test("normalizeJson always returns empty commonEvaluatorNames", () => {
+    const scenarios = evalScenariosJsonSchema.parse([
+      {
+        id: "s-01",
+        sop_slug: "sop",
+        input: { customer_message: "Hi" },
+        expected_output: { criteria: ["Agent responds politely"] },
+      },
+    ]);
+
+    const result = normalizeJson(scenarios, "agent");
+    expect(result.commonEvaluatorNames).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- **DB unique constraint** on `eval_suite_evaluators(suite_id, name)` — prevents duplicate evaluator rows per suite, makes concurrent imports safe
- **`reconcileSuiteEvaluators` uses `ON CONFLICT DO NOTHING`** instead of a pre-insert filter — simpler code, correct under concurrency
- **Suite-level evaluators from `common_evaluators`** — names listed under `common_evaluators` in the YAML are attached as `source="auto"` rows in `eval_suite_evaluators`; re-import reconciles (adds new, removes stale), manual dashboard rows (`source="manual"`) are never touched
- **`import-sops --replace` upserts inline SOPs in place** — preserves `sop.id` so `eval_suites.sop_id` foreign keys survive a re-import; template forks still delete+recreate (no in-place variant) and log a loud warning

## Test coverage

- 4 new unit tests for `common_evaluators` schema validation and `normalizeYaml`/`normalizeJson` pass-through
- 7 new integration tests for suite-level evaluator reconciliation: first import, per-case override filtering, idempotency, add, remove, manual row preservation, empty `common_evaluators`
- All 153 CLI integration tests pass

## Notes

- `eval_suite_evaluators` lacks a `bypass_rls_policy`, so teardown uses `forOrg` (not `forApp`) — documented in test file
- The `(agent_id, sop_id)` pair on `eval_suites` is still a non-unique index; two concurrent `import-evals` invocations could race to create a second suite — logged as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)