### PR TITLE
feat(ui): add bank-nowa2 logo for clean-slate demo

### DIFF
--- a/modelguide-ui/public/logos/bank-nowa2.svg
+++ b/modelguide-ui/public/logos/bank-nowa2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="5" fill="#0F3D2E"/>
+  <path d="M5 17V8.5L12 5l7 3.5V17h-2v-7H7v7H5zm4-7h2v7H9v-7zm4 0h2v7h-2v-7zM4 18h16v1H4v-1z" fill="#E8C978"/>
+</svg>


### PR DESCRIPTION
## Summary

Pair with demos PR #10 (`bank-nowa2` clean-slate demo) whose
`connectors.yaml` references `/logos/bank-nowa2.svg`. Copied from
`bank-nowa.svg` as a placeholder — swap for a distinct mark when brand
assets land.

## How to Test

1. Base both this PR and demos PR #10.
2. Run `make ui-dev` and open `/connectors` → Catalog.
3. Confirm Bank Nowa 2 Banking (Mock) row renders its logo.

## Verification

- [x] Lint
- [x] Typecheck
- [x] Logo path matches `demos/bank-nowa2/seed-modelguide/connectors.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)