### PR TITLE
feat(livekit): POC voice agent that fetches its prompt from ModelGuide on every session start

### DIFF
--- a/docs/decisions/015-livekit-runtime-prompt-fetch.md
+++ b/docs/decisions/015-livekit-runtime-prompt-fetch.md
@@ -1,0 +1,156 @@
+# ADR-015: LiveKit Workers Fetch Their Prompt at Runtime
+
+**Status:** Accepted
+
+## Context
+
+ADR-014 added the *Talk to agent* button so a dashboard user can click and
+start a WebRTC call against the deployed LiveKit worker. That covered the
+transport. It deliberately punted on the prompt: the API dispatches a
+worker into a room and the worker brings whatever prompt was baked into
+its image. The `createVoiceTestSession` doc string is explicit about it —
+*"prompt + tools baked into the worker image — we do NOT inject a prompt
+from here."*
+
+This left a UX gap. The dashboard exposes a *Compile* button on every
+agent (see `prompt-section.tsx` and the `compileAgent` service that
+persists `agents.compiled_instructions`). After clicking Compile, the
+operator's mental model is "the agent now uses my new prompt." Today that
+is only true for ElevenLabs agents (whose `syncAgentToElevenLabs` pushes
+the compiled prompt to the platform via the ElevenLabs API). For LiveKit
+agents, *Compile* updates a database column nobody downstream reads, and
+the next *Talk to agent* call still uses the prompt baked into the worker
+image at last deploy.
+
+The fix needs to:
+
+1. Be invisible to the operator — no extra "Sync to LiveKit" button.
+2. Avoid coupling the dashboard to LiveKit Cloud (no need for the API
+   server to call into the worker).
+3. Survive worker redeploys — the source of truth is ModelGuide, not
+   any one worker container.
+4. Degrade gracefully when ModelGuide is unreachable — the call must still
+   complete with audio, even if it's the old prompt.
+
+## Decision
+
+The worker fetches its prompt from ModelGuide on every session start.
+
+### New endpoint: `GET /api/agents/me/runtime-config`
+
+Authenticated by the worker's own agent API key (`mgk_*`). Returns the
+narrow set of fields a worker actually needs:
+
+```json
+{
+  "id": "uuid",
+  "name": "...",
+  "slug": "...",
+  "modality": "voice",
+  "agentPlatform": "livekit",
+  "modelFamily": "gpt",
+  "isActive": true,
+  "compiledInstructions": "...",
+  "compiledAt": "2026-04-01T00:00:00.000Z",
+  "promptConfig": { ... },
+  "metadata": { ... }
+}
+```
+
+Three things to note:
+
+- **API-key-only.** User JWTs are rejected. The endpoint is for workers,
+  not the dashboard — the dashboard's `GET /agents/{id}` is unchanged.
+- **No secrets, no integration URLs, no eval state.** Each new field is
+  a deliberate decision; the unit test
+  (`tests/unit/agents/runtime-config.test.ts`) explicitly asserts the
+  shape so a refactor that swaps in `formatAgent` doesn't widen the
+  payload by accident.
+- **`me`, not `{id}`.** The agent identity is derived from the API key,
+  so the worker doesn't need to know its own UUID. The route is registered
+  before `/:id` to avoid being parsed as a UUID.
+
+### Worker-side contract
+
+`examples/agents/livekit-poc-agent/src/livekit_poc_agent/runtime_config.py`
+exposes:
+
+- `fetch(base_url, api_key)` → typed `RuntimeConfig` dataclass
+- `resolve_instructions(config, fallback)` → str
+
+The worker's entrypoint resolves instructions like this:
+
+```python
+rt = await runtime_config.fetch(base_url=…, api_key=…)
+instructions = runtime_config.resolve_instructions(rt, fallback=BAKED_IN)
+agent = Agent(instructions=instructions)
+```
+
+`resolve_instructions` returns `compiled_instructions` if present (and
+non-blank), otherwise the baked-in fallback. Empty / whitespace-only is
+treated as 'not compiled' so a half-saved compile doesn't strand the
+worker with a useless prompt.
+
+### Failure handling
+
+- **HTTP error during fetch** — log, fall through to the baked-in
+  fallback. The call completes; the operator hears a generic greeting.
+- **Agent never compiled** — fall back. Same outcome.
+- **ModelGuide entirely down** — fall back. Same outcome.
+
+In all three cases the LiveKit call still connects and the operator gets
+audio. We deliberately do not block the room on a successful fetch.
+
+## Consequences
+
+### Positive
+
+- **Compile in dashboard → talk to the new prompt** works for LiveKit
+  agents the same way it works for ElevenLabs agents (just by a different
+  mechanism — pull vs. push).
+- **No worker-image rebuild** for prompt iteration. The image only needs
+  to change when the *worker code* changes.
+- **The contract is testable.** Both sides have unit tests that fail if
+  the shape drifts (`tests/unit/agents/runtime-config.test.ts` on the
+  API; `tests/test_runtime_config.py` on the worker). The integration
+  test (`tests/integration/agent-runtime-config.test.ts`) covers the
+  HTTP-level auth.
+
+### Negative / trade-offs
+
+- **One extra round-trip per session start.** It runs in parallel with
+  participant connection so it doesn't add to time-to-first-audio
+  unless the API is slow.
+- **The prompt is cached for the lifetime of the call.** A re-compile
+  mid-call is not picked up. Polling or push (LiveKit data channels)
+  would solve it; deferred until there's a real use case.
+- **Fallback drift.** A worker can quietly serve the baked-in fallback
+  forever if ModelGuide is unreachable on every call. Mitigated by the
+  warning log in `agent.py` and operator-visible session metadata in the
+  dashboard.
+
+### Alternatives rejected
+
+- **Push prompt at dispatch time** (e.g. include `compiledInstructions`
+  in the dispatch metadata blob). Rejected: metadata blobs are length-
+  limited in some LiveKit SDK versions, and it couples the dashboard to
+  knowing every worker's prompt format.
+- **Reuse `GET /agents/{id}`** with API key auth. Rejected: that endpoint
+  carries secrets, integration URLs, eval state — none of which a worker
+  needs and all of which become a future leak surface.
+- **Compile on every voice-test click** (so the database is always
+  fresh). Rejected: compilation is expensive and the operator may want
+  to test a half-edited prompt — let *Compile* be the explicit step.
+
+## References
+
+- POC implementation: `examples/agents/livekit-poc-agent/`
+- API: `src/features/agents/agents.service.ts` (`formatRuntimeConfig`,
+  `getAgentRuntimeConfig`) and `agents.routes.ts`
+  (`/me/runtime-config` route)
+- Tests:
+  - `modelguide-api/tests/unit/agents/runtime-config.test.ts`
+  - `modelguide-api/tests/integration/agent-runtime-config.test.ts`
+  - `examples/agents/livekit-poc-agent/tests/test_runtime_config.py`
+- Related: ADR-011 (LiveKit outbound calls), ADR-014 (browser voice
+  testing — the transport this builds on).

