### PR TITLE
feat(agents): prototype LiveKit voice test with prompt injection (ADR-015)

### DIFF
--- a/docs/decisions/015-prototype-prompt-injection.md
+++ b/docs/decisions/015-prototype-prompt-injection.md
@@ -1,0 +1,152 @@
+# ADR-015: Prototype LiveKit Voice Test via Prompt Injection
+
+**Status:** Accepted (POC)
+
+## Context
+
+[ADR-014](./014-browser-voice-testing.md) added the production Voice Test
+panel: click a button on an agent detail page and talk to the deployed
+LiveKit worker. That ADR explicitly **rejected** prompt injection — the
+worker's profile is the authoritative source of prompt + tools, and shipping
+a different prompt in dispatch metadata creates an "it works in voice-test
+but broke in prod" failure mode.
+
+That trade-off is the right one for the production button. It doesn't fit
+the prompt-iteration workflow:
+
+- The author edits a SOP, recompiles the prompt, and wants to **hear** the
+  new text immediately. With ADR-014 they have to redeploy the worker first,
+  which is slow and out of band of a normal SOP edit.
+- The friction discourages tight iteration. People write the prompt blind
+  and only listen to it once it's been deployed.
+
+[voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox) (the
+inspiration for this POC) and the company's `~/Project/modelguide/website`
+test page both accept the drift trade-off in exchange for a one-click
+"compile → talk" loop. We're carving out the same loop in the dashboard,
+explicitly bounded to a **prototype** worker.
+
+## Decision
+
+Add a parallel flow that injects the compiled prompt into dispatch metadata
+and dispatches a different worker that uses the metadata as its system
+prompt:
+
+- `POST /api/agents/:id/prototype-voice-test-token` — same shape as
+  `voice-test-token` plus `instructionsHash` + `instructionsLength` fields,
+  guarded by `agents:activate`.
+- `buildPrototypeDispatchMetadata` (pure helper, unit-tested) constructs the
+  payload `{ mode, agentName, session_id, user_identifier, email,
+  instructions }`. **Refuses** to build a payload with empty `instructions`.
+- `createPrototypeVoiceTestSession` requires `compiledInstructions` to be
+  non-empty on the agent row. Returns 400 if the agent hasn't been compiled.
+- A new minimal Python worker, `examples/agents/livekit-prototype/`, reads
+  `dispatch_metadata["instructions"]` and uses it as the `Agent(instructions=…)`
+  prompt. No tools, no MCP, no SOPs — just prompt-driven voice.
+- The dashboard's `PrototypeVoiceTestPanel` runs the loop in one click:
+  1. mic-permission probe,
+  2. `POST /agents/:id/compile` (the **Sync** half — guarantees the worker
+     dispatches with the freshest text),
+  3. `POST /agents/:id/prototype-voice-test-token`,
+  4. mounts `<LiveKitRoom>` and joins the room.
+
+This sits **alongside** the production Voice Test panel — not as a
+replacement. The production panel stays the right pre-ship check.
+
+### Worker selection
+
+The agent's `metadata.livekit.agentName` decides which LiveKit worker the
+dispatch lands on. Operators point a prototype-flavoured agent record at the
+prototype worker (`PROTOTYPE_AGENT_NAME` env, default
+`modelguide-prototype`) and the production agent record at the production
+worker. A single org can have both side by side.
+
+### Cross-language contract
+
+`buildPrototypeDispatchMetadata` (TypeScript) and
+`prototype_agent.metadata.parse_dispatch_metadata` (Python) are coupled by a
+JSON shape with no shared type system. **Both sides** have unit tests on the
+field names, presence, and validation rules, and the README's wire-contract
+table cross-links them. If a field renames silently on one side, the test on
+the other side breaks loudly.
+
+### Error taxonomy
+
+| Status | Condition |
+|---|---|
+| 400 | agent not active; modality ≠ voice; platform ≠ livekit; LiveKit URL/agentName missing; LiveKit secrets missing; **`compiledInstructions` empty** |
+| 401 | unauthenticated |
+| 403 | authenticated but lacks `agents:activate` |
+| 404 | agent doesn't exist or belongs to a different org |
+| 500 | LiveKit dispatch or token mint failed (session rolled to `abandoned`) |
+
+## Trade-offs we're explicitly accepting
+
+ADR-014 listed these as reasons to **not** inject a prompt. We accept all
+three, scoped to the prototype path:
+
+1. **Drift between voice-test and prod.** What you hear with the prototype
+   panel is **not** what callers will hear from the deployed worker. The
+   prototype worker has no tools, no MCP, no SOP-step routing. The fix is
+   social: name the panel "Prototype Voice Test" and document it as a
+   prompt-iteration aid, not a pre-ship check.
+2. **Metadata size.** LiveKit dispatch metadata caps at ~48KB. Compiled
+   prompts can be large. We don't add a guard yet — if a prompt overflows,
+   LiveKit's dispatch call returns an error and the existing rollback
+   abandons the session. If this becomes routine, add a 50K-char cap on the
+   API side (see ADR-014's rejected-alternatives rationale).
+3. **Two worker images.** A team running both the production and prototype
+   flow needs two deployments. Worth it for the dev-loop speedup.
+
+## Alternatives considered
+
+**Add a "test mode" flag to the production worker.** Rejected. The
+production worker is multi-profile, MCP-wired, SOP-aware. Forking its
+behaviour on a metadata flag invites the very drift that made ADR-014
+reject prompt injection in the first place — except now in production code.
+
+**Mint a token client-side and connect the browser straight to a
+self-hosted LiveKit Meet.** Rejected. Same issue as ADR-014: shipping the
+LiveKit secret to the browser, plus no MG session tracking.
+
+**Run the prototype agent process in-browser via WebRTC.** Rejected. STT +
+TTS in the browser are quality compromises, and the dispatch-and-deploy
+shape is what we actually want to test (it's the failure surface ops cares
+about).
+
+## Consequences
+
+- Sub-second iteration loop on prompt edits during development. Edit prompt
+  → click → talk.
+- Two LiveKit workers to deploy for an org that wants both. Documented in
+  the prototype README.
+- A second cross-language contract between TS API and Python worker.
+  Mitigated by symmetric unit tests.
+- ADR-014's rejection of prompt injection still applies to the production
+  voice-test path. This ADR is scoped to the prototype path only.
+
+## Test coverage
+
+- Pure helper: 8 unit tests in
+  `modelguide-api/tests/unit/agents/prototype-voice-test-dispatch.test.ts`
+  (locks shape + field names + validation).
+- Endpoint: 7 integration tests in
+  `modelguide-api/tests/integration/agents.test.ts` (each error path:
+  401, 403, 404 unknown, 404 cross-org, 400 inactive, 400 non-livekit, 400
+  non-voice, 400 missing compiled prompt).
+- Python worker contract: 11 unit tests in
+  `examples/agents/livekit-prototype/tests/test_metadata.py` (happy path +
+  bad JSON + missing required fields + whitespace + fallback paths).
+- UI: 5 unit tests in
+  `modelguide-ui/src/features/agents/components/prototype-voice-test-panel.test.tsx`
+  (renders for LiveKit only, gates on `livekitConfigured`, gates on
+  `canMutate`, **compile-then-dispatch order**, mic-denial path).
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls — the dispatch primitive both flows share.
+- ADR-014: Browser Voice Testing — the production flow that this prototype
+  pairs with (and that this ADR's "what about drift?" trade-off references).
+- voiceblox-ai/voiceblox — design inspiration for the dev-loop UX.
+- `examples/agents/livekit-prototype/README.md` — runbook for deploying the
+  prototype worker.

--- a/examples/agents/livekit-prototype/.gitignore
+++ b/examples/agents/livekit-prototype/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+*.egg-info/

--- a/examples/agents/livekit-prototype/Dockerfile
+++ b/examples/agents/livekit-prototype/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Pre-download Silero VAD weights so cold-start doesn't hit the network.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app/src
+
+USER agent
+CMD ["python", "-m", "prototype_agent.agent", "start"]

--- a/examples/agents/livekit-prototype/README.md
+++ b/examples/agents/livekit-prototype/README.md
@@ -1,0 +1,135 @@
+# LiveKit Prototype Worker
+
+A minimal LiveKit voice agent that reads its **system prompt from dispatch
+metadata**. Pair it with the dashboard's **Prototype Voice Test** panel to get
+a one-click "compile prompt → sync → talk" loop without redeploying.
+
+> See [ADR-015](../../../docs/decisions/015-prototype-prompt-injection.md) for
+> the design rationale and the trade-off versus the production voice-test
+> flow ([ADR-014](../../../docs/decisions/014-browser-voice-testing.md)).
+> Inspired by [voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox).
+
+## How it differs from `livekit-agent/`
+
+| Aspect | `livekit-agent/` (production) | `livekit-prototype/` (this) |
+|---|---|---|
+| Prompt source | Baked into worker image (per-profile) | `dispatch_metadata["instructions"]` |
+| Tools / MCP / SOPs | Yes | No — pure prompt |
+| Audience | Deployed agents in prod traffic | Prompt iteration during dev |
+| Deploy frequency | Slow (image build) | Never — dispatch carries the prompt |
+
+## Wire contract
+
+The MG API endpoint `POST /api/agents/:id/prototype-voice-test-token`
+JSON-encodes the dispatch payload. The worker decodes it in
+`prototype_agent.metadata.parse_dispatch_metadata`:
+
+```json
+{
+  "mode":            "voice-test-prototype",
+  "agentName":       "<agent slug>",
+  "instructions":    "<compiled system prompt>",
+  "session_id":      "<modelguide session uuid>",
+  "user_identifier": "<caller email>",
+  "email":           "<caller email>"
+}
+```
+
+Both sides have unit-test coverage of this contract:
+
+- API: `modelguide-api/tests/unit/agents/prototype-voice-test-dispatch.test.ts`
+- Worker: `tests/test_metadata.py`
+
+If you rename or reshape a field, **both** test files break — that's the
+point.
+
+## Local development
+
+Prerequisites: Python ≥3.11, [`uv`](https://github.com/astral-sh/uv) (or pip),
+a LiveKit Cloud project (or self-hosted server), and an OpenAI API key.
+
+```bash
+# From the repo root
+cd examples/agents/livekit-prototype
+
+# Install (uv preferred)
+uv venv && uv pip install -e ".[test]"
+
+# Required env
+export LIVEKIT_URL="wss://<project>.livekit.cloud"
+export LIVEKIT_API_KEY="…"
+export LIVEKIT_API_SECRET="…"
+export OPENAI_API_KEY="sk-…"
+# Optional: agent name registered with the LiveKit dispatcher
+export PROTOTYPE_AGENT_NAME="modelguide-prototype"
+
+# Run tests
+pytest
+
+# Run the worker (development mode — hot reload)
+python -m prototype_agent.agent dev
+
+# Run the worker (production mode)
+python -m prototype_agent.agent start
+```
+
+The worker registers itself with LiveKit Cloud under
+`PROTOTYPE_AGENT_NAME`. Configure the same value as the agent's
+`metadata.livekit.agentName` in ModelGuide and the dispatcher will route
+prototype voice-test requests to it.
+
+## Cloud deployment
+
+Build the image and push to your registry:
+
+```bash
+docker build -t <registry>/modelguide-livekit-prototype:latest .
+docker push <registry>/modelguide-livekit-prototype:latest
+```
+
+Deploy to Railway, Fly.io, Render, or any platform that runs a long-lived
+container. Required env vars at runtime:
+
+- `LIVEKIT_URL`
+- `LIVEKIT_API_KEY`
+- `LIVEKIT_API_SECRET`
+- `OPENAI_API_KEY`
+- `PROTOTYPE_AGENT_NAME` (optional; defaults to `modelguide-prototype`)
+- `PROTOTYPE_LLM_MODEL` (optional; defaults to `gpt-4o-mini`)
+
+The worker pre-downloads Silero VAD weights at image build time so cold
+starts are quick.
+
+## End-to-end test loop (manual)
+
+1. Configure a LiveKit voice agent in ModelGuide with
+   `metadata.livekit.agentName` matching `PROTOTYPE_AGENT_NAME` above.
+2. Activate the agent (`isActive: true`).
+3. Compile it once so `compiled_instructions` is non-null
+   (`POST /api/agents/:id/compile`, or the **Compile** button on the SOP page).
+4. Open the agent detail page. The **Prototype Voice Test** card appears
+   below the production Voice Test card.
+5. Click **Sync & test prompt**. The dashboard:
+   - Asks for mic permission.
+   - Re-runs the compiler.
+   - Dispatches this worker with the freshly compiled prompt in metadata.
+   - Joins the room over WebRTC.
+6. Talk. Edit the prompt. Click **Sync & test again**. The next dispatch
+   carries the updated text — no redeploy.
+
+## File layout
+
+```
+examples/agents/livekit-prototype/
+├── README.md            (this file)
+├── Dockerfile           (uv-based multi-stage build)
+├── pyproject.toml
+├── src/
+│   └── prototype_agent/
+│       ├── __init__.py
+│       ├── agent.py      (LiveKit entrypoint)
+│       └── metadata.py   (dispatch-metadata parser — the contract)
+└── tests/
+    ├── __init__.py
+    └── test_metadata.py  (11 tests — happy path + every error mode)
+```

--- a/examples/agents/livekit-prototype/pyproject.toml
+++ b/examples/agents/livekit-prototype/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "modelguide-livekit-prototype"
+version = "0.1.0"
+description = "ModelGuide LiveKit prototype worker — reads prompt from dispatch metadata (ADR-015)"
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/agents/livekit-prototype/src/prototype_agent/__init__.py
+++ b/examples/agents/livekit-prototype/src/prototype_agent/__init__.py
@@ -1,0 +1,23 @@
+"""ModelGuide LiveKit prototype voice agent.
+
+ADR-015: Reads its system prompt from dispatch metadata so an admin can
+compile a prompt in the dashboard, click "Sync & Test", and immediately
+talk to a worker reflecting the latest text — without redeploying.
+
+Modules:
+    metadata   — parse + validate dispatch metadata (the prompt-injection
+                 contract with the MG API).
+    agent      — LiveKit `entrypoint` that runs the voice session.
+"""
+
+from prototype_agent.metadata import (
+    DispatchMetadata,
+    InvalidDispatchMetadataError,
+    parse_dispatch_metadata,
+)
+
+__all__ = [
+    "DispatchMetadata",
+    "InvalidDispatchMetadataError",
+    "parse_dispatch_metadata",
+]

--- a/examples/agents/livekit-prototype/src/prototype_agent/agent.py
+++ b/examples/agents/livekit-prototype/src/prototype_agent/agent.py
@@ -1,0 +1,92 @@
+"""LiveKit voice agent — prototype "talk to my latest prompt" worker.
+
+Reads its system prompt from dispatch metadata (see `metadata.py` for the
+contract). On dispatch:
+
+    1. Parse `JobContext.job.metadata` → DispatchMetadata.
+    2. Connect to the room.
+    3. Wait for the participant.
+    4. Boot an `AgentSession` with `Agent(instructions=md.instructions, ...)`.
+    5. Greet the caller and run the conversation.
+    6. On disconnect, log a one-line summary.
+
+This worker is intentionally MCP-free / tool-free — the goal is the tightest
+possible feedback loop between editing a prompt in the UI and hearing the
+agent's voice change. For tool-equipped voice agents, see the production
+worker in `examples/agents/livekit-agent/`.
+
+Usage:
+    python -m prototype_agent.agent dev    # local LiveKit, full WebRTC
+    python -m prototype_agent.agent start  # production worker
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import openai, silero
+
+from prototype_agent.metadata import (
+    InvalidDispatchMetadataError,
+    parse_dispatch_metadata,
+)
+
+VERSION = "0.1.0"
+DEFAULT_AGENT_NAME = os.getenv("PROTOTYPE_AGENT_NAME", "modelguide-prototype")
+DEFAULT_LLM_MODEL = os.getenv("PROTOTYPE_LLM_MODEL", "gpt-4o-mini")
+GREETING = "Hi, I'm ready when you are."
+
+logging.basicConfig(
+    level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("prototype_agent")
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    """LiveKit agent entrypoint — one job per dispatched room."""
+    logger.info("prototype agent v%s — entrypoint called", VERSION)
+
+    try:
+        md = parse_dispatch_metadata(ctx.job.metadata)
+    except InvalidDispatchMetadataError as exc:
+        # Refusing to start a session with a default prompt would defeat the
+        # whole point of this worker. Fail loudly so the dashboard's spinner
+        # times out and the operator sees the failure in worker logs.
+        logger.error("invalid dispatch metadata — refusing to start: %s", exc)
+        return
+
+    logger.info(
+        "dispatched — profile=%s session=%s user=%s prompt_len=%d",
+        md.agent_name,
+        md.session_id,
+        md.user_identifier,
+        len(md.instructions),
+    )
+
+    await ctx.connect()
+    participant = await ctx.wait_for_participant()
+    logger.info("participant joined: %s", participant.identity)
+
+    agent = Agent(instructions=md.instructions)
+    session = AgentSession(
+        stt=openai.STT(),
+        llm=openai.LLM(model=DEFAULT_LLM_MODEL),
+        tts=openai.TTS(),
+        vad=silero.VAD.load(),
+        allow_interruptions=True,
+    )
+
+    await session.start(room=ctx.room, agent=agent)
+    await session.say(GREETING)
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=DEFAULT_AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-prototype/src/prototype_agent/metadata.py
+++ b/examples/agents/livekit-prototype/src/prototype_agent/metadata.py
@@ -1,0 +1,109 @@
+"""Dispatch-metadata parsing — the cross-language prompt-injection contract.
+
+The MG API endpoint `POST /api/agents/:id/prototype-voice-test-token` builds
+the metadata via `buildPrototypeDispatchMetadata` (TypeScript). Both sides are
+covered by their own unit tests; this module is the Python side.
+
+Wire shape (JSON-encoded string in `JobContext.job.metadata`):
+
+    {
+      "mode":            "voice-test-prototype",
+      "agentName":       "<agent slug>",
+      "instructions":    "<compiled system prompt>",   # required, non-empty
+      "session_id":      "<modelguide session uuid>",  # optional
+      "user_identifier": "<caller email>",             # falls back to email
+      "email":           "<caller email>"
+    }
+
+Field renames or shape changes break the prototype flow silently — the worker
+will fail to start a session and the browser will sit on "Waking up agent…"
+until the 15s timeout. Cross-language contract → unit-tested on both sides.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+class InvalidDispatchMetadataError(ValueError):
+    """Raised when the dispatch-metadata blob is missing, unparseable, or
+    missing required fields. Caller should refuse to start the session."""
+
+
+@dataclass(frozen=True)
+class DispatchMetadata:
+    agent_name: str
+    instructions: str
+    session_id: str | None
+    user_identifier: str
+    email: str | None
+    mode: str
+
+
+def parse_dispatch_metadata(raw: str | None) -> DispatchMetadata:
+    """Parse the JSON dispatch-metadata blob from `JobContext.job.metadata`.
+
+    Raises:
+        InvalidDispatchMetadataError: if the payload is missing, not valid
+        JSON, not an object, or missing required fields (`agentName`,
+        `instructions`).
+    """
+    if not raw:
+        raise InvalidDispatchMetadataError(
+            "dispatch metadata is empty — prototype worker requires a JSON payload"
+        )
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise InvalidDispatchMetadataError(
+            f"dispatch metadata is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise InvalidDispatchMetadataError(
+            "dispatch metadata must be a JSON object at the top level"
+        )
+
+    agent_name = data.get("agentName")
+    if not isinstance(agent_name, str) or not agent_name:
+        raise InvalidDispatchMetadataError(
+            "dispatch metadata is missing required field `agentName`"
+        )
+
+    instructions = data.get("instructions")
+    if (
+        not isinstance(instructions, str)
+        or not instructions
+        or not instructions.strip()
+    ):
+        raise InvalidDispatchMetadataError(
+            "dispatch metadata is missing or empty required field `instructions`"
+        )
+
+    email = data.get("email")
+    if email is not None and not isinstance(email, str):
+        email = None
+
+    user_identifier = data.get("user_identifier")
+    if not isinstance(user_identifier, str) or not user_identifier:
+        # Fall back to email so the worker still has a stable identity.
+        user_identifier = email or "anonymous"
+
+    session_id = data.get("session_id")
+    if session_id is not None and not isinstance(session_id, str):
+        session_id = None
+
+    mode = data.get("mode")
+    if not isinstance(mode, str):
+        mode = "voice-test-prototype"
+
+    return DispatchMetadata(
+        agent_name=agent_name,
+        instructions=instructions,
+        session_id=session_id,
+        user_identifier=user_identifier,
+        email=email,
+        mode=mode,
+    )

--- a/examples/agents/livekit-prototype/tests/test_metadata.py
+++ b/examples/agents/livekit-prototype/tests/test_metadata.py
@@ -1,0 +1,135 @@
+"""Tests for `parse_dispatch_metadata` — the prompt-injection contract.
+
+This worker is dispatched by the ModelGuide API's
+`POST /api/agents/:id/prototype-voice-test-token` endpoint. The endpoint
+JSON-encodes a payload with shape:
+
+    {
+      "mode": "voice-test-prototype",
+      "agentName": "<agent slug>",
+      "instructions": "<compiled system prompt>",
+      "session_id": "<modelguide session uuid>",
+      "user_identifier": "<caller email>",
+      "email": "<caller email>"
+    }
+
+`parse_dispatch_metadata` is the single point where this string is decoded
+into the values the agent uses. Tests cover happy path, bad JSON, missing
+required fields, and whitespace edge cases.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prototype_agent.metadata import (
+    DispatchMetadata,
+    InvalidDispatchMetadataError,
+    parse_dispatch_metadata,
+)
+
+
+def _payload(**overrides):
+    base = {
+        "mode": "voice-test-prototype",
+        "agentName": "demo_v1",
+        "instructions": "You are a helpful agent.",
+        "session_id": "00000000-0000-0000-0000-000000000001",
+        "user_identifier": "admin@example.com",
+        "email": "admin@example.com",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+class TestParseDispatchMetadata:
+    def test_happy_path_returns_typed_object(self):
+        md = parse_dispatch_metadata(_payload())
+        assert isinstance(md, DispatchMetadata)
+        assert md.agent_name == "demo_v1"
+        assert md.instructions == "You are a helpful agent."
+        assert md.session_id == "00000000-0000-0000-0000-000000000001"
+        assert md.user_identifier == "admin@example.com"
+
+    def test_instructions_are_returned_verbatim(self):
+        prompt = "# Role\nYou are an HVAC dispatcher.\n\n# Tone\nBrief."
+        md = parse_dispatch_metadata(_payload(instructions=prompt))
+        assert md.instructions == prompt
+
+    def test_none_metadata_raises(self):
+        with pytest.raises(InvalidDispatchMetadataError):
+            parse_dispatch_metadata(None)
+
+    def test_empty_string_raises(self):
+        with pytest.raises(InvalidDispatchMetadataError):
+            parse_dispatch_metadata("")
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(InvalidDispatchMetadataError):
+            parse_dispatch_metadata("{not valid json")
+
+    def test_non_object_payload_raises(self):
+        # An array or scalar at the top level should be rejected.
+        with pytest.raises(InvalidDispatchMetadataError):
+            parse_dispatch_metadata("[1, 2, 3]")
+
+    def test_missing_instructions_raises(self):
+        payload = json.dumps(
+            {
+                "mode": "voice-test-prototype",
+                "agentName": "demo_v1",
+                "session_id": "s",
+                "user_identifier": "u",
+                "email": "u",
+            }
+        )
+        with pytest.raises(InvalidDispatchMetadataError, match=r"instructions"):
+            parse_dispatch_metadata(payload)
+
+    def test_whitespace_only_instructions_raises(self):
+        with pytest.raises(InvalidDispatchMetadataError, match=r"instructions"):
+            parse_dispatch_metadata(_payload(instructions="   \n\t "))
+
+    def test_missing_agent_name_raises(self):
+        payload = json.dumps(
+            {
+                "mode": "voice-test-prototype",
+                "instructions": "x",
+                "session_id": "s",
+                "user_identifier": "u",
+                "email": "u",
+            }
+        )
+        with pytest.raises(InvalidDispatchMetadataError, match=r"agentName"):
+            parse_dispatch_metadata(payload)
+
+    def test_user_identifier_falls_back_to_email_when_missing(self):
+        # The MG API always sends both, but if a future caller drops
+        # `user_identifier` we still want a sane identity.
+        payload = json.dumps(
+            {
+                "mode": "voice-test-prototype",
+                "agentName": "demo_v1",
+                "instructions": "x",
+                "session_id": "s",
+                "email": "fallback@example.com",
+            }
+        )
+        md = parse_dispatch_metadata(payload)
+        assert md.user_identifier == "fallback@example.com"
+
+    def test_session_id_is_optional_and_defaults_to_none(self):
+        # Some smoke-test invocations may want to skip MG session creation.
+        payload = json.dumps(
+            {
+                "mode": "voice-test-prototype",
+                "agentName": "demo_v1",
+                "instructions": "x",
+                "user_identifier": "u@e.com",
+                "email": "u@e.com",
+            }
+        )
+        md = parse_dispatch_metadata(payload)
+        assert md.session_id is None

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -22,6 +22,7 @@ import {
   assignConnectorToAgent,
   createAgent,
   createOutboundCall,
+  createPrototypeVoiceTestSession,
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
@@ -1354,6 +1355,73 @@ router.openapi(voiceTestTokenRoute, async (c) => {
   const { id } = c.req.valid("param");
 
   const result = await createVoiceTestSession(orgId, id, {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+  });
+
+  return c.json(result, 201);
+});
+
+// ============================================================================
+// Prototype voice test (ADR-015)
+// ============================================================================
+
+router.post(
+  "/:id/prototype-voice-test-token",
+  requireUser(),
+  requirePermission("agents:activate"),
+  requireOrganization(),
+);
+
+const prototypeVoiceTestTokenResponseSchema = z.object({
+  livekitUrl: z.string(),
+  roomName: z.string(),
+  token: z.string(),
+  sessionId: z.string().uuid(),
+  dispatchId: z.string(),
+  agentName: z.string(),
+  profileName: z.string(),
+  identity: z.string(),
+  instructionsHash: z.string(),
+  instructionsLength: z.number(),
+});
+
+const prototypeVoiceTestTokenRoute = createRoute({
+  method: "post",
+  path: "/{id}/prototype-voice-test-token",
+  tags: ["Agents"],
+  summary: "Issue a LiveKit prototype voice-test token (prompt-injected)",
+  description:
+    "ADR-015 prototype flow. Reads the agent's compiled instructions, embeds them in dispatch metadata under `instructions`, dispatches a LiveKit worker that uses the metadata as its system prompt, and mints a short-lived AccessToken so the browser can join the room. Lets an admin compile a prompt and immediately talk to a worker reflecting the latest text without redeploying.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: agentIdParams,
+  },
+  responses: {
+    201: {
+      description: "Prototype voice-test session created",
+      content: {
+        "application/json": {
+          schema: prototypeVoiceTestTokenResponseSchema,
+        },
+      },
+    },
+    400: errorResponse(
+      "LiveKit not configured, missing credentials, wrong modality, or compiled prompt missing",
+    ),
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(prototypeVoiceTestTokenRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const user = getCurrentUser(c);
+  const { id } = c.req.valid("param");
+
+  const result = await createPrototypeVoiceTestSession(orgId, id, {
     userId: user.id,
     email: user.email,
     name: user.name,

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -1060,3 +1060,201 @@ export async function createVoiceTestSession(
     identity,
   };
 }
+
+// ============================================================================
+// Prototype voice-test (POC: prompt-injection over dispatch metadata)
+//
+// ADR-015 documents this flow. Unlike the production voice-test (ADR-014) the
+// prototype intentionally pushes the agent's compiled prompt into dispatch
+// metadata so an admin can edit a prompt in the UI, click "Sync & Test", and
+// immediately talk to a worker that reflects the latest text — without
+// redeploying. Dispatched at a worker that reads `instructions` from metadata
+// (`examples/agents/livekit-prototype`).
+// ============================================================================
+
+export function buildPrototypeDispatchMetadata(input: {
+  agentSlug: string;
+  sessionId: string;
+  callerEmail: string;
+  instructions: string;
+}): {
+  mode: "voice-test-prototype";
+  agentName: string;
+  session_id: string;
+  user_identifier: string;
+  email: string;
+  instructions: string;
+} {
+  if (!input.instructions || input.instructions.trim().length === 0) {
+    throw Errors.invalidInput(
+      "Prototype voice-test requires non-empty instructions",
+    );
+  }
+  return {
+    mode: "voice-test-prototype" as const,
+    agentName: input.agentSlug,
+    session_id: input.sessionId,
+    user_identifier: input.callerEmail,
+    email: input.callerEmail,
+    instructions: input.instructions,
+  };
+}
+
+export interface PrototypeVoiceTestSession {
+  livekitUrl: string;
+  roomName: string;
+  token: string;
+  sessionId: string;
+  dispatchId: string;
+  agentName: string;
+  profileName: string;
+  identity: string;
+  instructionsHash: string;
+  instructionsLength: number;
+}
+
+/**
+ * Lightweight content-addressable identifier so the UI can display "you're
+ * talking to a worker started with prompt #7c91" — useful for confirming the
+ * sync actually pushed the latest text. Not a security primitive.
+ */
+function shortHash(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, "0").slice(0, 8);
+}
+
+export async function createPrototypeVoiceTestSession(
+  orgId: string,
+  agentId: string,
+  caller: { userId: string; email: string; name: string },
+): Promise<PrototypeVoiceTestSession> {
+  const agent = await forOrg(orgId, async (tx) => {
+    const a = await requireAgent(tx, agentId);
+    if (!a.isActive) {
+      throw Errors.invalidInput("Agent is not active");
+    }
+    if (a.modality !== "voice") {
+      throw Errors.invalidInput("Voice test requires a voice agent");
+    }
+    if (a.agentPlatform !== "livekit") {
+      throw Errors.invalidInput(
+        "Prototype voice test is only supported for LiveKit agents",
+      );
+    }
+    if (!a.compiledInstructions || a.compiledInstructions.trim().length === 0) {
+      throw Errors.invalidInput(
+        "Compile the agent before starting a prototype voice test",
+      );
+    }
+    return a;
+  });
+
+  const meta = (agent.metadata ?? {}) as Record<string, unknown>;
+  const lkMeta = (meta.livekit ?? {}) as Record<string, unknown>;
+  const livekitUrl = lkMeta.url as string | undefined;
+  const agentName = lkMeta.agentName as string | undefined;
+
+  if (!livekitUrl || !agentName) {
+    throw Errors.invalidInput(
+      "LiveKit is not configured for this agent. Configure it first.",
+    );
+  }
+
+  const apiKey = await getAgentSecretByType(orgId, agentId, "livekit_api_key");
+  const apiSecret = await getAgentSecretByType(
+    orgId,
+    agentId,
+    "livekit_api_secret",
+  );
+
+  if (!apiKey || !apiSecret) {
+    throw Errors.invalidInput(
+      "LiveKit credentials not found. Re-configure LiveKit for this agent.",
+    );
+  }
+
+  const compiled = agent.compiledInstructions as string;
+  const roomName = `proto-${nanoid()}`;
+  const identity = `user-${caller.userId.slice(0, 8)}-${nanoid(6)}`;
+
+  const session = await createSession(orgId, agentId, {
+    channelType: "voice",
+    userIdentifier: caller.email,
+    userMetadata: {
+      voiceTest: true,
+      prototype: true,
+      userId: caller.userId,
+      name: caller.name,
+      roomName,
+      promptHash: shortHash(compiled),
+    },
+  });
+
+  const dispatchMetadata = buildPrototypeDispatchMetadata({
+    agentSlug: agent.slug,
+    sessionId: session.id,
+    callerEmail: caller.email,
+    instructions: compiled,
+  });
+
+  let dispatchId: string;
+  try {
+    dispatchId = await dispatchAgentToRoom(
+      livekitUrl,
+      apiKey,
+      apiSecret,
+      agentName,
+      roomName,
+      dispatchMetadata,
+    );
+  } catch (err) {
+    try {
+      await updateSession(orgId, session.id, agentId, { status: "abandoned" });
+    } catch (rollbackErr) {
+      getLogger().error(
+        { orgId, agentId, sessionId: session.id, rollbackErr },
+        "failed to abandon prototype voice-test session after dispatch failure",
+      );
+    }
+    throw err;
+  }
+
+  const token = await generateVoiceTestToken({
+    apiKey,
+    apiSecret,
+    roomName,
+    identity,
+    name: caller.name,
+  });
+
+  getLogger().info(
+    {
+      orgId,
+      agentId,
+      sessionId: session.id,
+      dispatchId,
+      roomName,
+      agentName,
+      profileName: agent.slug,
+      promptHash: shortHash(compiled),
+      promptLen: compiled.length,
+    },
+    "prototype voice-test dispatched",
+  );
+
+  return {
+    livekitUrl,
+    roomName,
+    token,
+    sessionId: session.id,
+    dispatchId,
+    agentName,
+    profileName: agent.slug,
+    identity,
+    instructionsHash: shortHash(compiled),
+    instructionsLength: compiled.length,
+  };
+}

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -1011,6 +1011,163 @@ describe("POST /api/agents/:id/voice-test-token", () => {
   });
 });
 
+// ============================================================================
+// POST /api/agents/:id/prototype-voice-test-token — ADR-015 prototype flow
+// ============================================================================
+
+describe("POST /api/agents/:id/prototype-voice-test-token", () => {
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/prototype-voice-test-token`,
+      { method: "POST" },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects support role (403) — agents:activate is admin-only", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgASupportHeaders },
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("org B cannot prototype-test an org A agent (404)", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgBAdminHeaders },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("returns 404 for unknown agent", async () => {
+    const response = await request(
+      "/api/agents/00000000-0000-0000-0000-000000000000/prototype-voice-test-token",
+      { method: "POST", headers: orgAAdminHeaders },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects inactive agents (400)", async () => {
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ name: "Inactive Prototype Voice Test Agent" }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    const response = await request(
+      `/api/agents/${agentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgAAdminHeaders },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/not active/i);
+  });
+
+  test("rejects when compiled instructions are missing (400)", async () => {
+    // Activate + LiveKit-config a voice agent but leave compiledInstructions null.
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({
+        name: "Uncompiled Prototype Voice Test Agent",
+      }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          agentPlatform: "livekit",
+          metadata: {
+            livekit: { url: "wss://test.livekit.cloud", agentName: "w" },
+          },
+        })
+        .where(eq(agents.id, agentId)),
+    );
+
+    const response = await request(
+      `/api/agents/${agentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgAAdminHeaders },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/compile/i);
+  });
+
+  test("rejects non-livekit platform (400)", async () => {
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ name: "Custom Prototype Voice Test Agent" }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          compiledInstructions: "test prompt",
+        })
+        .where(eq(agents.id, agentId)),
+    );
+
+    const response = await request(
+      `/api/agents/${agentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgAAdminHeaders },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/LiveKit/i);
+  });
+
+  test("rejects non-voice modality (400)", async () => {
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({
+        name: "Text Modality Prototype Voice Test Agent",
+        modality: "text",
+      }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          agentPlatform: "livekit",
+          compiledInstructions: "test prompt",
+          metadata: {
+            livekit: { url: "wss://test.livekit.cloud", agentName: "w" },
+          },
+        })
+        .where(eq(agents.id, agentId)),
+    );
+
+    const response = await request(
+      `/api/agents/${agentId}/prototype-voice-test-token`,
+      { method: "POST", headers: orgAAdminHeaders },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/voice agent/i);
+  });
+});
+
 describe("Agent slug uniqueness", () => {
   test("creating agent with duplicate name (same slug) returns 409", async () => {
     const res1 = await request("/api/agents", {

--- a/modelguide-api/tests/unit/agents/prototype-voice-test-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/prototype-voice-test-dispatch.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Prototype voice-test dispatch metadata — locks in the contract between the
+ * MG API and the prototype LiveKit worker (`examples/agents/livekit-prototype`).
+ *
+ * Unlike the production voice-test flow (see ADR-014), the prototype flow
+ * intentionally injects the agent's compiled prompt into dispatch metadata so
+ * an admin can edit a prompt in the UI, click "Sync & Test", and immediately
+ * talk to a worker that reflects the latest text — without redeploying.
+ *
+ * The Python worker reads:
+ *   - dispatch_metadata["agentName"]    → optional profile slug echo
+ *   - dispatch_metadata["instructions"] → REQUIRED: the system prompt to use
+ *   - dispatch_metadata["session_id"]   → MG session for transcript posting
+ *
+ * Field names + shape are NOT type-checked across the language boundary, so
+ * this test file IS the contract. ADR-015 documents the trade-off.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildPrototypeDispatchMetadata } from "../../../src/features/agents/agents.service";
+
+describe("buildPrototypeDispatchMetadata", () => {
+  test("carries agentName = agent.slug for routing parity with prod voice-test", () => {
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "demo_v1",
+      sessionId: "sess-1",
+      callerEmail: "admin@example.com",
+      instructions: "You are a helpful agent.",
+    });
+    expect(md.agentName).toBe("demo_v1");
+  });
+
+  test("mode is the literal 'voice-test-prototype' marker", () => {
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: "x",
+    });
+    expect(md.mode).toBe("voice-test-prototype");
+  });
+
+  test("instructions are echoed verbatim — the worker uses this as the system prompt", () => {
+    const prompt =
+      "# Role\nYou are an HVAC dispatcher.\n\n# Tone\nBrief and warm.";
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "hvac",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: prompt,
+    });
+    expect(md.instructions).toBe(prompt);
+  });
+
+  test("session_id + user_identifier + email carry caller context", () => {
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "sess-xyz",
+      callerEmail: "tester@corp.com",
+      instructions: "x",
+    });
+    expect(md.session_id).toBe("sess-xyz");
+    expect(md.user_identifier).toBe("tester@corp.com");
+    expect(md.email).toBe("tester@corp.com");
+  });
+
+  test("shape is stable — exactly these 6 keys, nothing else", () => {
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: "x",
+    });
+    expect(Object.keys(md).sort()).toEqual(
+      [
+        "agentName",
+        "email",
+        "instructions",
+        "mode",
+        "session_id",
+        "user_identifier",
+      ].sort(),
+    );
+  });
+
+  test("round-trips through JSON without dropping fields (dispatcher JSON-stringifies)", () => {
+    const md = buildPrototypeDispatchMetadata({
+      agentSlug: "demo",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: "Multi-line\nprompt with \"quotes\" and 'apostrophes'.",
+    });
+    expect(JSON.parse(JSON.stringify(md))).toEqual(md);
+  });
+
+  test("rejects empty instructions — worker has no fallback prompt", () => {
+    expect(() =>
+      buildPrototypeDispatchMetadata({
+        agentSlug: "x",
+        sessionId: "s",
+        callerEmail: "c@e.com",
+        instructions: "",
+      }),
+    ).toThrow(/instructions/i);
+  });
+
+  test("rejects whitespace-only instructions — same reason", () => {
+    expect(() =>
+      buildPrototypeDispatchMetadata({
+        agentSlug: "x",
+        sessionId: "s",
+        callerEmail: "c@e.com",
+        instructions: "   \n\t  ",
+      }),
+    ).toThrow(/instructions/i);
+  });
+});

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.20", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.17.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-hjkYOsJj9Jbghb7wM5cI8HoVisKeL6Zcy1VnRWTLm0sqVbto8GJp/17T4Udx85mCPY6Jgh8I1Cv0yVzgz7CQtg=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/prototype-voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/prototype-voice-test-panel.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * PrototypeVoiceTestPanel tests — ADR-015 prototype "compile → sync → talk" flow.
+ *
+ * Unlike the production VoiceTestPanel (which dispatches the worker as-is and
+ * lets the baked-in profile own the prompt), this panel:
+ *   1. Compiles the agent (POST /agents/:id/compile) to refresh
+ *      compiledInstructions on the server.
+ *   2. Dispatches the prototype worker with the refreshed prompt embedded
+ *      in metadata (POST /agents/:id/prototype-voice-test-token).
+ *   3. Joins the room from the browser via WebRTC.
+ *
+ * The compile step is the "Sync" half of the button — it guarantees the worker
+ * is dispatched with the latest text without requiring the operator to click
+ * "Compile" elsewhere first.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '~/schemas/agents'
+import { PrototypeVoiceTestPanel } from './prototype-voice-test-panel'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPost = vi.fn()
+const mockTokenResponse = {
+  livekitUrl: 'wss://test.livekit.cloud',
+  roomName: 'proto-abc',
+  token: 'test-token-123',
+  sessionId: '00000000-0000-0000-0000-000000000001',
+  dispatchId: 'disp_abc',
+  agentName: 'modelguide-prototype',
+  profileName: 'test-agent',
+  identity: 'user-xyz',
+  instructionsHash: 'deadbeef',
+  instructionsLength: 42,
+}
+const mockCompileResponse = {
+  agentId: 'agent-1',
+  compiledAt: '2026-04-27T00:00:00Z',
+  compiledFrom: { sopIds: [] },
+  compiledPrompt: 'Refreshed prompt.',
+  metadata: { warnings: [] },
+}
+
+vi.mock('~/lib/api', () => ({
+  api: {
+    post: (url: string) => {
+      mockPost(url)
+      const isCompile = url.endsWith('/compile')
+      return {
+        json: () => Promise.resolve(isCompile ? mockCompileResponse : mockTokenResponse),
+      }
+    },
+  },
+}))
+
+vi.mock('livekit-client', () => ({
+  ParticipantKind: { AGENT: 'agent' },
+  RoomEvent: { ParticipantConnected: 'participantConnected' },
+}))
+
+vi.mock('@livekit/components-react', () => ({
+  LiveKitRoom: ({ children }: { children: ReactNode }) => (
+    <div data-testid="lk-room">{children}</div>
+  ),
+  RoomAudioRenderer: () => <div data-testid="lk-audio" />,
+  useRoomContext: () => ({
+    localParticipant: { setMicrophoneEnabled: vi.fn().mockResolvedValue(undefined) },
+    remoteParticipants: new Map([['agent-1', { kind: 'agent', identity: 'agent-1' }]]),
+    on: vi.fn().mockReturnThis(),
+    off: vi.fn().mockReturnThis(),
+    disconnect: vi.fn(),
+  }),
+  useVoiceAssistant: () => ({ state: 'listening', audioTrack: undefined }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseAgent: Agent = {
+  id: 'agent-1',
+  name: 'Test Agent',
+  slug: 'test-agent',
+  description: null,
+  modality: 'voice',
+  modelFamily: 'gpt',
+  agentPlatform: 'livekit',
+  isActive: true,
+  evalSuiteCount: 0,
+  promptConfig: {},
+  metadata: { livekit: { url: 'wss://test.livekit.cloud', agentName: 'modelguide-prototype' } },
+  hasElevenLabsKey: false,
+  hasWebhookSecret: false,
+  keyPrefix: null,
+  integrationUrls: undefined,
+  compiledInstructions: 'You are a voice agent. Be helpful.',
+  compiledAt: '2026-04-01T00:00:00Z',
+  compiledFrom: null,
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+const configuredAgent: Agent = {
+  ...baseAgent,
+  secrets: { livekit_api_key: 'sec-1', livekit_api_secret: 'sec-2' },
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+function stubMicPermission(grant = true) {
+  const state: PermissionState = grant ? 'granted' : 'denied'
+  const getUserMedia = grant
+    ? vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: vi.fn() }],
+      })
+    : vi.fn().mockRejectedValue(Object.assign(new Error('denied'), { name: 'NotAllowedError' }))
+  // @ts-expect-error — jsdom does not provide mediaDevices by default
+  navigator.mediaDevices = { getUserMedia }
+  // @ts-expect-error — jsdom does not provide Permissions API by default
+  navigator.permissions = {
+    query: vi.fn().mockResolvedValue({ state }),
+  }
+  return getUserMedia
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PrototypeVoiceTestPanel', () => {
+  it('renders nothing for non-livekit agents', () => {
+    const elevenAgent = { ...configuredAgent, agentPlatform: 'elevenlabs' } as Agent
+    const { container } = render(<PrototypeVoiceTestPanel agent={elevenAgent} canMutate />, {
+      wrapper,
+    })
+    expect(container.textContent).toBe('')
+  })
+
+  it('disables the Sync & Test button when LiveKit is not configured', () => {
+    const unconfigured = { ...baseAgent } as Agent
+    render(<PrototypeVoiceTestPanel agent={unconfigured} canMutate />, { wrapper })
+    const btn = screen.getByRole('button', { name: /sync.*test/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('disables the Sync & Test button for viewers (canMutate=false)', () => {
+    stubMicPermission(true)
+    render(<PrototypeVoiceTestPanel agent={configuredAgent} canMutate={false} />, { wrapper })
+    expect(screen.getByRole('button', { name: /sync.*test/i })).toBeDisabled()
+  })
+
+  it('compiles, then dispatches with the refreshed prompt, then mounts the room', async () => {
+    stubMicPermission(true)
+    render(<PrototypeVoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: /sync.*test/i }))
+
+    // Compile call comes first, then the prototype-voice-test-token dispatch.
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/compile')
+    })
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/prototype-voice-test-token')
+    })
+    // Order check: compile must come before dispatch.
+    const calls = mockPost.mock.calls.map((c) => c[0])
+    expect(calls.indexOf('agents/agent-1/compile')).toBeLessThan(
+      calls.indexOf('agents/agent-1/prototype-voice-test-token'),
+    )
+
+    // Once the token is back, the LiveKit room mounts.
+    await waitFor(() => {
+      expect(screen.getByTestId('lk-room')).toBeInTheDocument()
+    })
+    // Prompt fingerprint surfaces in the footer so operators can confirm the
+    // sync actually pushed the new text.
+    await waitFor(() => {
+      expect(screen.getByText(/deadbeef/)).toBeInTheDocument()
+    })
+  })
+
+  it('does not dispatch the worker when mic permission is denied', async () => {
+    stubMicPermission(false)
+    render(<PrototypeVoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: /sync.*test/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/microphone/i)
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/modelguide-ui/src/features/agents/components/prototype-voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/prototype-voice-test-panel.tsx
@@ -1,0 +1,219 @@
+/**
+ * PrototypeVoiceTestPanel — ADR-015 "compile → sync → talk" prototype loop.
+ *
+ * One button. Click it and the dashboard:
+ *   1. ensures mic permission,
+ *   2. POSTs /agents/:id/compile so compiled_instructions reflects the latest
+ *      SOP + guardrail text,
+ *   3. POSTs /agents/:id/prototype-voice-test-token, which dispatches a
+ *      LiveKit worker (`examples/agents/livekit-prototype/`) with the
+ *      compiled prompt embedded in dispatch metadata,
+ *   4. mounts <LiveKitRoom> and joins the room over WebRTC.
+ *
+ * Trade-off vs the production VoiceTestPanel (ADR-014): that one dispatches
+ * the deployed worker as-is and lets the worker's profile own the prompt.
+ * This panel injects the prompt — closer to "what you see is what you'll
+ * hear" — at the cost of no longer testing exactly what's deployed.
+ *
+ * Audience: prompt iteration during development. Not a substitute for testing
+ * the production worker before shipping a SOP change.
+ */
+
+import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
+import { useMutation } from '@tanstack/react-query'
+import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
+import { api } from '~/lib/api'
+import type { Agent, PrototypeVoiceTestTokenResponse } from '~/schemas/agents'
+
+import { ensureMicPermission } from './voice-test/mic-permission'
+import { RoomController } from './voice-test/room-controller'
+import { PHASE_LABEL, type WidgetState } from './voice-test/state'
+
+interface PrototypeVoiceTestPanelProps {
+  agent: Agent
+  canMutate: boolean
+}
+
+export function PrototypeVoiceTestPanel({ agent, canMutate }: PrototypeVoiceTestPanelProps) {
+  const [state, setState] = useState<WidgetState>('IDLE')
+  const [token, setToken] = useState<string | null>(null)
+  const [wsUrl, setWsUrl] = useState<string | null>(null)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [promptHash, setPromptHash] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const endingRef = useRef(false)
+  const disconnectRef = useRef<(() => void) | null>(null)
+
+  const isLivekit = agent.agentPlatform === 'livekit'
+  const lkMeta = ((agent.metadata ?? {}) as Record<string, unknown>).livekit as
+    | Record<string, unknown>
+    | undefined
+  const secretsMap = agent.secrets ?? {}
+  const livekitConfigured =
+    !!lkMeta?.url &&
+    !!lkMeta?.agentName &&
+    !!secretsMap.livekit_api_key &&
+    !!secretsMap.livekit_api_secret
+
+  const reset = useCallback(() => {
+    endingRef.current = false
+    setToken(null)
+    setWsUrl(null)
+    setSessionId(null)
+    setPromptHash(null)
+    setErrorMsg(null)
+    setState('IDLE')
+  }, [])
+
+  const startMutation = useMutation({
+    mutationFn: async (): Promise<PrototypeVoiceTestTokenResponse> => {
+      setErrorMsg(null)
+      setState('CHECKING_MIC')
+      await ensureMicPermission()
+
+      // Step 1 — compile so the worker reads the freshest text. We don't
+      // care about the response payload here; the API persists
+      // compiled_instructions, which the next call reads from the DB.
+      setState('REQUESTING_TOKEN')
+      await api.post(`agents/${agent.id}/compile`).json<unknown>()
+
+      // Step 2 — dispatch the prototype worker with the refreshed prompt.
+      return api
+        .post(`agents/${agent.id}/prototype-voice-test-token`)
+        .json<PrototypeVoiceTestTokenResponse>()
+    },
+    onSuccess: (resp) => {
+      setSessionId(resp.sessionId)
+      setToken(resp.token)
+      setWsUrl(resp.livekitUrl)
+      setPromptHash(resp.instructionsHash)
+      setState('CONNECTING')
+    },
+    onError: (err) => {
+      setState('ERROR')
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to start prototype voice test')
+    },
+  })
+
+  const handleHangUp = useCallback(() => {
+    endingRef.current = true
+    setState('ENDING')
+    disconnectRef.current?.()
+  }, [])
+
+  const handleDisconnected = useCallback(() => {
+    setToken(null)
+    setWsUrl(null)
+    setState('ENDED')
+  }, [])
+
+  const handleRoomError = useCallback(
+    (err: Error) => {
+      if (endingRef.current || state === 'ENDED' || state === 'IDLE') return
+      const name = (err as unknown as { name?: string })?.name
+      const msg =
+        name === 'NotAllowedError'
+          ? 'Microphone access was revoked.'
+          : (err?.message ?? 'Connection lost.')
+      setErrorMsg(msg)
+      setState('ERROR')
+    },
+    [state],
+  )
+
+  if (!isLivekit) return null
+
+  const inCall =
+    state === 'CHECKING_MIC' ||
+    state === 'REQUESTING_TOKEN' ||
+    state === 'CONNECTING' ||
+    state === 'CONNECTED' ||
+    state === 'ENDING'
+
+  const showStartButton = state === 'IDLE' || state === 'ENDED' || state === 'ERROR'
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <Radio className="h-4 w-4" />
+            Prototype Voice Test
+          </CardTitle>
+          <Badge variant={state === 'CONNECTED' ? 'success' : 'default'} dot>
+            {PHASE_LABEL[state]}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {livekitConfigured ? (
+          <p className="text-sm text-fg-muted">
+            Recompiles the prompt, dispatches the prototype LiveKit worker with the freshly compiled
+            instructions in metadata, then joins the room from your browser. Use this for tight
+            prompt-iteration loops — the production voice-test panel is what you ship.
+          </p>
+        ) : (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-fg-secondary">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            Configure the LiveKit URL, API key, and secret for this agent before testing.
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          {showStartButton ? (
+            <Button
+              onClick={() => {
+                reset()
+                startMutation.mutate()
+              }}
+              loading={startMutation.isPending}
+              disabled={!canMutate || !livekitConfigured}
+            >
+              <Mic className="h-4 w-4" />
+              {state === 'ENDED' ? 'Sync & test again' : 'Sync & test prompt'}
+            </Button>
+          ) : null}
+
+          {token && wsUrl ? (
+            <LiveKitRoom
+              serverUrl={wsUrl}
+              token={token}
+              connect={true}
+              audio={true}
+              video={false}
+              onDisconnected={handleDisconnected}
+              onError={handleRoomError}
+            >
+              <RoomAudioRenderer />
+              <RoomController
+                state={state}
+                setState={setState}
+                onHangUp={handleHangUp}
+                endingRef={endingRef}
+                disconnectRef={disconnectRef}
+              />
+            </LiveKitRoom>
+          ) : null}
+        </div>
+
+        {errorMsg ? (
+          <p className="mt-3 text-xs text-error" role="alert">
+            {errorMsg}
+          </p>
+        ) : null}
+
+        {inCall && sessionId ? (
+          <p className="mt-3 font-mono text-[11px] text-fg-muted">
+            Session {sessionId}
+            {promptHash ? ` · prompt #${promptHash}` : ''}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
+++ b/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
@@ -27,6 +27,7 @@ import { IntegrationCard } from '~/features/agents/components/integration-card'
 import { OutboundCallDialog } from '~/features/agents/components/outbound-call-dialog'
 import { PlatformCard } from '~/features/agents/components/platform-card'
 import { PromptSection } from '~/features/agents/components/prompt-section'
+import { PrototypeVoiceTestPanel } from '~/features/agents/components/prototype-voice-test-panel'
 import { VoiceTestPanel } from '~/features/agents/components/voice-test-panel'
 import { api } from '~/lib/api'
 import type { PaginatedResponse } from '~/lib/pagination'
@@ -464,6 +465,9 @@ function AgentDetailPage() {
 
           {/* Row 3b: Voice test (LiveKit agents only, rendered by the panel) */}
           <VoiceTestPanel agent={agent} canMutate={isAdmin} />
+
+          {/* Row 3c: Prototype voice test — ADR-015 compile-then-sync-then-talk loop */}
+          <PrototypeVoiceTestPanel agent={agent} canMutate={isAdmin} />
 
           {/* Row 4: Integration (full width) */}
           <IntegrationCard agent={agent} isAdmin={isAdmin} onRegenerateSuccess={setNewApiKey} />

--- a/modelguide-ui/src/schemas/agents.ts
+++ b/modelguide-ui/src/schemas/agents.ts
@@ -142,3 +142,10 @@ export const voiceTestTokenResponseSchema = z.object({
 })
 
 export type VoiceTestTokenResponse = z.infer<typeof voiceTestTokenResponseSchema>
+
+export const prototypeVoiceTestTokenResponseSchema = voiceTestTokenResponseSchema.extend({
+  instructionsHash: z.string(),
+  instructionsLength: z.number(),
+})
+
+export type PrototypeVoiceTestTokenResponse = z.infer<typeof prototypeVoiceTestTokenResponseSchema>


### PR DESCRIPTION
## Summary

A working POC for the "compile prompt → click sync/test → start talking" loop, alongside the existing production voice-test panel. One click on the new **Prototype Voice Test** card recompiles the agent prompt, dispatches a minimal LiveKit worker with the freshly compiled instructions in dispatch metadata, and joins the room from the browser — no worker redeploy.

Inspired by [voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox).

## What's in the box

- **`POST /api/agents/:id/prototype-voice-test-token`** — guarded by `agents:activate`. Refuses dispatch unless the agent has a non-empty `compiled_instructions`.
- **`buildPrototypeDispatchMetadata`** — pure helper that constructs the JSON payload crossing into the Python worker. Unit-tested.
- **`createPrototypeVoiceTestSession`** — orchestrates compile-fingerprint → MG session → LiveKit dispatch → token mint, with rollback on dispatch failure.
- **New worker `examples/agents/livekit-prototype/`** — minimal Python LiveKit agent that reads `instructions` from dispatch metadata and uses it as the system prompt. No tools / MCP / SOPs — prompt-driven only, ideal for tight prompt iteration. Ships with `Dockerfile` for cloud deploy.
- **`PrototypeVoiceTestPanel`** in the dashboard — runs `compile → dispatch → WebRTC join` in one click, including a mic-permission probe. Surfaces the prompt fingerprint (`#deadbeef`) so operators can confirm the dispatched worker really started with the latest text.
- **ADR-015** — explicit counter-decision to ADR-014 ("no prompt injection in production voice-test"). Documents the drift trade-off we're accepting for the prototype path.
- **README** for the prototype worker — wire contract, local dev, cloud deploy, end-to-end manual test loop.

## TDD coverage

Each component was built red → green:

- **API dispatch helper** — 8 unit tests on shape, field names, JSON round-trip, empty-instructions rejection (`prototype-voice-test-dispatch.test.ts`).
- **Endpoint error paths** — 7 integration tests covering 401, 403, 404 (unknown), 404 (cross-org), 400 (inactive), 400 (non-livekit), 400 (non-voice), 400 (uncompiled).
- **Python metadata parser** — 11 unit tests on happy path, bad JSON, missing required fields, whitespace-only instructions, fallback paths (`test_metadata.py`).
- **UI panel** — 5 unit tests including the **compile-must-precede-dispatch** ordering check.

The TS `buildPrototypeDispatchMetadata` and Python `parse_dispatch_metadata` form a cross-language contract with no shared type system. **Both sides** unit-test field names — if either drifts, the other side's test breaks loudly.

## Trade-offs

ADR-014 rejected prompt injection in production voice-test for good reasons (drift between voice-test and prod). ADR-015 documents why the prototype path explicitly accepts that drift in exchange for sub-second prompt iteration, names the panel "Prototype" so the audience is clear, and keeps the production panel as the right pre-ship check.

## Test plan

- [x] API typecheck clean
- [x] API biome lint clean
- [x] 904 API unit tests pass (incl. 8 new dispatch tests)
- [x] Python `pytest` — 11/11 pass
- [x] UI typecheck clean
- [x] UI biome lint clean
- [x] 273 UI tests pass (incl. 5 new panel tests)
- [ ] CI runs the 7 new integration tests (no Docker locally)
- [ ] Manual: deploy prototype worker, click "Sync & test prompt" against a configured LiveKit agent, hear the latest prompt, edit the prompt, click again, hear the change

https://claude.ai/code/session_019BVLT8husiEYeFyWDFjCpE

---
_Generated by [Claude Code](https://claude.ai/code/session_019BVLT8husiEYeFyWDFjCpE)_