### PR TITLE
fix(agents): pass agentName in outbound dispatch metadata for multi-profile workers

### DIFF
--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -820,13 +820,13 @@ export async function createOutboundCall(
       apiSecret,
       agentName,
       roomName,
-      {
-        phone_number: data.phoneNumber,
+      buildOutboundDispatchMetadata({
+        agentSlug: agent.slug,
+        sessionId: session.id,
+        phoneNumber: data.phoneNumber,
         email: data.email,
         name: data.name,
-        session_id: session.id,
-        user_identifier: data.phoneNumber,
-      },
+      }),
     );
   } catch (err) {
     await updateSession(orgId, session.id, agentId, { status: "abandoned" });
@@ -834,6 +834,44 @@ export async function createOutboundCall(
   }
 
   return { sessionId: session.id, roomName, dispatchId };
+}
+
+/**
+ * Build the dispatch-metadata payload for an outbound call.
+ *
+ * Mirrors ``buildVoiceTestDispatchMetadata`` — ``agentName`` is the
+ * MG agent slug, which a multi-profile worker reads to pick the matching
+ * profile (``dispatch_metadata.get("agentName")`` in the worker). Without
+ * this field, a worker that hosts more than one profile can't route and
+ * the dispatched call goes silent.
+ *
+ * Extracted as a pure function so the contract is unit-tested rather than
+ * living only inside ``createOutboundCall``.
+ */
+export function buildOutboundDispatchMetadata(input: {
+  agentSlug: string;
+  sessionId: string;
+  phoneNumber: string;
+  email?: string;
+  name?: string;
+}): {
+  mode: "outbound";
+  agentName: string;
+  session_id: string;
+  user_identifier: string;
+  phone_number: string;
+  email?: string;
+  name?: string;
+} {
+  return {
+    mode: "outbound" as const,
+    agentName: input.agentSlug,
+    session_id: input.sessionId,
+    user_identifier: input.phoneNumber,
+    phone_number: input.phoneNumber,
+    ...(input.email !== undefined && { email: input.email }),
+    ...(input.name !== undefined && { name: input.name }),
+  };
 }
 
 // ============================================================================

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -845,6 +845,12 @@ export async function createOutboundCall(
  * this field, a worker that hosts more than one profile can't route and
  * the dispatched call goes silent.
  *
+ * ``user_identifier`` intentionally duplicates ``phone_number`` — downstream
+ * session-attribution joins (transcripts, analytics) use ``user_identifier``
+ * as the stable handle for the caller regardless of the call's modality.
+ * Keeping both fields means callers reading the metadata don't have to know
+ * which one to prefer.
+ *
  * Extracted as a pure function so the contract is unit-tested rather than
  * living only inside ``createOutboundCall``.
  */

--- a/modelguide-api/tests/unit/agents/outbound-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/outbound-dispatch.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Outbound dispatch metadata — locks in the MG-agent-slug ↔ worker-profile
+ * coupling for outbound calls, mirroring the voice-test contract.
+ *
+ * The LiveKit worker's entrypoint (see
+ * `demos/bank-nowa/voice-agent/src/agent.py`) reads `agentName` from the
+ * JSON metadata blob to pick a profile from its registry. Without this
+ * field, a worker that hosts multiple profiles can't route and every
+ * dispatched outbound call goes silent.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildOutboundDispatchMetadata } from "../../../src/features/agents/agents.service";
+
+describe("buildOutboundDispatchMetadata", () => {
+  test("carries agentName = agent.slug for multi-profile routing", () => {
+    const md = buildOutboundDispatchMetadata({
+      agentSlug: "banknowa_v2",
+      sessionId: "sess-abc",
+      phoneNumber: "+15551234567",
+    });
+    expect(md.agentName).toBe("banknowa_v2");
+  });
+
+  test("mode is a literal 'outbound' marker so the worker can branch on it", () => {
+    const md = buildOutboundDispatchMetadata({
+      agentSlug: "ttec",
+      sessionId: "s",
+      phoneNumber: "+1",
+    });
+    expect(md.mode).toBe("outbound");
+  });
+
+  test("phone_number + session_id + user_identifier carry call context", () => {
+    const md = buildOutboundDispatchMetadata({
+      agentSlug: "ttec",
+      sessionId: "sess-xyz",
+      phoneNumber: "+15557654321",
+    });
+    expect(md.session_id).toBe("sess-xyz");
+    expect(md.phone_number).toBe("+15557654321");
+    // user_identifier defaults to the phone number so downstream
+    // session-attribution joins still have a stable handle.
+    expect(md.user_identifier).toBe("+15557654321");
+  });
+
+  test("email + name are included only when provided", () => {
+    const withExtras = buildOutboundDispatchMetadata({
+      agentSlug: "ttec",
+      sessionId: "s",
+      phoneNumber: "+1",
+      email: "c@x.com",
+      name: "Candidate",
+    });
+    expect(withExtras.email).toBe("c@x.com");
+    expect(withExtras.name).toBe("Candidate");
+
+    const minimal = buildOutboundDispatchMetadata({
+      agentSlug: "ttec",
+      sessionId: "s",
+      phoneNumber: "+1",
+    });
+    expect("email" in minimal).toBe(false);
+    expect("name" in minimal).toBe(false);
+  });
+
+  test("agentSlug is echoed verbatim — no mutation", () => {
+    // Guard against a refactor that lowercases/trims the slug; the worker
+    // matches on exact string equality.
+    const weird = "Weird_Slug-v1";
+    const md = buildOutboundDispatchMetadata({
+      agentSlug: weird,
+      sessionId: "s",
+      phoneNumber: "+1",
+    });
+    expect(md.agentName).toBe(weird);
+  });
+
+  test("round-trips through JSON without dropping fields", () => {
+    const md = buildOutboundDispatchMetadata({
+      agentSlug: "banknowa_v1",
+      sessionId: "s",
+      phoneNumber: "+48500000000",
+      email: "c@x.com",
+    });
+    expect(JSON.parse(JSON.stringify(md))).toEqual(md);
+  });
+});


### PR DESCRIPTION
## Summary

Voice-test already sends \`agentName: agent.slug\` in dispatch metadata so
a multi-profile LiveKit worker can route to the matching profile. Outbound
didn't — its metadata carried \`phone_number\` / \`email\` / \`name\` /
\`session_id\` / \`user_identifier\` but no \`agentName\`, so any worker
hosting more than one profile (e.g. bank-nowa2 with v1 + v2 + ttec) had no
way to pick a profile and silently rejected the dispatch.

Extract \`buildOutboundDispatchMetadata\` as a pure function, mirroring the
voice-test builder, and unit-test the contract. Without this test the
MG-side ↔ worker-side coupling is entirely implicit.

## Changes

- \`modelguide-api/src/features/agents/agents.service.ts\` — new
  \`buildOutboundDispatchMetadata\` pure function. \`createOutboundCall\`
  now uses it so the dispatch payload includes
  \`agentName: agent.slug\` + \`mode: \"outbound\"\` marker.
- \`modelguide-api/tests/unit/agents/outbound-dispatch.test.ts\` (new) —
  6 contract tests: shape, verbatim-slug preservation, conditional
  email/name fields, JSON round-trip.

## How to Test

1. Seed a multi-profile demo (e.g. via demos PR #10 bank-nowa2).
2. Call \`POST /agents/:id/outbound-call\` with a phone number.
3. Verify the dispatched worker sees \`agentName\` in job metadata and
   routes to the correct profile.

## Verification

- [x] \`make api-typecheck\` passes
- [x] \`make api-lint-check\` passes
- [x] 886 / 886 unit tests pass (+6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)