--- a/examples/agents/livekit-poc-agent/.env.example
+++ b/examples/agents/livekit-poc-agent/.env.example
@@ -1,0 +1,27 @@
+# Worker identity — must match metadata.livekit.agentName on the dashboard
+# agent so voice-test dispatches reach this worker.
+AGENT_NAME=livekit-poc-agent
+
+# LiveKit (use built-in dev creds with `livekit-server --dev`, or LiveKit Cloud).
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# Provider API keys
+OPENAI_API_KEY=sk-...
+DEEPGRAM_API_KEY=...
+ELEVENLABS_API_KEY=...
+ELEVENLABS_VOICE_ID=iP95p4xoKVk53GoZ742B
+
+# Optional model override
+# LLM_MODEL=gpt-4.1-mini
+
+# ModelGuide — base URL (no trailing slash) + agent API key (mgk_*).
+# The worker calls GET /api/agents/me/runtime-config with this key on every
+# session start to pull the latest compiled prompt from the dashboard.
+MODELGUIDE_API_URL=http://localhost:3000
+MODELGUIDE_API_KEY=mgk_replace_me
+
+# Used only when the agent has never been compiled in the dashboard.
+# Once you click Compile in the UI, this value is ignored.
+# FALLBACK_INSTRUCTIONS=You are a friendly voice assistant. ...

--- a/examples/agents/livekit-poc-agent/.gitignore
+++ b/examples/agents/livekit-poc-agent/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/examples/agents/livekit-poc-agent/Dockerfile
+++ b/examples/agents/livekit-poc-agent/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+COPY src/ src/
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Pre-download VAD + turn-detector so cold-start latency stays low.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "-m", "livekit_poc_agent.agent", "start"]

