### PR TITLE
docs(skills): seed-building learnings from bank-nowa2 rebuild

### DIFF
--- a/.claude/skills/build-agent/SKILL.md
+++ b/.claude/skills/build-agent/SKILL.md
@@ -549,8 +549,32 @@ Always generate:
 - `guardrails.yaml` — from D-08, always include no-fabrication baseline
 - `evals.yaml` — 5-10 test cases per SOP across three shapes: full-flow (happy path + all SOP tool mocks + persona), replay (specific conversational moment via `conversation_history`), and single-turn (guardrail refusals, escalations). See `references/yaml-templates.md` for the structure + `common_evaluators:` pattern. Do NOT hand-write `tool_called` evaluators — the importer auto-derives them from each SOP step's tool binding.
 - `personas.yaml` — start with 1 baseline persona, and add a **variant per branching scenario** your SOPs contain. For example: if a SOP offers "standard vs express card", emit one persona that picks standard and a `-express` variant that picks express. If a SOP handles "recognized vs suspicious transaction", emit one persona that recognizes and another that doesn't. A single catch-all persona can't reliably drive both branches under LLM non-determinism. See `references/yaml-templates.md` for format. Reference in test cases via `persona: <id>`; missing persona ID causes silent fallback to raw message.
+- `sessions.yaml` — 10–15 seeded historical sessions so CSAT / feedback / trend charts render non-empty the moment the import completes. Without this the demo org looks dead on first login. Mix completed + abandoned (~15–20% abandoned), customer + support feedback sources, and cover every SOP branch. See `references/yaml-templates.md` for the distribution rules.
 
 **`agents.yaml`** — see `references/yaml-templates.md` for ElevenLabs and LiveKit formats.
