### PR TITLE
feat(ui): voice-activity equalizer for Talk to agent panel

### DIFF
--- a/modelguide-ui/src/features/agents/components/voice-test/room-controller.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test/room-controller.tsx
@@ -118,27 +118,27 @@ export function RoomController({
     )
   }
 
-  const speaking = voiceAssistant.state === 'speaking'
-  const thinking = voiceAssistant.state === 'thinking'
+  // Collapse the LiveKit SDK's voice-assistant state + our widget state into
+  // a single signal the visualizer renders. Keeps animation mapping local.
+  const activity: VoiceActivity =
+    state === 'ENDING'
+      ? 'disconnecting'
+      : voiceAssistant.state === 'speaking'
+        ? 'speaking'
+        : voiceAssistant.state === 'thinking'
+          ? 'thinking'
+          : 'listening'
 
   return (
     <div className="flex items-center gap-2">
       <div
-        className="flex items-center gap-2 rounded-full border border-fg-muted/20 bg-bg-subtle px-3 py-1.5"
+        className="flex h-8 items-center gap-2.5 rounded-full border border-fg-muted/15 bg-bg-subtle/80 pl-3 pr-3.5"
         aria-live="polite"
       >
-        <span
-          className={
-            speaking
-              ? 'h-2 w-2 rounded-full bg-success animate-pulse'
-              : thinking
-                ? 'h-2 w-2 rounded-full bg-warning animate-pulse'
-                : 'h-2 w-2 rounded-full bg-fg-muted'
-          }
-          aria-hidden
-        />
-        <span className="text-xs text-fg-secondary">
-          {speaking ? 'Agent speaking' : thinking ? 'Agent thinking' : 'Listening'}
+        <VoiceVisualizer activity={activity} />
+        <span className="text-xs font-medium text-fg-secondary tracking-wide">
+          <span className="sr-only">Agent </span>
+          {ACTIVITY_LABEL[activity]}
         </span>
       </div>
 
@@ -150,6 +150,68 @@ export function RoomController({
         <PhoneOff className="h-4 w-4" />
         Hang up
       </Button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Voice activity visualizer
+// ---------------------------------------------------------------------------
+
+type VoiceActivity = 'speaking' | 'thinking' | 'listening' | 'disconnecting'
+
+const ACTIVITY_LABEL: Record<VoiceActivity, string> = {
+  speaking: 'Speaking',
+  thinking: 'Thinking',
+  listening: 'Listening',
+  disconnecting: 'Disconnecting',
+}
+
+/**
+ * Four-bar equalizer that reads as "audio is happening" at a glance.
+ *
+ * Speaking: ember bars scale-Y bounce with non-uniform delays so motion
+ *   feels organic, not mechanical. This is the loud signal.
+ * Thinking: warning-tinted bars hold at mid-height and ripple via opacity
+ *   L→R — reads as "working, not vocalizing".
+ * Listening / Disconnecting: static, muted, quietly present.
+ *
+ * prefers-reduced-motion drops all animation in app.css; the static bar
+ * heights still communicate the activity band (speaking=tall, thinking=mid,
+ * listening=low) so state stays legible without motion.
+ */
+function VoiceVisualizer({ activity }: { activity: VoiceActivity }) {
+  // Delays chosen to break sync and feel amplitude-like.
+  const bounceDelays = ['0ms', '150ms', '80ms', '220ms']
+  // Even stride produces a L→R sweep.
+  const waveDelays = ['0ms', '120ms', '240ms', '360ms']
+
+  return (
+    <div className="flex h-4 items-center gap-[3px]" aria-hidden>
+      {[0, 1, 2, 3].map((i) => {
+        const styleByActivity =
+          activity === 'speaking'
+            ? 'h-full bg-brand-500 animate-[voice-bar-bounce_600ms_ease-in-out_infinite]'
+            : activity === 'thinking'
+              ? 'h-[55%] bg-warning/80 animate-[voice-bar-wave_1200ms_ease-in-out_infinite]'
+              : activity === 'disconnecting'
+                ? 'h-[25%] bg-fg-muted/40'
+                : 'h-[30%] bg-fg-muted/70'
+        return (
+          <span
+            key={i}
+            className={`w-[3px] rounded-full origin-center transition-colors ${styleByActivity}`}
+            style={{
+              animationDelay:
+                activity === 'speaking'
+                  ? bounceDelays[i]
+                  : activity === 'thinking'
+                    ? waveDelays[i]
+                    : undefined,
+            }}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/modelguide-ui/src/features/agents/components/voice-test/room-controller.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test/room-controller.tsx
@@ -186,8 +186,12 @@ function VoiceVisualizer({ activity }: { activity: VoiceActivity }) {
   // Even stride produces a L→R sweep.
   const waveDelays = ['0ms', '120ms', '240ms', '360ms']
 
+  // `items-end` + `origin-bottom` anchors the bars to the container's
+  // baseline so they grow upward like every EQ the user has seen (iOS
+  // Siri, Zoom, Slack Huddle, Discord). `origin-center` made the bars
+  // breathe in place — wrong visual vocabulary for audio level.
   return (
-    <div className="flex h-4 items-center gap-[3px]" aria-hidden>
+    <div className="flex h-4 items-end gap-[3px]" aria-hidden>
       {[0, 1, 2, 3].map((i) => {
         const styleByActivity =
           activity === 'speaking'
@@ -200,7 +204,7 @@ function VoiceVisualizer({ activity }: { activity: VoiceActivity }) {
         return (
           <span
             key={i}
-            className={`w-[3px] rounded-full origin-center transition-colors ${styleByActivity}`}
+            className={`w-[3px] rounded-full origin-bottom transition-colors ${styleByActivity}`}
             style={{
               animationDelay:
                 activity === 'speaking'

--- a/modelguide-ui/src/styles/app.css
+++ b/modelguide-ui/src/styles/app.css
@@ -161,6 +161,43 @@
   }
 }
 
+/* Voice activity indicator — used in the Voice Test panel. */
+
+@keyframes voice-bar-bounce {
+  0%,
+  100% {
+    transform: scaleY(0.25);
+  }
+  30% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(0.45);
+  }
+  70% {
+    transform: scaleY(0.85);
+  }
+}
+
+@keyframes voice-bar-wave {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scaleY(0.55);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(0.85);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="animate-[voice-bar-"] {
+    animation: none !important;
+    opacity: 0.7;
+  }
+}
+
 /* Utility classes */
 @layer utilities {
   .animate-fade-up {


### PR DESCRIPTION
## Summary

Replaces the 2×2 px colored dot in the Voice Test panel's in-call toolbar with a 4-bar equalizer that reads as "audio is happening" at a glance. Purely a visual polish PR — no behaviour change, no server-side touches, no new dependencies.

**Base: #240 (stacked).** Merge #240 first, then this rebases onto main and merges cleanly.

## Why a separate PR

#240 is about dispatching to multi-profile workers from the dashboard — a functional + infra concern. The visual polish is a UI concern with its own rationale, its own design-system touches (`app.css` keyframes), and should be reviewed on its own merits. Keeping them separate also keeps #240's CLA/review surface small.

## Changes

- feat(ui): replace 2px status dot with a voice-activity equalizer

## Design

| State | Bars | Color | Motion |
|---|---|---|---|
| speaking | full height | ember `brand-500` | scaleY bounce, 600ms, non-uniform delays (0 / 150 / 80 / 220 ms) so motion feels amplitude-like, not metronomic |
| thinking | 55% height | `warning` @ 80% | opacity wave, 1.2s, L→R stagger — "working, not vocalizing" |
| listening | 30% height | `fg-muted` @ 70% | static |
| disconnecting | 25% height | `fg-muted` @ 40% | static — quieter variant |

Pill chrome (`h-8`, `rounded-full`, `bg-bg-subtle/80`, `fg-muted/15` border) matches the existing phase-badge in the Card header so the two status indicators read as the same design family.

Two keyframes added to `app.css` alongside the existing animation library. `prefers-reduced-motion` block drops animation but keeps the activity band (speaking=tall, thinking=mid, listening=low) readable via static bar heights.

## How to Test

1. Merge or check out #240 + this branch.
2. `make ui-dev`, open an agent detail page with LiveKit configured, click **Talk to agent**.
3. While the agent speaks, the ember bars should bounce like an audio-level EQ. Non-uniform delays mean no two bars hit the same peak simultaneously.
4. During thinking (pre-speech), bars shift to warning-tinted and ripple L→R.
5. During listening (between turns), bars settle low and static in muted grey.
6. Toggle OS-level "Reduce Motion" — animation drops, static bars still communicate state.

## Files

- `modelguide-ui/src/features/agents/components/voice-test/room-controller.tsx` — `VoiceVisualizer` component + activity mapping
- `modelguide-ui/src/styles/app.css` — `voice-bar-bounce` + `voice-bar-wave` keyframes + `prefers-reduced-motion` block

## Verification

- [x] `make ui-typecheck` clean
- [x] `make ui-lint` clean
- [x] `make ui-test` — 268/268 (the existing panel test still passes — visualizer is rendered via `aria-hidden` so no test assertions needed change)
- [x] No new dependencies (pure Tailwind + CSS keyframes)