--- a/examples/agents/livekit-poc-agent/README.md
+++ b/examples/agents/livekit-poc-agent/README.md
@@ -1,0 +1,165 @@
+# LiveKit POC Voice Agent
+
+The smallest possible LiveKit voice agent that runs against ModelGuide. It
+exists for one reason: to make the dashboard's **Compile → Talk to agent**
+loop actually mean something. On every session start, the worker fetches
+the latest compiled system prompt from ModelGuide via
+`GET /api/agents/me/runtime-config` — so when you click *Compile* in the UI
+and then *Talk to agent*, the next greeting uses the prompt you just
+edited. No worker redeploy, no cache to bust, no SOPs to forge.
+
+This is the spiritual sibling of [voiceblox](https://github.com/voiceblox-ai/voiceblox)
+adapted to ModelGuide's API surface. For the full-featured demo with MCP
+tools, SOP guardrails, transcript sync, and SIP, see
+[`examples/agents/livekit-agent`](../livekit-agent/) (BuildPro Sam).
+
+## Architecture
+
+```
+Dashboard (modelguide-ui)
+  ├── Compile prompt          → POST /api/agents/{id}/compile
+  └── Talk to agent (button)  → POST /api/agents/{id}/voice-test-token
+                                  → ModelGuide creates session +
+                                    dispatches this worker into a room
+
+LiveKit Cloud / livekit-server
+  └── dispatches worker with metadata = { agentName, session_id, … }
+
+POC worker (this directory)
+  ├── on entrypoint:
+  │     GET /api/agents/me/runtime-config   ← fetches LATEST compiled prompt
+  │     (Bearer mgk_… — agent's own API key)
+  ├── builds livekit.agents.AgentSession with that prompt
+  ├── says a static greeting (predictable first-token latency)
+  └── on shutdown: PATCH /api/sessions/{id} → completed
+```
+
+The `Agent.instructions` come straight from `compiled_instructions` in the
+runtime-config response. If the agent has never been compiled, the worker
+falls back to the prompt in `FALLBACK_INSTRUCTIONS` so the call still
+completes — see `runtime_config.resolve_instructions`.
+
+See [ADR-015](../../../docs/decisions/015-livekit-runtime-prompt-fetch.md)
+for the rationale.
+
+## Stack
+
+| Component       | Service                                       |
+| --------------- | --------------------------------------------- |
+| Transport       | LiveKit WebRTC (Cloud or self-hosted)         |
+| VAD             | Silero                                        |
+| Turn detection  | LiveKit `EnglishModel` (end-of-utterance)     |
+| STT             | Deepgram Nova-3                               |
+| LLM             | OpenAI GPT-4.1-mini                           |
+| TTS             | ElevenLabs Flash v2.5                         |
+| Prompt source   | ModelGuide `GET /api/agents/me/runtime-config` |
+| Tools           | None (POC scope — see BuildPro Sam for MCP)   |
+
+## Prerequisites
+
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
+- API keys for OpenAI, Deepgram, ElevenLabs
+- A running ModelGuide API + a LiveKit-platform agent with a `mgk_*` API
+  key. In the dashboard:
+  1. Create or open a voice agent.
+  2. On the agent detail page, configure LiveKit (URL + API key + secret)
+     and set `metadata.livekit.agentName = livekit-poc-agent` (this name
+     must match `AGENT_NAME` in the worker's env so dispatches route
+     here).
+  3. Click *Generate API key* and copy it into the worker's
+     `MODELGUIDE_API_KEY`.
+  4. Edit the prompt blocks (or upload an SOP) and click *Compile*.
+
+## Quick start
+
+```bash
+# 1. Install
+uv venv
+uv pip install -e ".[test]"
+cp .env.example .env  # then edit with your keys
+
+# 2. (Three terminals)
+# Terminal 1 — local LiveKit
+livekit-server --dev
+
+# Terminal 2 — POC worker
+python -m livekit_poc_agent.agent dev
+
+# Terminal 3 — open the modelguide-ui dashboard, click "Talk to agent"
+# on the agent's detail page.
+```
+
+Want a text-only loop (no LiveKit server, no mic)?
+
+```bash
+python -m livekit_poc_agent.agent console
+```
+
+## Testing — what's in the box
+
+This is a TDD-grown POC. The contract between the worker and ModelGuide
+is fixed by tests on both sides:
+
+| Test                                                                       | What it locks in                                |
+| -------------------------------------------------------------------------- | ----------------------------------------------- |
+| `tests/test_runtime_config.py`                                             | `runtime_config.fetch` request shape + parsing  |
+| `tests/test_mg_session.py`                                                 | Session create/complete swallows transient errors |
+| `modelguide-api/tests/unit/agents/runtime-config.test.ts`                  | `formatRuntimeConfig` payload shape             |
+| `modelguide-api/tests/integration/agent-runtime-config.test.ts`            | Route auth + response (API-key only)            |
+
+```bash
+# From this directory:
+uv run pytest                  # 12 tests, ~0.1s
+
+# From the repo root, the API contract test:
+make api-test-unit             # includes runtime-config.test.ts
+make api-test-integration      # includes agent-runtime-config.test.ts
+```
+
+## Deployment to LiveKit Cloud
+
+1. Build & push the image (or let LiveKit Cloud build it):
+   ```bash
+   docker build -t ghcr.io/<you>/livekit-poc-agent:latest .
+   ```
+2. In LiveKit Cloud → *Agents*, register a worker with
+   `agent_name = livekit-poc-agent` and the env vars from `.env.example`.
+3. In the ModelGuide dashboard, set `metadata.livekit.agentName` on the
+   agent to `livekit-poc-agent` so voice-test dispatches reach this worker.
+
+The dispatch metadata produced by `createVoiceTestSession` is JSON-decoded
+in the entrypoint and used for caller identity / session correlation. Any
+fields beyond `agentName`, `session_id`, `user_identifier`, `email` are
+ignored.
+
+## Limitations (and how to lift them)
+
+- **No tools.** Tool calling needs the MCP wiring from
+  `examples/agents/livekit-agent/src/mg_client.py`. Drop in `MCPConnection`
+  and decorate functions with `@function_tool` — the runtime-config flow
+  is orthogonal and stays unchanged.
+- **No transcript sync.** Reuse `TranscriptCollector` and the cleanup
+  pattern from `examples/agents/livekit-agent/src/agent.py:_cleanup`.
+- **No SIP.** This worker only takes WebRTC dispatches. SIP is purely
+  additive; see the BuildPro Sam DEPLOY guide.
+- **Prompt cached for the lifetime of the session.** A long-running call
+  will not pick up a re-compile mid-stream. To support that, poll
+  `runtime_config.fetch` periodically and update `agent.instructions`.
+
+## Directory layout
+
+```
+src/livekit_poc_agent/
+  __init__.py
+  agent.py            # entrypoint — fetch prompt, run AgentSession
+  config.py           # env validation + fallback prompt
+  runtime_config.py   # GET /api/agents/me/runtime-config client
+  mg_session.py       # POST/PATCH /api/sessions  (best-effort, never raises)
+tests/
+  test_runtime_config.py
+  test_mg_session.py
+.env.example
+Dockerfile
+pyproject.toml
+README.md
+```

--- a/examples/agents/livekit-poc-agent/pyproject.toml
+++ b/examples/agents/livekit-poc-agent/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "livekit-poc-agent"
+version = "0.1.0"
+description = "POC LiveKit voice agent that fetches its prompt from ModelGuide on every session start"
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[project.scripts]
+livekit-poc-agent = "livekit_poc_agent.agent:main"
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/agents/livekit-poc-agent/src/livekit_poc_agent/__init__.py
+++ b/examples/agents/livekit-poc-agent/src/livekit_poc_agent/__init__.py
@@ -1,0 +1,10 @@
+"""LiveKit POC voice agent for ModelGuide.
+
+A Voiceblox-style minimal voice agent that fetches its system prompt
+from ModelGuide on every session start so the dashboard's "Compile"
+button has an immediate effect on the next call (no worker redeploy).
+
+See README.md for the architecture and ADR-015 for the decision context.
+"""
+
+__version__ = "0.1.0"

--- a/examples/agents/livekit-poc-agent/src/livekit_poc_agent/agent.py
+++ b/examples/agents/livekit-poc-agent/src/livekit_poc_agent/agent.py
@@ -1,0 +1,129 @@
+"""LiveKit POC voice agent entrypoint.
+
+Boots a LiveKit AgentSession, fetches the latest compiled prompt from
+ModelGuide on connect, and runs a vanilla STT → LLM → TTS pipeline. No
+custom tools, no SOP machinery — the smallest possible "talk to the
+latest dashboard prompt" demo.
+
+Usage:
+    python -m livekit_poc_agent.agent console   # text-only, no WebRTC
+    python -m livekit_poc_agent.agent dev       # WebRTC, local LiveKit server
+    python -m livekit_poc_agent.agent start     # production worker
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import deepgram, elevenlabs, openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+from . import config, mg_session, runtime_config
+
+VERSION = "0.1.0"
+
+logging.basicConfig(level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s")
+logger = logging.getLogger("agent")
+
+
+async def entrypoint(ctx: agents.JobContext):
+    """Called by the LiveKit worker for every dispatched room."""
+    config.validate()
+    logger.info("livekit-poc-agent v%s — entrypoint", VERSION)
+
+    # Dispatch metadata from createVoiceTestSession (see modelguide-api
+    # buildVoiceTestDispatchMetadata). The voice-test flow includes a
+    # pre-created session_id so the first transcript hits the right call.
+    md: dict = {}
+    if ctx.job.metadata:
+        try:
+            md = json.loads(ctx.job.metadata)
+        except json.JSONDecodeError:
+            logger.warning("invalid job metadata: %s", ctx.job.metadata[:200])
+
+    await ctx.connect()
+    participant = await ctx.wait_for_participant()
+    logger.info("participant joined: %s", participant.identity)
+
+    # 1. Fetch the latest compiled prompt from ModelGuide. Fail open: if
+    #    the API is unreachable we still complete the call using the
+    #    baked-in fallback so the operator hears *something*.
+    instructions = config.FALLBACK_INSTRUCTIONS
+    rt: runtime_config.RuntimeConfig | None = None
+    try:
+        rt = await runtime_config.fetch(
+            base_url=config.MODELGUIDE_API_URL, api_key=config.MODELGUIDE_API_KEY
+        )
+        instructions = runtime_config.resolve_instructions(
+            rt, fallback=config.FALLBACK_INSTRUCTIONS
+        )
+        logger.info(
+            "runtime-config loaded: agent=%s compiledAt=%s len=%d",
+            rt.slug,
+            rt.compiled_at,
+            len(instructions),
+        )
+    except Exception:
+        logger.exception("runtime-config fetch failed — using fallback prompt")
+
+    # 2. Session bookkeeping. Voice-test pre-creates the session so the
+    #    dashboard can show "Session sess-…" before audio starts; for any
+    #    other dispatch we create one ourselves.
+    user_identifier = md.get("user_identifier") or md.get("email") or "voice-caller"
+    session_id: str | None = md.get("session_id")
+    if not session_id:
+        session_id = await mg_session.create_session(
+            base_url=config.MODELGUIDE_API_URL,
+            api_key=config.MODELGUIDE_API_KEY,
+            user_identifier=user_identifier,
+        )
+    logger.info("session=%s user=%s", session_id, user_identifier)
+
+    # 3. Build the LiveKit AgentSession. We use the same provider stack as
+    #    the full BuildPro Sam example so deployment artifacts (Dockerfile,
+    #    LiveKit Cloud worker config) carry over.
+    agent = Agent(instructions=instructions)
+    session = AgentSession(
+        stt=deepgram.STT(model="nova-3", api_key=config.DEEPGRAM_API_KEY),
+        llm=openai.LLM(model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY),
+        tts=elevenlabs.TTS(
+            voice_id=config.ELEVENLABS_VOICE_ID,
+            api_key=config.ELEVENLABS_API_KEY,
+        ),
+        vad=silero.VAD.load(),
+        turn_detection=EnglishModel(),
+        allow_interruptions=True,
+    )
+
+    await session.start(room=ctx.room, agent=agent)
+
+    # Greet the caller. We use a static greeting rather than asking the
+    # LLM to generate one so first-token latency stays predictable.
+    await session.say("Hi! I'm listening.")
+
+    async def _on_shutdown():
+        if session_id:
+            await mg_session.complete_session(
+                base_url=config.MODELGUIDE_API_URL,
+                api_key=config.MODELGUIDE_API_KEY,
+                session_id=session_id,
+            )
+
+    ctx.add_shutdown_callback(_on_shutdown)
+
+
+def main() -> None:
+    """CLI entrypoint — same surface as the LiveKit ``agents`` CLI."""
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agents/livekit-poc-agent/src/livekit_poc_agent/config.py
+++ b/examples/agents/livekit-poc-agent/src/livekit_poc_agent/config.py
@@ -1,0 +1,81 @@
+"""Environment configuration for the POC LiveKit agent.
+
+Validation is deferred so the LiveKit worker process can boot before env
+vars are checked. Call ``validate()`` once at the top of the entrypoint.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+REQUIRED = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    """Raised when required env vars are missing."""
+
+
+# Read at import time — used by WorkerOptions before validate() runs.
+AGENT_NAME: str = os.getenv("AGENT_NAME", "livekit-poc-agent")
+
+# All other config — populated by validate().
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+LLM_MODEL: str = ""
+ELEVENLABS_VOICE_ID: str = ""
+
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+
+# Fallback prompt used when the agent has not been compiled yet in the
+# dashboard. The whole point of the POC is to override this with the
+# user's compiled prompt — but we must still complete the call gracefully
+# if compile has never been clicked.
+FALLBACK_INSTRUCTIONS: str = (
+    "You are a friendly voice assistant. Greet the caller, listen, and "
+    "respond conversationally. If you do not know the answer, say so."
+)
+
+
+_validated = False
+
+
+def validate() -> None:
+    """Load env vars and raise on any missing required value."""
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED if not os.getenv(v)]
+    if missing:
+        raise ConfigError(f"Missing required env vars: {', '.join(missing)}")
+
+    g = globals()
+    g.update(
+        {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+            "ELEVENLABS_API_KEY": os.getenv("ELEVENLABS_API_KEY", ""),
+            "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4.1-mini"),
+            "ELEVENLABS_VOICE_ID": os.getenv(
+                "ELEVENLABS_VOICE_ID", "iP95p4xoKVk53GoZ742B"
+            ),
+            "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+            "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+            "FALLBACK_INSTRUCTIONS": os.getenv(
+                "FALLBACK_INSTRUCTIONS", FALLBACK_INSTRUCTIONS
+            ),
+        }
+    )
+    _validated = True