+
+**LiveKit seed pitfalls** (easy to get wrong, caught by the CLI schema):
+- `config:` accepts ONLY `url` + `agentName`. `llmModel` is rejected for livekit
+  agents (it's baked into the worker image).
+- `agentName` in `config` must match the profile key in the worker's
+  `config/agents.yaml` exactly — the worker reads this from dispatch
+  metadata to pick the profile.
+- You MUST declare `livekit_api_key` + `livekit_api_secret` secrets on
+  each livekit agent, with no inline `value:`. That makes `mg setup`
+  prompt interactively at import time. Without them, voice-test and
+  outbound dispatch throw `LiveKit credentials not found` at runtime.
+
+**A/B variants on one worker** — when two agents share a worker but differ in
+one intentional way (e.g. a prompt nudge, a different tool-set):
+- Keep the delta **mechanically isolated**. For Python prompts, put the
+  common parts in a shared module and expose a `build(*, include_X: bool)`
+  helper. Each variant becomes a 3-line wrapper.
+- Lock the invariant with a **byte-for-byte contract test** (e.g.
+  `assert v2.replace(DELTA_BLOCK, "") == v1`). Without this the A/B eval
+  signal drifts silently as prompts get edited.
+- In the seed, each variant is its OWN agent slug and each SOP/guardrail
+  attaches to the agent(s) it actually applies to — shared SOPs to both,
+  delta-specific SOPs to only the matching variant.
 
 Connector handling (same for both platforms):
 - If `connectorStatus: done` (or no custom connector): generate `connectors.yaml` now

--- a/.claude/skills/build-agent/references/yaml-templates.md
+++ b/.claude/skills/build-agent/references/yaml-templates.md
@@ -65,15 +65,46 @@ agents:
     platform: livekit
     active: true
     config:
+      # ONLY url + agentName are allowed here. llmModel is rejected by the
+      # schema for livekit agents (it's baked into the worker image). See
+      # modelguide-api/src/cli/schemas/agents.schema.ts livekitConfigSchema.
       url: "ws://localhost:7880"
-      agentName: "{{agentSlug}}"
+      agentName: "{{agentSlug}}"                       # MUST match the profile key in the worker's config/agents.yaml
     # Conversation-only agents: omit the `tools:` block entirely.
     tools:
       - connectorSlug: "{{connectorSlug}}"
+    # LiveKit requires creds to dispatch the worker into a room. Declaring
+    # the secrets WITHOUT `value:` lets `mg setup` prompt interactively for
+    # them (via add-agents.ts → promptSecret). The API stores only the
+    # encrypted secret ID — `livekit_api_key` / `livekit_api_secret` are the
+    # canonical field names read by agents.service.ts:getAgentSecretByType.
+    secrets:
+      - field: livekit_api_key
+        name: "LiveKit API Key"
+        type: api_key
+      - field: livekit_api_secret
+        name: "LiveKit API Secret"
+        type: api_key
 ```
 
 Conversation-only render: omit the entire `tools:` block. The final
 `agents.yaml` must not contain `connectorSlug`.
+
+### A/B variants on the same worker (bank-nowa2 pattern)
+
+When shipping two prompt variants (e.g. v1 without a proactive nudge, v2 with
+it) on a single LiveKit worker, keep the delta isolated:
+
+- **Python side**: put `SCOPE`, `SCENARIOS`, `CLOSING` in a shared
+  `prompt.py` and expose a `build(*, include_nudge: bool) -> str` helper.
+  Each variant becomes a 3-line wrapper. Lock the invariant with a
+  byte-for-byte test: `assert v2.replace(NUDGE, "") == v1`. This is what
+  makes the A/B eval signal meaningful — any drift on a non-nudge axis
+  pollutes the result.
+- **Seed side**: each variant is its OWN agent slug and OWN LiveKit profile
+  key (e.g. `banknowa2_v1` / `banknowa2_v2`). Shared SOPs attach to both;
+  variant-specific SOPs (the one that contains the nudge step) attach only
+  to the matching agent.
 
 ## connectors.yaml — Medusa (catalog)
 
@@ -414,3 +445,48 @@ To reference a persona in a test case, add `persona: "{{orgSlug}}-customer"` to 
       persona: "{{orgSlug}}-customer"
       conversation_history: [...]
 ```
+
+## sessions.yaml
+
+Seed a handful of historical sessions so the dashboard renders non-empty
+CSAT and feedback coverage the moment `mg setup` finishes. Without this,
+a freshly-imported demo org looks dead — no trend chart, no CSAT, no
+session list — which kills the "it works!" moment.
+
+Aim for **10–15 sessions** with a distribution that tells a story:
+
+- **Balanced across agents** — if two variants exist (v1/v2), split roughly 50/50 so A/B dashboards render both columns.
+- **Realistic abandonment rate** — ~15–20% `status: abandoned` (no feedback block).
+- **CSAT mix** — ~75% `verdict: good`, the rest `bad` with a concrete `comment` pointing at a real failure mode (guardrail violation, wrong step order, missed acknowledgement). Bad cases with specific comments teach more than generic "it was great".
+- **Cover every SOP branch** — if a SOP has a decision point (e.g. "customer recognizes vs doesn't"), seed at least one session on each branch.
+- **Mix `source: customer` and `source: support`** — customer CSAT and support eval coverage look different on the dashboard; both should be non-empty.
+
+```yaml
+sessions:
+  - agentSlug: "{{agentSlug}}"
+    externalId: "seed-{{variant}}-{{scenario}}"   # stable key so re-imports are idempotent
+    channel: voice                        # voice | web | api | slack | widget | sms | whatsapp | email
+    status: completed                     # active | completed | abandoned (default: completed)
+    userIdentifier: "{{phone-or-email}}"
+    hoursAgo: 36                           # timestamps messages N hours in the past
+    messages:
+      - role: assistant
+        content: "{{greeting}}"
+      - role: user
+        content: "{{opening intent}}"
+      - role: tool                         # tool-role message = JSON stringified tool result
+        content: '{"success":true,"customer_id":"CUST-001","card_id":"CARD-001"}'
+      - role: assistant
+        content: "{{next turn}}"
+      # … continue until a closing sign-off
+    feedback:                              # omit for abandoned sessions
+      verdict: good                        # good | bad
+      comment: "{{specific observation — why it was good/bad}}"
+      source: customer                     # customer | support | system
+    links: []                              # optional
+```
+
+**Pitfalls**:
+- Tool-role messages must be JSON strings, not YAML objects. Schema accepts any string but tests/analyzers expect stringified JSON.
+- Every `agentSlug` referenced must exist in `agents.yaml` — unknown slugs fail the import.
+- For tool-calling SOPs, put a tool-role message BEFORE the assistant's natural-language response that uses the result. Readers skim the transcript top-to-bottom and the tool-before-reply ordering is what teaches the SOP flow.

--- a/.claude/skills/mg-cli/SKILL.md
+++ b/.claude/skills/mg-cli/SKILL.md
@@ -161,11 +161,37 @@ agents:
     slug: "acme-voice-agent"
     description: "Handles phone orders"
     modality: voice             # voice | text (default: voice)
-    platform: custom            # custom | elevenlabs (default: custom)
+    platform: custom            # custom | elevenlabs | livekit (default: custom)
     tools:
       - connectorSlug: "acme_store"           # all tools from this connector
       - connectorSlug: "acme_support"
         toolSlugs: [create_ticket, get_ticket] # specific tools only
+```
+
+**For `platform: livekit`** (voice-test + outbound dispatch require this):
+```yaml
+agents:
+  - name: "Acme Voice Agent"
+    slug: "acme-voice-agent"
+    modality: voice
+    platform: livekit
+    config:
+      # Only url + agentName are valid for livekit. llmModel is rejected
+      # (baked into the worker image).
+      url: "wss://your-project.livekit.cloud"
+      agentName: "acme_voice_agent"   # must match the profile key in the worker's config/agents.yaml
+    tools:
+      - connectorSlug: "acme_store"
+    secrets:
+      # No `value:` → `mg setup` prompts once per field. These exact field
+      # names are read by agents.service.ts:getAgentSecretByType when
+      # dispatching the worker.
+      - field: livekit_api_key
+        name: "LiveKit API Key"
+        type: api_key
+      - field: livekit_api_secret
+        name: "LiveKit API Secret"
+        type: api_key
 ```
 
 ### sops.yaml — two modes


### PR DESCRIPTION
## Summary

Encode the non-obvious gotchas surfaced while rebuilding the bank-nowa2
demo from scratch into targeted additions to the \`build-agent\` and
\`mg-cli\` skills. Future seed work benefits without us re-deriving the
lessons.

## What the rebuild revealed

- The LiveKit \`agents.yaml\` template didn't include the
  \`livekit_api_key\` / \`livekit_api_secret\` block. Dispatch fails at
  runtime with \"LiveKit credentials not found\" — hours of debugging if
  you don't know to look.
- \`sessions.yaml\` wasn't in the always-generate list. Freshly-imported
  demos render empty CSAT / feedback / trend charts, which kills the
  first-login moment.
- A/B prompt variants (e.g. wallet-nudge on/off) drift on more than the
  intended axis unless the invariant is mechanically enforced.
  \`build(*, include_X: bool)\` + byte-for-byte contract test is the
  pattern that works.
- \`llmModel\` is rejected by the livekit config schema but the YAML
  template didn't flag it.

## Changes

### \`build-agent/SKILL.md\` — Stage 2a
- Add \`sessions.yaml\` to always-generate (10-15 sessions, ~75% good CSAT,
  ~15-20% abandoned, cover every SOP branch).
- \"LiveKit seed pitfalls\" callout: config field whitelist + mandatory
  interactive-prompt secrets.
- \"A/B variants on one worker\" guidance: shared \`prompt.py\` +
  \`build()\` helper + contract test.

### \`build-agent/references/yaml-templates.md\`
- LiveKit \`agents.yaml\` template now includes the secrets block with
  inline comments explaining the prompt-on-import behavior.
- New \"A/B variants on the same worker\" subsection.
- New top-level \`sessions.yaml\` section with distribution rules and
  common pitfalls.

### \`mg-cli/SKILL.md\`
- \`agents.yaml\` reference now documents \`platform: livekit\` including
  the config shape and secrets convention.

## How to Test

1. Open each modified file and skim. No runtime code changes.
2. Follow the LiveKit flow in \`yaml-templates.md\` and confirm the
   example would parse against \`agents.schema.ts\` (verified during the
   bank-nowa2 build — validates cleanly).

## Verification

- [x] All modified files are markdown-only (no code / no schema changes)
- [x] Patterns cross-reference the MG source code so future edits to
      the schema surface mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)