### PR TITLE
fix(simulation): resolve tool schemas via in-memory manifest fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ drizzle/meta/
 # Claude Code
 .claude/local/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 **/.claude/settings.local.json
 
 # Skill eval workspaces (run artifacts, not source)

--- a/modelguide-api/src/features/simulations/simulation-mcp.routes.ts
+++ b/modelguide-api/src/features/simulations/simulation-mcp.routes.ts
@@ -12,7 +12,11 @@
 
 import type { AppBindings } from "@/types";
 import { forApp } from "@db/rls";
-import { sessions } from "@db/schema";
+import { connectors, connectorsCatalog, sessions } from "@db/schema";
+import {
+  getConnectorManifest,
+  loadAllManifests,
+} from "@features/connectors/catalog/registry";
 import type { SimulationSessionMetadata } from "@features/evals/eval-suites.types";
 import { getAgentTools } from "@features/mcp/mcp.service";
 import { createMcpSession } from "@features/mcp/mcp.shared";
@@ -22,6 +26,7 @@ import type { ResolvedTool } from "@features/mcp/mcp.types";
 import { jsonSchemaToZod } from "@features/mcp/schema-utils";
 import { verifySimulationJWT } from "@lib/jwt";
 import { getLogger } from "@lib/logger";
+import { toolSlug } from "@lib/slugify";
 import { eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { z } from "zod";
@@ -97,6 +102,79 @@ export function buildMockToolsWithFallbacks(
   return tools;
 }
 
+let manifestsLoaded: Promise<unknown> | null = null;
+async function ensureManifestsLoaded() {
+  manifestsLoaded ??= loadAllManifests();
+  return manifestsLoaded;
+}
+
+/**
+ * Resolve ResolvedTool entries from the in-memory manifest registry for mock
+ * tool names that aren't present in the agent's connector_tools DB rows.
+ *
+ * This handles cases where the connector catalog seed hasn't been applied yet
+ * or where a simulation runs against a connector that exists in the manifest
+ * registry but isn't wired into the agent's tool list.
+ */
+async function resolveToolsFromManifests(
+  orgId: string,
+  toolNames: string[],
+): Promise<ResolvedTool[]> {
+  const rows = await forApp((tx) =>
+    tx
+      .select({
+        instanceId: connectors.id,
+        instanceSlug: connectors.slug,
+        catalogSlug: connectorsCatalog.slug,
+      })
+      .from(connectors)
+      .innerJoin(
+        connectorsCatalog,
+        eq(connectors.connectorCatalogId, connectorsCatalog.id),
+      )
+      .where(eq(connectors.organizationId, orgId)),
+  );
+
+  const slugMap = new Map(
+    rows.map((r) => [
+      r.instanceSlug,
+      { catalogSlug: r.catalogSlug, instanceId: r.instanceId },
+    ]),
+  );
+  await ensureManifestsLoaded();
+
+  const result: ResolvedTool[] = [];
+  for (const mcpName of toolNames) {
+    for (const [instanceSlug, { catalogSlug, instanceId }] of slugMap) {
+      if (!mcpName.startsWith(`${instanceSlug}_`)) continue;
+      const manifest = getConnectorManifest(catalogSlug);
+      if (!manifest) continue;
+      const suffix = mcpName.slice(instanceSlug.length + 1);
+      const manifestTool = manifest.tools.find(
+        (t) => toolSlug(t.catalog.name) === suffix,
+      );
+      if (!manifestTool) continue;
+      result.push({
+        mcpName,
+        description: manifestTool.catalog.description,
+        inputSchema: manifestTool.catalog.inputSchema as Record<
+          string,
+          unknown
+        >,
+        requiresConfirmation:
+          manifestTool.catalog.defaultRequiresConfirmation ?? false,
+        connectorId: instanceId,
+        connectorSlug: instanceSlug,
+        catalogSlug,
+        toolSlug: suffix,
+        catalogToolName: manifestTool.catalog.name,
+      });
+      break;
+    }
+  }
+  return result;
+}
+
 /**
  * Handle simulation MCP requests.
  *
@@ -155,13 +233,27 @@ export async function simulationMcpHandler(
   const metadata = (session.metadata ?? {}) as SimulationSessionMetadata;
   const mockToolResponses = metadata.mockToolResponses ?? {};
 
-  // Load agent tools for fallback registration
+  // Load agent tools for schema resolution
   const agentTools =
     session.agentId && session.organizationId
       ? await getAgentTools(session.organizationId, session.agentId)
       : [];
 
-  const mockTools = buildMockToolsWithFallbacks(mockToolResponses, agentTools);
+  // For mock tools whose schemas aren't in agent_connector_tools (e.g. catalog
+  // seed not applied yet), fall back to the in-memory manifest registry.
+  const resolvedNames = new Set(agentTools.map((t) => t.mcpName));
+  const unmatched = Object.keys(mockToolResponses).filter(
+    (n) => !resolvedNames.has(n),
+  );
+  const fallbackTools =
+    unmatched.length > 0 && session.organizationId
+      ? await resolveToolsFromManifests(session.organizationId, unmatched)
+      : [];
+
+  const mockTools = buildMockToolsWithFallbacks(mockToolResponses, [
+    ...agentTools,
+    ...fallbackTools,
+  ]);
 
   if (mockTools.length === 0) {
     log.warn(


### PR DESCRIPTION
## Summary

When a simulation scenario references a tool that isn't explicitly wired into the agent's `agent_connector_tools` rows (common with `mock_tool_responses` in eval YAML), `getAgentTools` returns no schema for it and the MCP dispatch fails. This adds a fallback that resolves the tool schema from the in-memory connector manifest registry, joined through `connectors` → `connectors_catalog` for the org.

Rebased onto main after [#237 (ADR-013)](https://github.com/modelguide/modelguide/pull/237) merged — dropped the bank-nowa seed/handlers changes since the TypeScript module is now gone. What remains is an independent simulation-runner robustness fix that benefits medusa/zendesk scenarios too.

## Changes

- chore: gitignore .claude/scheduled_tasks.lock
- fix(simulation): resolve tool schemas via in-memory manifest registry fallback

## How to Test

1. Run an eval suite with a scenario whose `mock_tool_responses` references a tool that IS in a connector's manifest but NOT in the agent's enabled tool list.
2. Before this PR: simulation dispatch fails — no schema.
3. After this PR: `resolveToolsFromManifests` finds the schema via the catalog join + manifest registry, and the simulation dispatches successfully.

Cached manifest load means no repeated filesystem walks on subsequent simulations.

## Relationship to ADR-013 / #237

Orthogonal. #237 resolves tool **responses** for dry-run production calls via `connector_tools.mock_response`. This PR resolves tool **schemas** for the simulation runner. Different code path, different concern.

## Verification

- [x] Type check passes
- [x] Lint passes
- [x] Unit tests pass (871)
- [x] Rebased cleanly onto main post-#237