--- a/examples/agents/livekit-poc-agent/src/livekit_poc_agent/mg_session.py
+++ b/examples/agents/livekit-poc-agent/src/livekit_poc_agent/mg_session.py
@@ -1,0 +1,68 @@
+"""Thin ModelGuide REST client — session lifecycle only.
+
+This POC deliberately skips the MCP tool wiring that the full BuildPro Sam
+agent has (see ``examples/agents/livekit-agent/src/mg_client.py``). The
+goal here is the smallest possible "talk to the latest prompt" loop.
+Tool execution can be layered in later by reusing the full client.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger("mg_session")
+
+
+def _client(base_url: str, api_key: str, timeout: float = 30.0) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=base_url.rstrip("/"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        timeout=timeout,
+    )
+
+
+async def create_session(
+    *, base_url: str, api_key: str, user_identifier: str
+) -> str | None:
+    """Create a ModelGuide session for this call. Returns session id or None on failure.
+
+    Failures are logged but never raised — the call should still complete
+    even if session tracking is broken.
+    """
+    async with _client(base_url, api_key) as c:
+        try:
+            resp = await c.post(
+                "/api/sessions",
+                json={"channelType": "voice", "userIdentifier": user_identifier},
+            )
+            resp.raise_for_status()
+            return resp.json()["id"]
+        except Exception:
+            logger.exception("create_session failed")
+            return None
+
+
+async def complete_session(
+    *, base_url: str, api_key: str, session_id: str, status: str = "completed"
+) -> None:
+    """Mark the session as completed/abandoned. Errors are logged, not raised."""
+    async with _client(base_url, api_key) as c:
+        try:
+            resp = await c.patch(
+                f"/api/sessions/{session_id}",
+                json={"status": status},
+            )
+            if not resp.is_success:
+                logger.warning(
+                    "complete_session %s returned %s: %s",
+                    session_id,
+                    resp.status_code,
+                    resp.text,
+                )
+        except Exception:
+            logger.exception("complete_session failed for %s", session_id)

--- a/examples/agents/livekit-poc-agent/src/livekit_poc_agent/runtime_config.py
+++ b/examples/agents/livekit-poc-agent/src/livekit_poc_agent/runtime_config.py
@@ -1,0 +1,93 @@
+"""ModelGuide runtime-config client for the POC LiveKit agent.
+
+On every session start, the worker calls
+``GET /api/agents/me/runtime-config`` with its agent API key (mgk_*) to
+pick up the latest compiled prompt. This is the single piece that makes
+"compile in dashboard → talk to the new prompt" work without a worker
+redeploy. Contract is locked by ``tests/test_runtime_config.py`` here
+and ``tests/integration/agent-runtime-config.test.ts`` in the API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    """The narrow worker-facing slice of an agent.
+
+    Mirrors ``AgentRuntimeConfig`` in ``modelguide-api/src/features/
+    agents/agents.service.ts``. We deliberately do NOT carry secrets,
+    integration URLs, or eval state — the worker has no business
+    seeing them.
+    """
+
+    id: str
+    name: str
+    slug: str
+    modality: str  # "voice" | "text"
+    agent_platform: str  # "custom" | "elevenlabs" | "livekit"
+    model_family: str  # "gpt" | "claude" | "gemini" | "generic"
+    is_active: bool
+    compiled_instructions: str | None
+    compiled_at: str | None  # ISO 8601 string or None if never compiled
+    prompt_config: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+async def fetch(*, base_url: str, api_key: str, timeout: float = 10.0) -> RuntimeConfig:
+    """Fetch the calling agent's runtime config from ModelGuide.
+
+    Args:
+        base_url: Base URL of the ModelGuide API (with or without trailing slash).
+        api_key: Agent API key (mgk_xxx) — the agent identity is derived from it.
+        timeout: HTTP timeout in seconds.
+
+    Raises:
+        httpx.HTTPStatusError: On 4xx/5xx — log and decide whether to fall
+            back to a baked-in prompt at the call site.
+    """
+    base = base_url.rstrip("/")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    client = httpx.AsyncClient(base_url=base, headers=headers, timeout=timeout)
+    try:
+        resp = await client.get("/api/agents/me/runtime-config")
+        resp.raise_for_status()
+        data = resp.json()
+    finally:
+        await client.aclose()
+
+    return RuntimeConfig(
+        id=data["id"],
+        name=data["name"],
+        slug=data["slug"],
+        modality=data["modality"],
+        agent_platform=data["agentPlatform"],
+        model_family=data["modelFamily"],
+        is_active=data["isActive"],
+        compiled_instructions=data.get("compiledInstructions"),
+        compiled_at=data.get("compiledAt"),
+        prompt_config=data.get("promptConfig") or {},
+        metadata=data.get("metadata") or {},
+    )
+
+
+def resolve_instructions(config: RuntimeConfig, *, fallback: str) -> str:
+    """Choose the prompt to actually feed the LLM.
+
+    Prefers the freshly compiled prompt from the dashboard; falls back to
+    the baked-in default when the agent has never been compiled (so the
+    worker still completes the call instead of erroring out mid-greeting).
+    Empty / whitespace-only strings are treated as 'not compiled'.
+    """
+    compiled = config.compiled_instructions
+    if compiled and compiled.strip():
+        return compiled
+    return fallback

--- a/examples/agents/livekit-poc-agent/tests/test_mg_session.py
+++ b/examples/agents/livekit-poc-agent/tests/test_mg_session.py
@@ -1,0 +1,86 @@
+"""Tests for the thin ModelGuide session client.
+
+Session creation/completion failures must NEVER raise out of these helpers
+— a logging hiccup at session-end shouldn't be the reason a real call
+ends in a stack trace. These tests pin that 'always swallow' contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from livekit_poc_agent import mg_session
+
+
+def _resp(status: int, json_data: dict | None = None, text: str = ""):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.is_success = 200 <= status < 300
+    r.json.return_value = json_data or {}
+    r.text = text
+    if status >= 400:
+        r.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("err", request=MagicMock(), response=r)
+        )
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+def _client(method: str, response):
+    c = AsyncMock()
+    getattr(c, method).return_value = response
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=False)
+    return c
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_id_on_success():
+    c = _client("post", _resp(200, {"id": "sess_123"}))
+    with patch("livekit_poc_agent.mg_session.httpx.AsyncClient", return_value=c):
+        sid = await mg_session.create_session(
+            base_url="http://x", api_key="mgk_x", user_identifier="caller@x.com"
+        )
+    assert sid == "sess_123"
+    body = c.post.call_args[1]["json"]
+    assert body == {"channelType": "voice", "userIdentifier": "caller@x.com"}
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_none_on_http_error():
+    """Don't crash the call just because session tracking is degraded."""
+    c = _client("post", _resp(500, text="boom"))
+    with patch("livekit_poc_agent.mg_session.httpx.AsyncClient", return_value=c):
+        sid = await mg_session.create_session(
+            base_url="http://x", api_key="mgk_x", user_identifier="caller@x.com"
+        )
+    assert sid is None
+
+
+@pytest.mark.asyncio
+async def test_complete_session_swallows_errors():
+    """Same: session completion failures must not propagate."""
+    c = _client("patch", _resp(500, text="server gone"))
+    with patch("livekit_poc_agent.mg_session.httpx.AsyncClient", return_value=c):
+        # Must not raise.
+        await mg_session.complete_session(
+            base_url="http://x", api_key="mgk_x", session_id="sess_x"
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_session_sends_status():
+    c = _client("patch", _resp(200, {"id": "sess_x", "status": "completed"}))
+    with patch("livekit_poc_agent.mg_session.httpx.AsyncClient", return_value=c):
+        await mg_session.complete_session(
+            base_url="http://x",
+            api_key="mgk_x",
+            session_id="sess_x",
+            status="abandoned",
+        )
+    body = c.patch.call_args[1]["json"]
+    assert body == {"status": "abandoned"}

--- a/examples/agents/livekit-poc-agent/tests/test_runtime_config.py
+++ b/examples/agents/livekit-poc-agent/tests/test_runtime_config.py
@@ -1,0 +1,171 @@
+"""Red-green TDD tests for ``runtime_config.fetch``.
+
+The POC LiveKit agent fetches its system prompt from ModelGuide on every
+session start so the dashboard's "Compile" button has an immediate effect
+on the next call (no worker redeploy). That contract is what these tests
+pin down — see ADR-015 and the README in this folder.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from livekit_poc_agent import runtime_config
+
+
+def _resp(status: int = 200, json_data: dict | None = None, text: str = ""):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.is_success = 200 <= status < 300
+    r.json.return_value = json_data or {}
+    r.text = text
+    if status >= 400:
+        r.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("err", request=MagicMock(), response=r)
+        )
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+def _client(response):
+    c = AsyncMock()
+    c.get.return_value = response
+    c.aclose = AsyncMock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_runtime_config_dataclass():
+    """Happy path — GET /api/agents/me/runtime-config → RuntimeConfig."""
+    client = _client(
+        _resp(
+            200,
+            {
+                "id": "00000000-0000-0000-0000-000000000abc",
+                "name": "Demo Voice Agent",
+                "slug": "demo-voice",
+                "modality": "voice",
+                "agentPlatform": "livekit",
+                "modelFamily": "gpt",
+                "isActive": True,
+                "compiledInstructions": "You are Demo. Greet the caller.",
+                "compiledAt": "2026-04-01T00:00:00.000Z",
+                "promptConfig": {"persona": "warm"},
+                "metadata": {"livekit": {"agentName": "demo-voice"}},
+            },
+        )
+    )
+    with patch("livekit_poc_agent.runtime_config.httpx.AsyncClient", return_value=client):
+        cfg = await runtime_config.fetch(
+            base_url="http://localhost:3000", api_key="mgk_test"
+        )
+
+    assert cfg.id == "00000000-0000-0000-0000-000000000abc"
+    assert cfg.name == "Demo Voice Agent"
+    assert cfg.slug == "demo-voice"
+    assert cfg.compiled_instructions == "You are Demo. Greet the caller."
+    assert cfg.compiled_at == "2026-04-01T00:00:00.000Z"
+    assert cfg.is_active is True
+    assert cfg.modality == "voice"
+
+
+@pytest.mark.asyncio
+async def test_fetch_sends_bearer_authorization_header():
+    """Correct auth header — without it the API returns 401."""
+    client = _client(_resp(200, {"id": "x", "name": "n", "slug": "s",
+                                 "modality": "voice", "agentPlatform": "livekit",
+                                 "modelFamily": "gpt", "isActive": True,
+                                 "compiledInstructions": None, "compiledAt": None,
+                                 "promptConfig": {}, "metadata": {}}))
+    with patch(
+        "livekit_poc_agent.runtime_config.httpx.AsyncClient", return_value=client
+    ) as ctor:
+        await runtime_config.fetch(base_url="http://x", api_key="mgk_secret")
+        # httpx.AsyncClient(headers=...) — kwarg forwarded to the constructor
+        ctor_kwargs = ctor.call_args[1]
+
+    assert ctor_kwargs["headers"]["Authorization"] == "Bearer mgk_secret"
+    # Path is the runtime-config route, not the user-scoped /api/agents/{id}
+    assert client.get.call_args[0][0] == "/api/agents/me/runtime-config"
+
+
+@pytest.mark.asyncio
+async def test_fetch_strips_trailing_slash_from_base_url():
+    """A common .env mistake — must not produce //api/agents/me/runtime-config."""
+    client = _client(_resp(200, {"id": "x", "name": "n", "slug": "s",
+                                 "modality": "voice", "agentPlatform": "livekit",
+                                 "modelFamily": "gpt", "isActive": True,
+                                 "compiledInstructions": None, "compiledAt": None,
+                                 "promptConfig": {}, "metadata": {}}))
+    with patch(
+        "livekit_poc_agent.runtime_config.httpx.AsyncClient", return_value=client
+    ) as ctor:
+        await runtime_config.fetch(base_url="http://localhost:3000/", api_key="mgk_x")
+        ctor_kwargs = ctor.call_args[1]
+
+    assert ctor_kwargs["base_url"] == "http://localhost:3000"
+
+
+@pytest.mark.asyncio
+async def test_fetch_handles_null_compiled_prompt():
+    """When the agent has not been compiled yet, compiled_instructions is None."""
+    client = _client(_resp(200, {"id": "x", "name": "n", "slug": "s",
+                                 "modality": "voice", "agentPlatform": "livekit",
+                                 "modelFamily": "gpt", "isActive": True,
+                                 "compiledInstructions": None, "compiledAt": None,
+                                 "promptConfig": {}, "metadata": {}}))
+    with patch("livekit_poc_agent.runtime_config.httpx.AsyncClient", return_value=client):
+        cfg = await runtime_config.fetch(base_url="http://x", api_key="mgk_x")
+    assert cfg.compiled_instructions is None
+    assert cfg.compiled_at is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_on_http_error():
+    """401/403/etc. should propagate so the worker logs visibly and falls back."""
+    client = _client(_resp(401, text="Unauthorized"))
+    with patch("livekit_poc_agent.runtime_config.httpx.AsyncClient", return_value=client):
+        with pytest.raises(httpx.HTTPStatusError):
+            await runtime_config.fetch(base_url="http://x", api_key="mgk_bad")
+
+
+def test_resolve_instructions_prefers_compiled_prompt():
+    """If the agent has been compiled, that prompt wins over any fallback."""
+    cfg = runtime_config.RuntimeConfig(
+        id="x", name="n", slug="s", modality="voice",
+        agent_platform="livekit", model_family="gpt", is_active=True,
+        compiled_instructions="LATEST FROM DASHBOARD",
+        compiled_at="2026-04-01T00:00:00.000Z",
+        prompt_config={}, metadata={},
+    )
+    assert (
+        runtime_config.resolve_instructions(cfg, fallback="OLD")
+        == "LATEST FROM DASHBOARD"
+    )
+
+
+def test_resolve_instructions_falls_back_when_uncompiled():
+    """If the dashboard never compiled, use the baked-in fallback so the worker
+    doesn't crash and the call still completes."""
+    cfg = runtime_config.RuntimeConfig(
+        id="x", name="n", slug="s", modality="voice",
+        agent_platform="livekit", model_family="gpt", is_active=True,
+        compiled_instructions=None, compiled_at=None,
+        prompt_config={}, metadata={},
+    )
+    assert runtime_config.resolve_instructions(cfg, fallback="DEFAULT") == "DEFAULT"
+
+
+def test_resolve_instructions_falls_back_when_empty_string():
+    """Empty string is treated as 'not compiled' — same as None."""
+    cfg = runtime_config.RuntimeConfig(
+        id="x", name="n", slug="s", modality="voice",
+        agent_platform="livekit", model_family="gpt", is_active=True,
+        compiled_instructions="   ", compiled_at=None,
+        prompt_config={}, metadata={},
+    )
+    assert runtime_config.resolve_instructions(cfg, fallback="DEFAULT") == "DEFAULT"

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRuntimeConfig,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -586,6 +589,58 @@ router.openapi(createPlatformAgentRoute, async (c) => {
   }
 
   throw Errors.invalidInput(`Unsupported platform: ${platform}`);
+});
+
+// ============================================================================
+// GET /me/runtime-config — worker-only (agent API key)
+//
+// MUST be registered BEFORE the `/:id` catch-all so "me" is not parsed as an
+// agent UUID. Used by the POC LiveKit agent (and any other voice/text
+// worker) to fetch its own latest compiled prompt at session start.
+// See examples/agents/livekit-poc-agent and ADR-015.
+// ============================================================================
+
+router.get("/me/runtime-config", requireAgent(), requireOrganization());
+
+const runtimeConfigResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  modality: z.enum(["voice", "text"]),
+  agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]),
+  modelFamily: modelFamilySchema,
+  isActive: z.boolean(),
+  compiledInstructions: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+  promptConfig: z.record(z.unknown()),
+  metadata: z.record(z.unknown()),
+});
+
+const runtimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me/runtime-config",
+  tags: ["Agents"],
+  summary: "Get the calling agent's runtime config (worker)",
+  description:
+    "Returns the latest compiled prompt and identity for the agent bound to the API key making this request. Designed for voice/text workers (e.g. the LiveKit POC agent) to pick up the freshly compiled prompt on session start so 'compile in dashboard → talk to the new prompt' works without redeploying the worker. The response is intentionally narrower than GET /agents/{id} — it omits secrets, integration URLs, and eval state.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Runtime config",
+      content: {
+        "application/json": { schema: runtimeConfigResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Agent inactive or wrong auth type"),
+  },
+});
+
+router.openapi(runtimeConfigRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const config = await getAgentRuntimeConfig(orgId, agent.id);
+  return c.json(config, 200);
 });
 
 // GET /:id

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -14,7 +14,7 @@ import {
   evalSuites,
   secrets,
 } from "@db/schema";
-import type { EntitySecretsMap, PromptConfig } from "@db/schema";
+import type { Agent, EntitySecretsMap, PromptConfig } from "@db/schema";
 import { getAgentSecretByType } from "@features/secrets/secrets.service";
 import {
   createSession,
@@ -1059,4 +1059,57 @@ export async function createVoiceTestSession(
     profileName: agent.slug,
     identity,
   };
+}
+
+// ============================================================================
+// Worker runtime-config (POC LiveKit agent fetches latest compiled prompt)
+// ============================================================================
+
+/**
+ * Worker-facing payload returned by GET /api/agents/me/runtime-config.
+ *
+ * Intentionally narrower than `formatAgent` — a worker authenticated by API
+ * key has no business seeing secret refs, integration URLs, or eval state.
+ * The shape is locked by `tests/unit/agents/runtime-config.test.ts`.
+ */
+export interface AgentRuntimeConfig {
+  id: string;
+  name: string;
+  slug: string;
+  modality: "voice" | "text";
+  agentPlatform: "custom" | "elevenlabs" | "livekit";
+  modelFamily: "gpt" | "claude" | "gemini" | "generic";
+  isActive: boolean;
+  compiledInstructions: string | null;
+  compiledAt: string | null;
+  promptConfig: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+export function formatRuntimeConfig(agent: Agent): AgentRuntimeConfig {
+  return {
+    id: agent.id,
+    name: agent.name,
+    slug: agent.slug,
+    modality: agent.modality as AgentRuntimeConfig["modality"],
+    agentPlatform: agent.agentPlatform as AgentRuntimeConfig["agentPlatform"],
+    modelFamily: agent.modelFamily as AgentRuntimeConfig["modelFamily"],
+    isActive: agent.isActive,
+    compiledInstructions: agent.compiledInstructions ?? null,
+    compiledAt: agent.compiledAt ? agent.compiledAt.toISOString() : null,
+    promptConfig: (agent.promptConfig ?? {}) as Record<string, unknown>,
+    metadata: (agent.metadata ?? {}) as Record<string, unknown>,
+  };
+}
+
+/**
+ * Fetch the runtime config for the API-key-bound agent. Used by the POC
+ * LiveKit worker to load the latest compiled prompt on session start.
+ */
+export async function getAgentRuntimeConfig(
+  orgId: string,
+  agentId: string,
+): Promise<AgentRuntimeConfig> {
+  const agent = await forOrg(orgId, (tx) => requireAgent(tx, agentId));
+  return formatRuntimeConfig(agent);
 }

--- a/modelguide-api/tests/integration/agent-runtime-config.test.ts
+++ b/modelguide-api/tests/integration/agent-runtime-config.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration tests for GET /api/agents/me/runtime-config
+ *
+ * Contract surfaced to LiveKit/voice workers: an agent can use its own
+ * API key to fetch the latest compiled prompt + voice config from
+ * ModelGuide on session start. This is what makes "compile in dashboard
+ * → talk to the new prompt" work for the POC LiveKit agent —
+ * see docs/decisions/015-livekit-runtime-prompt-fetch.md and
+ * examples/agents/livekit-poc-agent.
+ *
+ * The endpoint is API-key-only (mgk_*) — user JWTs are rejected. The
+ * response is intentionally narrow: the worker should not need to know
+ * about secrets, integration URLs, or evaluation state.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import app from "@/app";
+import { forApp } from "@db/rls";
+import { agents } from "@db/schema";
+import { eq } from "drizzle-orm";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
+
+let s: TestSeed;
+let orgAAgentHeaders: Record<string, string>;
+let orgAAdminHeaders: Record<string, string>;
+
+const KNOWN_PROMPT = "You are a helpful demo voice agent.";
+
+function request(path: string, options?: RequestInit) {
+  return app.fetch(new Request(`http://localhost${path}`, options));
+}
+
+beforeAll(async () => {
+  s = await getTestSeed();
+  orgAAgentHeaders = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+  orgAAdminHeaders = await authHeadersFor(s.orgAAdmin);
+
+  // Stamp a known compiled prompt on the seed agent so tests don't depend
+  // on whatever the seed happens to compile.
+  await forApp((tx) =>
+    tx
+      .update(agents)
+      .set({
+        compiledInstructions: KNOWN_PROMPT,
+        compiledAt: new Date("2026-04-01T00:00:00Z"),
+      })
+      .where(eq(agents.id, s.orgAAgentId)),
+  );
+});
+
+afterAll(async () => {
+  // Restore: clear out the test-stamped fields.
+  await forApp((tx) =>
+    tx
+      .update(agents)
+      .set({ compiledInstructions: null, compiledAt: null })
+      .where(eq(agents.id, s.orgAAgentId)),
+  );
+});
+
+describe("GET /api/agents/me/runtime-config", () => {
+  test("returns compiled prompt and identity for the API-key-bound agent (200)", async () => {
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.name).toBeString();
+    expect(body.slug).toBeString();
+    expect(body.modality).toBe("voice");
+    expect(body.compiledInstructions).toBe(KNOWN_PROMPT);
+    expect(body.compiledAt).toBe("2026-04-01T00:00:00.000Z");
+    expect(body.agentPlatform).toBeString();
+    expect(body.isActive).toBe(true);
+  });
+
+  test("does not leak secrets, integrationUrls, or evalSuiteCount", async () => {
+    // The runtime-config endpoint is intentionally narrower than the
+    // dashboard's GET /api/agents/:id. A worker has no business seeing
+    // secret refs or webhook URLs.
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAgentHeaders,
+    });
+    const body = await response.json();
+
+    expect(body.secrets).toBeUndefined();
+    expect(body.integrationUrls).toBeUndefined();
+    expect(body.evalSuiteCount).toBeUndefined();
+    expect(body.keyPrefix).toBeUndefined();
+    expect(body.hasElevenLabsKey).toBeUndefined();
+    expect(body.hasWebhookSecret).toBeUndefined();
+  });
+
+  test("returns null compiledInstructions when the agent has not been compiled", async () => {
+    // Clear the prompt for this test, then put it back so the rest of the
+    // suite still sees KNOWN_PROMPT.
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({ compiledInstructions: null, compiledAt: null })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAgentHeaders,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.compiledInstructions).toBeNull();
+    expect(body.compiledAt).toBeNull();
+
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          compiledInstructions: KNOWN_PROMPT,
+          compiledAt: new Date("2026-04-01T00:00:00Z"),
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+  });
+
+  test("rejects user JWT auth — agent API key only (401)", async () => {
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAdminHeaders,
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects unauthenticated requests (401)", async () => {
+    const response = await request("/api/agents/me/runtime-config");
+    expect(response.status).toBe(401);
+  });
+});

--- a/modelguide-api/tests/unit/agents/runtime-config.test.ts
+++ b/modelguide-api/tests/unit/agents/runtime-config.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure-function unit tests for `formatRuntimeConfig`.
+ *
+ * The runtime-config endpoint returns a deliberately narrow payload — see
+ * `agent-runtime-config.test.ts` (integration) for the route-level contract.
+ * This test pins the exact shape so a refactor of the dashboard agent
+ * response (which happily carries secrets, integrationUrls, etc.) doesn't
+ * accidentally widen the worker-facing payload.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Agent } from "@db/schema";
+import { formatRuntimeConfig } from "../../../src/features/agents/agents.service";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  const now = new Date("2026-04-01T00:00:00Z");
+  return {
+    id: "00000000-0000-0000-0000-000000000abc",
+    organizationId: "00000000-0000-0000-0000-0000000000aa",
+    name: "Demo Voice Agent",
+    slug: "demo-voice",
+    description: null,
+    modality: "voice",
+    modelFamily: "gpt",
+    promptConfig: {},
+    agentPlatform: "livekit",
+    isActive: true,
+    metadata: { livekit: { url: "wss://x", agentName: "demo-voice" } },
+    secrets: { livekit_api_key: "00000000-0000-0000-0000-000000000111" },
+    compiledInstructions: "You are Demo. Say hi.",
+    compiledAt: now,
+    compiledFrom: null,
+    keyPrefix: "mgk_demo",
+    elevenlabsKeyEncrypted: null,
+    webhookSecretEncrypted: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as unknown as Agent;
+}
+
+describe("formatRuntimeConfig", () => {
+  test("returns the worker-facing fields verbatim", () => {
+    const out = formatRuntimeConfig(fakeAgent());
+    expect(out).toEqual({
+      id: "00000000-0000-0000-0000-000000000abc",
+      name: "Demo Voice Agent",
+      slug: "demo-voice",
+      modality: "voice",
+      agentPlatform: "livekit",
+      modelFamily: "gpt",
+      isActive: true,
+      compiledInstructions: "You are Demo. Say hi.",
+      compiledAt: "2026-04-01T00:00:00.000Z",
+      promptConfig: {},
+      metadata: { livekit: { url: "wss://x", agentName: "demo-voice" } },
+    });
+  });
+
+  test("does NOT leak secrets, keyPrefix, or webhook flags", () => {
+    // Guard against a refactor that swaps formatRuntimeConfig for the
+    // dashboard's formatAgent. The worker's API key already grants
+    // narrower scope than a user JWT — keep the response narrow too.
+    const out = formatRuntimeConfig(fakeAgent());
+    expect(out).not.toHaveProperty("secrets");
+    expect(out).not.toHaveProperty("integrationUrls");
+    expect(out).not.toHaveProperty("evalSuiteCount");
+    expect(out).not.toHaveProperty("keyPrefix");
+    expect(out).not.toHaveProperty("hasElevenLabsKey");
+    expect(out).not.toHaveProperty("hasWebhookSecret");
+    expect(out).not.toHaveProperty("organizationId");
+    expect(out).not.toHaveProperty("description");
+  });
+
+  test("returns null compiledInstructions/compiledAt when not yet compiled", () => {
+    const out = formatRuntimeConfig(
+      fakeAgent({ compiledInstructions: null, compiledAt: null }),
+    );
+    expect(out.compiledInstructions).toBeNull();
+    expect(out.compiledAt).toBeNull();
+  });
+
+  test("metadata defaults to {} when null", () => {
+    const out = formatRuntimeConfig(
+      fakeAgent({ metadata: null as unknown as Record<string, unknown> }),
+    );
+    expect(out.metadata).toEqual({});
+  });
+});

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 


### PR DESCRIPTION
## Summary

Closes the dashboard's *Compile → Talk to agent* loop for LiveKit. Today,
clicking *Compile* updates `agents.compiled_instructions` but the dispatched
LiveKit worker keeps using whatever prompt was baked into its image — so the
*Talk to agent* button doesn't reflect prompt edits without a worker redeploy.

This PR adds a Voiceblox-style minimal LiveKit voice agent
(`examples/agents/livekit-poc-agent/`) plus a small API endpoint that lets it
pull the latest compiled prompt on every session start.

### What's in the box

- **API** — `GET /api/agents/me/runtime-config` (agent API key auth, `mgk_*`).
  Returns a deliberately narrow worker-facing payload: `compiledInstructions`,
  `compiledAt`, `slug`, `modality`, `agentPlatform`, `modelFamily`,
  `promptConfig`, `metadata`. **No** secrets, integration URLs, or eval state
  — the unit test asserts this explicitly so future refactors don't widen
  the payload by accident.
- **POC LiveKit agent** — `examples/agents/livekit-poc-agent/` (Python /
  livekit-agents 1.4). On entrypoint, fetches its own runtime-config and
  feeds `compiled_instructions` into `Agent(instructions=...)`. Falls back
  to a baked-in prompt if ModelGuide is unreachable so the call still
  completes with audio. Includes Dockerfile + `.env.example` for LiveKit
  Cloud deployment.
- **ADR-015** documents the pull-vs-push trade-off and the rejected
  alternatives (push at dispatch / reuse `GET /agents/{id}` / compile on
  every voice-test).

### Red→green TDD

The cross-language contract is locked by tests on both sides:

| Test | What it pins |
| --- | --- |
| `modelguide-api/tests/unit/agents/runtime-config.test.ts` | `formatRuntimeConfig` payload shape (the no-leak guarantee) |
| `modelguide-api/tests/integration/agent-runtime-config.test.ts` | Route auth — agent API key only, user JWT rejected |
| `examples/agents/livekit-poc-agent/tests/test_runtime_config.py` | `runtime_config.fetch` request shape + parsing + fallback resolution |
| `examples/agents/livekit-poc-agent/tests/test_mg_session.py` | Session create/complete swallow transient errors |

Each suite was written failing first, then implemented to green.

### How to verify locally

```bash
# Three terminals
livekit-server --dev
cd examples/agents/livekit-poc-agent && python -m livekit_poc_agent.agent dev
# In modelguide-ui dashboard: open the LiveKit agent, edit a block,
# click Compile, then Talk to agent.
```

The greeting is static ("Hi! I'm listening.") for predictable first-token
latency; everything after that uses the freshly compiled prompt.

## Test plan

- [x] `bun test --preload tests/setup/unit-preload.ts tests/unit` (900 pass)
- [x] `cd modelguide-ui && bun run test:ci` (268 pass)
- [x] `cd examples/agents/livekit-poc-agent && pytest` (12 pass)
- [x] `bun run typecheck` (API + UI)
- [x] `bun run lint` (API + UI, no findings)
- [ ] `make api-test-integration` — requires Docker (will run in CI)
- [ ] Manual: compile a prompt in the dashboard → click *Talk to agent* →
  verify the agent greets per the new prompt without redeploying the worker

## Out of scope (called out in the README)

- MCP tool calling — reuse `MCPConnection` from
  `examples/agents/livekit-agent/src/mg_client.py` when needed.
- Transcript sync — same source.
- SIP — additive, see BuildPro Sam DEPLOY guide.
- Mid-call re-compile pickup — the prompt is cached for the call's lifetime.

https://claude.ai/code/session_01Q7yEb31eGvhQpQGw5Z6D5t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7yEb31eGvhQpQGw5Z6D5t)_