### PR TITLE
feat(livekit): runtime prompt fetch for voice-test workers (POC)

### DIFF
--- a/docs/decisions/015-livekit-runtime-prompt-fetch.md
+++ b/docs/decisions/015-livekit-runtime-prompt-fetch.md
@@ -1,0 +1,87 @@
+# ADR-015: LiveKit Runtime Prompt Fetch
+
+**Status:** Proposed (POC)
+
+## Context
+
+ADR-014 shipped browser voice testing: from the agent detail page an admin can click **Voice Test** and start talking. The dispatch contract was deliberately narrow — it routes by slug, but the prompt itself comes from whatever the worker was packaged with.
+
+Meanwhile the platform's **Compile** flow (compiler service in `modelguide-api/src/features/compiler/`) takes one or more SOPs + guardrails and writes a compiled prompt to `agents.compiled_instructions`. For the **ElevenLabs** platform we already push that prompt to the hosted agent inside `agents.sync.ts:syncAgentToElevenLabs` so a click-to-talk reflects the latest compile.
+
+There is no equivalent path for **LiveKit**. Today, "Compile → Voice Test → Talk" mechanically works, but the conversation runs against whatever prompt the worker's `prompts/base.py` happens to contain. Operators discover this when they:
+
+1. Edit a SOP.
+2. Click **Compile** (success — `compiled_instructions` updated).
+3. Click **Voice Test**.
+4. Talk for 30 seconds and hear the *old* prompt's behavior.
+5. File a bug.
+
+The goal is to close that loop with the same iteration speed admins have on ElevenLabs: **the next call uses the prompt you just compiled, no worker redeploy**.
+
+## Decision
+
+The LiveKit worker fetches its system prompt from ModelGuide at the start of every job, via:
+
+```
+GET /api/agents/me/runtime-config
+Authorization: Bearer mgk_<agent-key>
+```
+
+Response:
+
+```jsonc
+{
+  "id":           "uuid",
+  "slug":         "glowbox-voice",
+  "name":         "GlowBox Voice",
+  "modality":     "voice",
+  "modelFamily":  "gpt",
+  "instructions": "You are GlowBox …" | null,
+  "compiledAt":   "2026-05-07T10:00:00Z" | null
+}
+```
+
+The endpoint authenticates via the agent's API key (the same `mgk_…` already used for MCP). The bound agent is read from the auth context, so there's no path param — this stops a worker that holds key for *agent A* from accidentally pulling the prompt of *agent B*.
+
+Worker-side precedence for the system prompt:
+
+1. **Compiled prompt** from runtime-config — the dashboard is the source of truth.
+2. **`DEFAULT_INSTRUCTIONS`** env var — local-dev escape hatch.
+3. **Built-in fallback** so the worker always boots even if ModelGuide is unreachable on first run.
+
+The dispatch contract (`buildVoiceTestDispatchMetadata`) gains a sixth field: `agentId`. The worker doesn't strictly need it for `/me/runtime-config` (the API key is already 1:1 with an agent), but downstream multi-profile workers may want to verify the dispatched agentId matches the one their key is scoped to.
+
+The reference implementation lives in [`examples/agents/modelguide-voice-agent/`](../../examples/agents/modelguide-voice-agent/). It is intentionally smaller than the BuildPro Sam example — no MCP tools, no SIP, no tracing — so the prompt-fetch mechanism is easy to read and copy.
+
+## Alternatives Considered
+
+**Stamp the prompt into the worker image at deploy time.** Considered and rejected. CI builds are 60–120 s; that's the iteration cost an operator pays per prompt tweak. The whole reason "Voice Test" exists is to drive that cost to ~2 s.
+
+**Inject the prompt into dispatch metadata.** Already considered and rejected in ADR-014:
+
+> Earlier iterations shipped a `prompt_override` / `instructions_override` field in dispatch metadata so an admin could test a compiled prompt without redeploying the worker. We rejected this because the worker's profile is the authoritative source of prompt + tools. Injecting a different prompt creates a "it works in voice-test but broke in prod" failure mode.
+
+This ADR doesn't undo that decision. We are *not* injecting a prompt-of-the-moment via metadata; we are giving the worker a way to pull the *same* compiled prompt it would use for any other call, on a fresh fetch. No drift.
+
+**Fetch via MCP resource.** ModelGuide already has an MCP server (`modelguide-api/src/features/mcp/`). We could expose `mg://agent/runtime-config` as an MCP resource and let the worker read it that way. Rejected for the POC: MCP is the *agent-to-tools* boundary; runtime-config is *worker-to-platform*. Mixing the two would force every alternate worker stack (LangGraph, Mastra, …) to add an MCP client just to read a prompt. A boring HTTP GET is easier to lift into any stack.
+
+**Cache + push (server pushes a webhook to all listening workers on compile).** A real solution for production at scale, where you want to swap prompts on every active call. Rejected for the POC because it requires the worker to expose an inbound endpoint and the platform to track active workers — out of scope for "talk to my prompt." A future ADR can layer this on top.
+
+**Fetch on every turn, not just job-start.** Rejected. Prompts are stable within a single conversation; refetching mid-call adds latency on every user turn for no gain. Operators *expect* "Voice Test" to be a fresh session; if they want the new prompt, they hang up and click again.
+
+## Consequences
+
+- **Click → Compile → Voice Test → Talk** now reflects the just-compiled prompt within ~2 s of the click. Same iteration speed as the ElevenLabs sync flow.
+- **The runtime-config endpoint becomes a load-bearing contract** between the API and any worker that uses it. Like the dispatch metadata in ADR-014, there's no shared schema across the TypeScript / Python boundary, so we lock the contract behind tests on both sides:
+  - API: `tests/integration/agents.test.ts` — describes shape, auth, and the uncompiled-agent path.
+  - Worker: `examples/agents/modelguide-voice-agent/tests/test_runtime_config.py` — exercises the fetch against `respx`.
+- **One API key per worker per agent.** Because `/me/runtime-config` reads the bound agent from auth, multi-tenant workers (one process serving many agents) need either (a) a key registry keyed by dispatched `agentId`, or (b) an org-scoped key + a `/agents/:id/runtime-config` variant. We deferred that decision; the POC is one-key-one-agent.
+- **First-boot UX:** if someone deploys the worker before clicking **Compile** even once, `instructions` is `null`. The agent doesn't crash — it falls back to `DEFAULT_INSTRUCTIONS` then to a baked-in apology prompt and tells the caller to compile a SOP first. This is a deliberately visible failure mode, not a silent one.
+- **Failure mode if ModelGuide is unreachable:** worker logs a warning and boots with the env / built-in fallback. The agent will sound generic, but the call still connects — same posture as ADR-014's "no silent failures" rule.
+
+## Out of Scope (future work)
+
+- Pushing prompt updates into a live call.
+- Multi-agent workers (one process, many keys).
+- Including tool definitions in runtime-config so a single worker can serve different SOPs without redeploy. (Today the BuildPro example hard-codes `TOOL_NAMES`; a follow-up could move that into runtime-config too.)
+- Versioning / pinning a compile so a long-running test conversation isn't disrupted by a re-compile mid-session.

--- a/examples/agents/modelguide-voice-agent/.env.example
+++ b/examples/agents/modelguide-voice-agent/.env.example
@@ -1,0 +1,36 @@
+# ============================================================================
+# LiveKit (the worker process registers with this server)
+# ============================================================================
+# When running `python src/agent.py dev` against a local server:
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# ============================================================================
+# AI providers
+# ============================================================================
+OPENAI_API_KEY=sk-...
+DEEPGRAM_API_KEY=...
+ELEVENLABS_API_KEY=...
+ELEVENLABS_VOICE_ID=iP95p4xoKVk53GoZ742B
+LLM_MODEL=gpt-4.1-mini
+
+# ============================================================================
+# ModelGuide — used to fetch the compiled prompt at job-start
+# ============================================================================
+MODELGUIDE_API_URL=http://localhost:3000
+# API key for the agent you want to test. Get this from the dashboard
+# (Agents → <agent> → Integration → "Generate API key").
+MODELGUIDE_API_KEY=mgk_...
+
+# ============================================================================
+# Optional
+# ============================================================================
+# Worker name registered with LiveKit. Must match the value stored on the
+# agent's metadata.livekit.agentName in ModelGuide so explicit dispatch
+# can route correctly.
+AGENT_NAME=modelguide-voice-agent
+
+# Local-dev escape hatch — used as the system prompt when the dashboard
+# hasn't compiled the agent yet. Leave empty in production.
+DEFAULT_INSTRUCTIONS=

--- a/examples/agents/modelguide-voice-agent/.gitignore
+++ b/examples/agents/modelguide-voice-agent/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/examples/agents/modelguide-voice-agent/Dockerfile
+++ b/examples/agents/modelguide-voice-agent/Dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/agent.py", "start"]

--- a/examples/agents/modelguide-voice-agent/README.md
+++ b/examples/agents/modelguide-voice-agent/README.md
@@ -1,0 +1,125 @@
+# ModelGuide Voice Agent (POC)
+
+A minimal LiveKit voice agent that **pulls its system prompt from
+ModelGuide at the start of every call**. Talk to it from the dashboard:
+
+> Agents → *your agent* → **Compile** → **Voice Test** → Talk
+
+…and the next call uses the prompt you just compiled. No worker redeploy.
+
+This is the smaller, prompt-only sibling of
+[`livekit-agent`](../livekit-agent) (the BuildPro Sam demo with 11 MCP
+tools). Use this one when you want to iterate on prompts; use the other
+when you want to exercise tool calls.
+
+## How it works
+
+```
+                    ┌─────────────────┐
+                    │   Dashboard UI  │
+                    └────────┬────────┘
+        Click Compile        │        Click Voice Test
+                ▼            │            ▼
+     ┌──────────────────┐    │    ┌──────────────────┐
+     │ POST /agents/:id │    │    │  POST /agents/:id│
+     │     /compile     │────┼───▶│ /voice-test-token│
+     └──────────────────┘    │    └────────┬─────────┘
+                             │             │ dispatch
+                             │             ▼
+                             │    ┌────────────────────┐
+                             │    │  LiveKit dispatch  │
+                             │    │ + JWT for browser  │
+                             │    └────────┬───────────┘
+                             │             │
+                             │             ▼
+                             │    ┌──────────────────────┐
+                             └───▶│  this worker         │
+       GET /agents/me/runtime-cfg │  ↳ resolves prompt   │
+                                  │  ↳ AgentSession()    │
+                                  └──────────────────────┘
+```
+
+1. Operator clicks **Compile** — API stores the result on
+   `agents.compiled_instructions`.
+2. Operator clicks **Voice Test** — API mints a LiveKit token + dispatches
+   this worker into a fresh `voice-test-<nanoid>` room with metadata
+   carrying `{ agentId, agentName, session_id, … }`.
+3. Worker boot (this repo):
+   - `parse_dispatch_metadata` decodes the metadata JSON.
+   - `fetch_runtime_config` calls `GET /api/agents/me/runtime-config` with
+     the worker's API key and gets `{ id, slug, name, modality,
+     modelFamily, instructions, compiledAt }`.
+   - `resolve_instructions` picks the prompt with this precedence: compiled
+     prompt → `DEFAULT_INSTRUCTIONS` env override → built-in fallback.
+   - LiveKit `AgentSession` starts with the resolved instructions.
+4. Browser side (`VoiceTestPanel` in `modelguide-ui`) is unchanged — it
+   just joins the room and starts publishing mic.
+
+See [ADR-015](../../../docs/decisions/015-livekit-runtime-prompt-fetch.md)
+for the design rationale.
+
+## Quick start (local dev)
+
+Prereqs: `python3.11+`, [`uv`](https://docs.astral.sh/uv/), API keys for
+OpenAI / Deepgram / ElevenLabs, a running ModelGuide API.
+
+```bash
+# 1. Install deps
+uv venv .venv
+source .venv/bin/activate
+uv pip install -e ".[test]"
+
+# 2. Configure
+cp .env.example .env
+# Fill in MODELGUIDE_API_KEY (Agents → <agent> → Integration → "Generate API key")
+# and your provider keys.
+
+# 3. Console mode — no LiveKit server needed, text-only
+python src/agent.py console
+
+# OR: full WebRTC (needs LiveKit server running locally)
+python src/agent.py dev
+```
+
+Then from the dashboard: pick the same agent, click **Compile**, then
+**Voice Test**. Speak — you should hear the latest compiled prompt.
+
+## Tests
+
+```bash
+source .venv/bin/activate
+pytest -q
+```
+
+The tests are pure-Python and do not require LiveKit, OpenAI, or any
+network access. They cover:
+
+- `test_dispatch.py` — locks in the contract with the API's
+  `buildVoiceTestDispatchMetadata` (must include `agentId`).
+- `test_runtime_config.py` — runs the runtime-config fetch against a
+  mocked transport (`respx`).
+- `test_resolve_instructions.py` — pins the prompt-precedence rules so
+  the LLM doesn't silently switch sources.
+
+## Production deploy (LiveKit Cloud)
+
+```bash
+livekit-cli agent create  # picks up the Dockerfile and pyproject.toml
+```
+
+Set the same env vars as `.env.example` in your LiveKit Cloud dashboard.
+The worker registers with `agent_name = AGENT_NAME` (default
+`modelguide-voice-agent`) — make sure the corresponding ModelGuide
+agent's `metadata.livekit.agentName` matches.
+
+## What this POC intentionally does NOT do
+
+- **No tools.** This is the smallest possible "talk to a prompt" loop.
+  For tool-calling, see `examples/agents/livekit-agent` (BuildPro Sam).
+- **No SIP / phone number.** WebRTC only.
+- **No tracing / Langfuse / transcript posting.** Add these once the
+  prompt-fetch mechanism stabilizes.
+- **No auth-token rotation.** The worker uses a static API key, scoped
+  per-agent, generated from the dashboard. If you need multi-agent
+  routing in one worker process, see the alternatives section in
+  ADR-015.

--- a/examples/agents/modelguide-voice-agent/pyproject.toml
+++ b/examples/agents/modelguide-voice-agent/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "modelguide-voice-agent"
+version = "0.1.0"
+description = "Minimal LiveKit voice agent that pulls its compiled prompt from ModelGuide at job-start"
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/agents/modelguide-voice-agent/src/agent.py
+++ b/examples/agents/modelguide-voice-agent/src/agent.py
@@ -1,0 +1,113 @@
+"""LiveKit voice-agent entrypoint that pulls its system prompt from
+ModelGuide at job-start.
+
+Run modes:
+
+  python src/agent.py console     # text-only REPL (no WebRTC)
+  python src/agent.py dev         # full WebRTC, local LiveKit server
+  python src/agent.py start       # production worker
+
+The "compile prompt → click voice test → talk" loop in the dashboard
+relies on the worker fetching the *latest* compiled prompt every time a
+new room job arrives, so iteration time stays sub-second.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import deepgram, elevenlabs, openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+from agent_factory import resolve_instructions
+from dispatch import parse_dispatch_metadata
+from runtime_config import RuntimeConfig, RuntimeConfigError, fetch_runtime_config
+
+logging.basicConfig(
+    level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("agent")
+
+
+async def _load_runtime_config() -> RuntimeConfig | None:
+    """Fetch runtime config from ModelGuide. Logs and returns None on failure
+    so the worker can fall back to env defaults rather than crashing."""
+    try:
+        cfg = await fetch_runtime_config(
+            config.MODELGUIDE_API_URL, config.MODELGUIDE_API_KEY
+        )
+        logger.info(
+            "Runtime config loaded: agent=%s slug=%s compiled=%s",
+            cfg.id,
+            cfg.slug,
+            cfg.has_compiled_prompt,
+        )
+        return cfg
+    except RuntimeConfigError as exc:
+        logger.warning("Runtime config fetch failed (%s) — using env fallback", exc)
+        return None
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    config.validate()
+    logger.info("modelguide-voice-agent entrypoint — room=%s", ctx.room.name)
+
+    metadata = parse_dispatch_metadata(ctx.job.metadata)
+    if metadata:
+        logger.info(
+            "Dispatch metadata: mode=%s agentId=%s slug=%s",
+            metadata.mode,
+            metadata.agent_id,
+            metadata.agent_slug,
+        )
+
+    await ctx.connect()
+
+    runtime = await _load_runtime_config()
+    instructions = resolve_instructions(
+        runtime=runtime,
+        env_default=config.DEFAULT_INSTRUCTIONS or None,
+    )
+
+    participant = await ctx.wait_for_participant()
+    logger.info("Participant joined: %s", participant.identity)
+
+    agent = Agent(instructions=instructions)
+    session = AgentSession(
+        stt=deepgram.STT(
+            model="nova-3",
+            api_key=config.DEEPGRAM_API_KEY,
+            interim_results=True,
+            endpointing_ms=300,
+        ),
+        llm=openai.LLM(model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY),
+        tts=elevenlabs.TTS(
+            voice_id=config.ELEVENLABS_VOICE_ID,
+            model="eleven_flash_v2_5",
+            api_key=config.ELEVENLABS_API_KEY,
+        ),
+        vad=silero.VAD.load(),
+        turn_detection=EnglishModel(),
+        allow_interruptions=True,
+        min_interruption_duration=1.0,
+        min_endpointing_delay=0.5,
+    )
+
+    await session.start(agent=agent, room=ctx.room)
+
+    name = runtime.name if runtime else "there"
+    await session.say(
+        f"Hi {name} — I'm using the latest compiled prompt from ModelGuide. What can I do for you?"
+    )
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/modelguide-voice-agent/src/agent_factory.py
+++ b/examples/agents/modelguide-voice-agent/src/agent_factory.py
@@ -1,0 +1,37 @@
+"""Helpers for assembling the LiveKit ``Agent`` instance from a runtime config.
+
+Kept in a separate module from ``agent.py`` so it stays unit-testable
+without importing the full ``livekit.agents`` machinery.
+"""
+
+from __future__ import annotations
+
+from runtime_config import RuntimeConfig
+
+FALLBACK_INSTRUCTIONS = (
+    "You are a friendly voice assistant connected to ModelGuide. "
+    "The dashboard hasn't compiled a prompt for this agent yet, so keep "
+    "answers brief and let the caller know to compile a SOP first."
+)
+
+
+def resolve_instructions(
+    *,
+    runtime: RuntimeConfig | None,
+    env_default: str | None,
+) -> str:
+    """Pick the system prompt with a clear precedence order.
+
+    1. Compiled prompt from ModelGuide — the dashboard is the source of
+       truth.
+    2. ``DEFAULT_INSTRUCTIONS`` env var — a local-dev escape hatch.
+    3. Built-in ``FALLBACK_INSTRUCTIONS`` — so the worker always boots.
+    """
+    if runtime and runtime.has_compiled_prompt:
+        # has_compiled_prompt already filtered out empty/whitespace, so
+        # ``runtime.instructions`` is a non-trivial string here.
+        assert runtime.instructions is not None
+        return runtime.instructions
+    if env_default and env_default.strip():
+        return env_default
+    return FALLBACK_INSTRUCTIONS

--- a/examples/agents/modelguide-voice-agent/src/config.py
+++ b/examples/agents/modelguide-voice-agent/src/config.py
@@ -1,0 +1,86 @@
+"""Environment-variable loading.
+
+Mirrors the layout of ``examples/agents/livekit-agent/src/config.py`` but
+with a much smaller surface — this POC has no MCP tooling, no telephony,
+no Langfuse. Just enough to talk to the user.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Worker identity (read at import time — needed before validate())
+# ---------------------------------------------------------------------------
+
+# `agent_name` registered with the LiveKit worker. The ModelGuide dashboard
+# stores this on the agent's metadata.livekit.agentName so explicit dispatch
+# can route to the correct worker.
+AGENT_NAME: str = os.getenv("AGENT_NAME", "modelguide-voice-agent")
+
+# ---------------------------------------------------------------------------
+# Required vars — populated by validate()
+# ---------------------------------------------------------------------------
+
+REQUIRED_VARS = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+ELEVENLABS_VOICE_ID: str = "iP95p4xoKVk53GoZ742B"
+LLM_MODEL: str = "gpt-4.1-mini"
+
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+
+# Local-dev escape hatch — used when the dashboard hasn't compiled the
+# agent yet. Also handy for working offline.
+DEFAULT_INSTRUCTIONS: str = ""
+
+
+_validated = False
+
+
+def validate() -> None:
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    g = globals()
+    g.update(
+        {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+            "ELEVENLABS_API_KEY": os.environ["ELEVENLABS_API_KEY"],
+            "ELEVENLABS_VOICE_ID": os.getenv(
+                "ELEVENLABS_VOICE_ID", ELEVENLABS_VOICE_ID
+            ),
+            "LLM_MODEL": os.getenv("LLM_MODEL", LLM_MODEL),
+            "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+            "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+            "DEFAULT_INSTRUCTIONS": os.getenv("DEFAULT_INSTRUCTIONS", ""),
+        }
+    )
+
+    _validated = True

--- a/examples/agents/modelguide-voice-agent/src/dispatch.py
+++ b/examples/agents/modelguide-voice-agent/src/dispatch.py
@@ -1,0 +1,53 @@
+"""Parse the JSON metadata that ModelGuide attaches to each LiveKit dispatch.
+
+Contract is defined on the API side in
+``modelguide-api/src/features/agents/agents.service.ts:buildVoiceTestDispatchMetadata``
+— there's no shared schema, so we keep this file small and keep the test
+suite (``tests/test_dispatch.py``) honest.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger("dispatch")
+
+
+@dataclass(frozen=True)
+class DispatchMetadata:
+    agent_id: str | None
+    agent_slug: str | None
+    session_id: str | None
+    caller_email: str | None
+    mode: str | None
+
+
+def parse_dispatch_metadata(raw: str | None) -> DispatchMetadata | None:
+    """Decode dispatch metadata. Returns None for missing/invalid input.
+
+    Returning None (rather than raising) is deliberate — a malformed payload
+    shouldn't take down the worker; the caller can fall back to env-config
+    so a human can still join the room and triage.
+    """
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Invalid JSON in dispatch metadata: %s", raw[:120])
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("Dispatch metadata is not a JSON object: %r", type(data))
+        return None
+
+    return DispatchMetadata(
+        agent_id=data.get("agentId"),
+        agent_slug=data.get("agentName"),
+        session_id=data.get("session_id"),
+        caller_email=data.get("email") or data.get("user_identifier"),
+        mode=data.get("mode"),
+    )

--- a/examples/agents/modelguide-voice-agent/src/runtime_config.py
+++ b/examples/agents/modelguide-voice-agent/src/runtime_config.py
@@ -1,0 +1,74 @@
+"""Fetch the agent's runtime config (incl. compiled prompt) from ModelGuide.
+
+The endpoint is ``GET /api/agents/me/runtime-config``; it authenticates via
+the agent's API key (Bearer ``mgk_…``) and returns just enough for the
+worker to spin up an LLM session with the latest compiled instructions.
+
+See ADR-006 for why we fetch at job-start instead of stamping the prompt
+into the worker image at deploy time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger("runtime_config")
+
+
+class RuntimeConfigError(RuntimeError):
+    """Raised when ModelGuide returns a non-2xx status."""
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    id: str
+    slug: str
+    name: str
+    modality: str
+    model_family: str
+    instructions: str | None
+    compiled_at: str | None
+
+    @property
+    def has_compiled_prompt(self) -> bool:
+        return bool(self.instructions and self.instructions.strip())
+
+
+async def fetch_runtime_config(
+    base_url: str,
+    api_key: str,
+    *,
+    timeout: float = 5.0,
+) -> RuntimeConfig:
+    """GET /api/agents/me/runtime-config and parse the response."""
+    url = base_url.rstrip("/") + "/api/agents/me/runtime-config"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            raise RuntimeConfigError(
+                f"Network error fetching runtime config: {exc}"
+            ) from exc
+
+    if response.status_code != 200:
+        raise RuntimeConfigError(
+            f"Runtime config fetch failed: HTTP {response.status_code} {response.text[:200]}"
+        )
+
+    body = response.json()
+    return RuntimeConfig(
+        id=body["id"],
+        slug=body["slug"],
+        name=body["name"],
+        modality=body["modality"],
+        model_family=body["modelFamily"],
+        instructions=body.get("instructions"),
+        compiled_at=body.get("compiledAt"),
+    )

--- a/examples/agents/modelguide-voice-agent/tests/conftest.py
+++ b/examples/agents/modelguide-voice-agent/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest fixtures and path setup.
+
+We expose the `src/` directory on ``sys.path`` so tests can import the
+agent modules with their plain names (e.g. ``import dispatch``) — same
+convention used by ``examples/agents/livekit-agent/tests/conftest.py``.
+"""
+
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/examples/agents/modelguide-voice-agent/tests/test_dispatch.py
+++ b/examples/agents/modelguide-voice-agent/tests/test_dispatch.py
@@ -1,0 +1,56 @@
+"""Tests for dispatch-metadata parsing.
+
+The ModelGuide API includes ``agentId`` and ``agentName`` in the JSON
+metadata it attaches to each LiveKit dispatch (see
+``modelguide-api/src/features/agents/agents.service.ts:buildVoiceTestDispatchMetadata``).
+
+We treat that contract as load-bearing: if the worker can't pull
+``agentId`` out of the dispatch payload, every voice-test call ends up
+running against the wrong (or no) compiled prompt and the user thinks
+"Compile" did nothing. So lock it in here.
+"""
+
+import json
+
+import pytest
+
+from dispatch import parse_dispatch_metadata
+
+
+class TestParseDispatchMetadata:
+    def test_extracts_agent_id_and_slug(self):
+        raw = json.dumps(
+            {
+                "mode": "voice-test",
+                "agentId": "11111111-2222-3333-4444-555555555555",
+                "agentName": "glowbox-voice",
+                "session_id": "sess-abc",
+                "user_identifier": "tester@corp.com",
+                "email": "tester@corp.com",
+            }
+        )
+        md = parse_dispatch_metadata(raw)
+        assert md.agent_id == "11111111-2222-3333-4444-555555555555"
+        assert md.agent_slug == "glowbox-voice"
+        assert md.session_id == "sess-abc"
+        assert md.caller_email == "tester@corp.com"
+
+    def test_returns_none_for_empty_metadata(self):
+        # SIP / dev-room dispatches arrive without any metadata. The agent
+        # should fall back to env-config rather than crashing the worker.
+        assert parse_dispatch_metadata(None) is None
+        assert parse_dispatch_metadata("") is None
+
+    def test_returns_none_for_invalid_json(self):
+        # Invalid metadata isn't worth blowing up over — log and run with
+        # env-config defaults so a human can still reach the agent.
+        assert parse_dispatch_metadata("not-json") is None
+
+    def test_missing_agent_id_yields_partial_object(self):
+        # Older outbound dispatches don't carry agentId. The worker should
+        # still parse what's there and degrade to env-config for the prompt.
+        raw = json.dumps({"agentName": "old-style", "session_id": "s"})
+        md = parse_dispatch_metadata(raw)
+        assert md is not None
+        assert md.agent_id is None
+        assert md.agent_slug == "old-style"

--- a/examples/agents/modelguide-voice-agent/tests/test_resolve_instructions.py
+++ b/examples/agents/modelguide-voice-agent/tests/test_resolve_instructions.py
@@ -1,0 +1,71 @@
+"""Tests for ``resolve_instructions`` — the small precedence helper that
+chooses what system prompt to hand the LLM.
+
+Precedence (highest first):
+
+1. Compiled prompt fetched from ModelGuide (the whole point of this POC).
+2. ``DEFAULT_INSTRUCTIONS`` env override (escape hatch for local dev).
+3. Built-in fallback so the worker always has *something* to say even
+   when ModelGuide is unreachable on first boot.
+
+Locking this in as a unit test because the LiveKit AgentSession picks up
+``instructions`` exactly once at construction — there's no second chance
+to fix a wrong choice without disconnecting the caller.
+"""
+
+from runtime_config import RuntimeConfig
+from agent_factory import FALLBACK_INSTRUCTIONS, resolve_instructions
+
+
+def _cfg(instructions):
+    return RuntimeConfig(
+        id="a",
+        slug="s",
+        name="n",
+        modality="voice",
+        model_family="gpt",
+        instructions=instructions,
+        compiled_at=None,
+    )
+
+
+class TestResolveInstructions:
+    def test_uses_compiled_prompt_when_available(self):
+        result = resolve_instructions(
+            runtime=_cfg("Compiled prompt."),
+            env_default=None,
+        )
+        assert result == "Compiled prompt."
+
+    def test_compiled_prompt_wins_over_env_default(self):
+        # The dashboard is the source of truth; env defaults exist only so
+        # the worker can boot before the agent has ever been compiled.
+        result = resolve_instructions(
+            runtime=_cfg("Compiled."),
+            env_default="Env override.",
+        )
+        assert result == "Compiled."
+
+    def test_falls_back_to_env_default_when_uncompiled(self):
+        result = resolve_instructions(
+            runtime=_cfg(None),
+            env_default="Env override.",
+        )
+        assert result == "Env override."
+
+    def test_falls_back_to_builtin_when_no_runtime_and_no_env(self):
+        result = resolve_instructions(runtime=None, env_default=None)
+        assert result == FALLBACK_INSTRUCTIONS
+
+    def test_falls_back_to_builtin_when_runtime_uncompiled_and_no_env(self):
+        result = resolve_instructions(runtime=_cfg(None), env_default=None)
+        assert result == FALLBACK_INSTRUCTIONS
+
+    def test_treats_empty_compiled_prompt_as_uncompiled(self):
+        # A whitespace-only compiled prompt would tell the LLM nothing
+        # useful; treat it the same as None and fall through.
+        result = resolve_instructions(
+            runtime=_cfg("   \n  "),
+            env_default="Env override.",
+        )
+        assert result == "Env override."

--- a/examples/agents/modelguide-voice-agent/tests/test_runtime_config.py
+++ b/examples/agents/modelguide-voice-agent/tests/test_runtime_config.py
@@ -1,0 +1,134 @@
+"""Tests for the runtime-config HTTP client.
+
+The whole point of this agent is "click Compile in the dashboard, then click
+Voice Test, and the next call uses the freshly compiled prompt." That hinges
+on a single GET against ``/api/agents/me/runtime-config`` at job-start.
+
+These tests exercise that fetch in isolation with a mocked transport.
+"""
+
+import httpx
+import pytest
+import respx
+
+from runtime_config import (
+    RuntimeConfig,
+    RuntimeConfigError,
+    fetch_runtime_config,
+)
+
+
+@pytest.mark.asyncio
+class TestFetchRuntimeConfig:
+    async def test_returns_compiled_prompt(self):
+        with respx.mock(base_url="https://mg.example.com") as router:
+            router.get("/api/agents/me/runtime-config").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "agent-id",
+                        "slug": "glowbox-voice",
+                        "name": "GlowBox Voice",
+                        "modality": "voice",
+                        "modelFamily": "gpt",
+                        "instructions": "You are GlowBox.",
+                        "compiledAt": "2026-05-07T10:00:00.000Z",
+                    },
+                )
+            )
+            cfg = await fetch_runtime_config(
+                "https://mg.example.com",
+                "mgk_test123",
+            )
+        assert isinstance(cfg, RuntimeConfig)
+        assert cfg.id == "agent-id"
+        assert cfg.slug == "glowbox-voice"
+        assert cfg.instructions == "You are GlowBox."
+        assert cfg.has_compiled_prompt is True
+
+    async def test_handles_uncompiled_agent(self):
+        # Until the dashboard-side "Compile" button has been clicked at least
+        # once, instructions is null. The agent must NOT crash — it should
+        # surface this so the worker can pick a fallback prompt.
+        with respx.mock(base_url="https://mg.example.com") as router:
+            router.get("/api/agents/me/runtime-config").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "agent-id",
+                        "slug": "fresh",
+                        "name": "Fresh",
+                        "modality": "voice",
+                        "modelFamily": "generic",
+                        "instructions": None,
+                        "compiledAt": None,
+                    },
+                )
+            )
+            cfg = await fetch_runtime_config(
+                "https://mg.example.com", "mgk_test"
+            )
+        assert cfg.instructions is None
+        assert cfg.has_compiled_prompt is False
+
+    async def test_sends_bearer_authorization_header(self):
+        # The runtime-config endpoint requires API-key auth; using JWT or no
+        # auth would 401. Lock the header shape here so a refactor of the
+        # client can't silently drop it.
+        with respx.mock(base_url="https://mg.example.com") as router:
+            route = router.get("/api/agents/me/runtime-config").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "a",
+                        "slug": "s",
+                        "name": "n",
+                        "modality": "voice",
+                        "modelFamily": "gpt",
+                        "instructions": "x",
+                        "compiledAt": None,
+                    },
+                )
+            )
+            await fetch_runtime_config(
+                "https://mg.example.com",
+                "mgk_my_secret_key",
+            )
+        assert route.called
+        sent = route.calls.last.request
+        assert sent.headers["authorization"] == "Bearer mgk_my_secret_key"
+
+    async def test_strips_trailing_slash_from_base_url(self):
+        with respx.mock(base_url="https://mg.example.com") as router:
+            route = router.get("/api/agents/me/runtime-config").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "a",
+                        "slug": "s",
+                        "name": "n",
+                        "modality": "voice",
+                        "modelFamily": "gpt",
+                        "instructions": "x",
+                        "compiledAt": None,
+                    },
+                )
+            )
+            # Trailing slash variant — should normalize to the same URL.
+            await fetch_runtime_config(
+                "https://mg.example.com/",
+                "mgk_t",
+            )
+        assert route.called
+
+    async def test_raises_on_unauthorized(self):
+        with respx.mock(base_url="https://mg.example.com") as router:
+            router.get("/api/agents/me/runtime-config").mock(
+                return_value=httpx.Response(
+                    401, json={"error": "unauthorized"}
+                )
+            )
+            with pytest.raises(RuntimeConfigError):
+                await fetch_runtime_config(
+                    "https://mg.example.com", "mgk_bad"
+                )

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRuntimeConfig,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -392,6 +395,60 @@ router.openapi(createAgentRoute, async (c) => {
 // ============================================================================
 // Platform Models Endpoint
 // ============================================================================
+
+// ============================================================================
+// GET /me/runtime-config — agent worker bootstrap
+// ============================================================================
+//
+// Voice/chat workers (e.g. examples/agents/modelguide-voice-agent) call this
+// at job-start with their own API key to fetch the *latest* compiled prompt.
+// This is what closes the "Compile → Voice Test" loop without redeploying
+// the worker. See ADR-006.
+//
+// The route MUST stay above any `/:id` route — Hono matches in registration
+// order, and `/me` would otherwise be parsed as `id="me"` and 404 there.
+
+router.get("/me/runtime-config", requireAgent(), requireOrganization());
+
+const agentRuntimeConfigSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string(),
+  name: z.string(),
+  modality: z.enum(["voice", "text"]),
+  modelFamily: modelFamilySchema,
+  instructions: z.string().nullable().openapi({
+    description:
+      "Latest compiled system prompt. Null until the agent has been compiled at least once.",
+  }),
+  compiledAt: z.string().nullable(),
+});
+
+const agentRuntimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me/runtime-config",
+  tags: ["Agents"],
+  summary: "Fetch runtime config for the calling agent",
+  description:
+    "Returns the agent's identity + latest compiled prompt. Authenticates via the agent's API key (mgk_…). Designed for voice/chat workers to pull the freshest instructions at job-start without a redeploy.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Runtime config",
+      content: {
+        "application/json": { schema: agentRuntimeConfigSchema },
+      },
+    },
+    401: errorResponse("Not authenticated as an agent (API key required)"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(agentRuntimeConfigRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const config = await getAgentRuntimeConfig(orgId, agent.id);
+  return c.json(config, 200);
+});
 
 // GET /platform-models
 router.get(

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -108,6 +108,49 @@ export async function listAgents(
   });
 }
 
+/**
+ * Runtime-config: minimal shape that voice/chat workers need at job-start.
+ *
+ * Stays narrow on purpose — exposed under API-key auth so we don't want
+ * platform-config noise (secrets map, integration URLs, eval counters)
+ * leaking out. The worker only needs identity + the latest compiled prompt
+ * so a hot "Compile → Voice Test" loop reflects the freshest instructions.
+ *
+ * See ADR-006 (`docs/decisions/006-livekit-runtime-prompt-fetch.md`) for
+ * the design rationale and the alternatives we rejected (env-stamping the
+ * prompt at deploy time, pushing the prompt over dispatch metadata, etc.).
+ */
+export async function getAgentRuntimeConfig(orgId: string, agentId: string) {
+  return forOrg(orgId, async (tx) => {
+    const [agent] = await tx
+      .select({
+        id: agents.id,
+        slug: agents.slug,
+        name: agents.name,
+        modality: agents.modality,
+        modelFamily: agents.modelFamily,
+        compiledInstructions: agents.compiledInstructions,
+        compiledAt: agents.compiledAt,
+      })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+
+    if (!agent) {
+      throw Errors.agentNotFound(agentId);
+    }
+
+    return {
+      id: agent.id,
+      slug: agent.slug,
+      name: agent.name,
+      modality: agent.modality,
+      modelFamily: agent.modelFamily,
+      instructions: agent.compiledInstructions ?? null,
+      compiledAt: agent.compiledAt?.toISOString() ?? null,
+    };
+  });
+}
+
 export async function getAgentById(orgId: string, agentId: string) {
   return forOrg(orgId, async (tx) => {
     const [agent] = await tx
@@ -901,11 +944,13 @@ export function buildOutboundDispatchMetadata(input: {
  * the right profile and every dispatched call goes silent.
  */
 export function buildVoiceTestDispatchMetadata(input: {
+  agentId: string;
   agentSlug: string;
   sessionId: string;
   callerEmail: string;
 }): {
   mode: "voice-test";
+  agentId: string;
   agentName: string;
   session_id: string;
   user_identifier: string;
@@ -913,6 +958,7 @@ export function buildVoiceTestDispatchMetadata(input: {
 } {
   return {
     mode: "voice-test" as const,
+    agentId: input.agentId,
     agentName: input.agentSlug,
     session_id: input.sessionId,
     user_identifier: input.callerEmail,
@@ -993,6 +1039,7 @@ export async function createVoiceTestSession(
   });
 
   const dispatchMetadata = buildVoiceTestDispatchMetadata({
+    agentId: agent.id,
     agentSlug: agent.slug,
     sessionId: session.id,
     callerEmail: caller.email,

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,7 +8,12 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
@@ -1008,6 +1013,94 @@ describe("POST /api/agents/:id/voice-test-token", () => {
     );
 
     expect(response.status).toBe(403);
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me/runtime-config — agent worker bootstrap
+// ============================================================================
+//
+// Voice / chat workers (e.g. the LiveKit agent in
+// examples/agents/modelguide-voice-agent) call this endpoint at job-start to
+// pull the *current* compiled prompt and model — that's what makes the
+// "click Compile → click Voice Test → talk" loop reflect the latest prompt
+// without redeploying the worker.
+//
+// Auth: agent API key (Bearer mgk_...). The bound agent is read from the
+// auth context, so there's no path param — that's why the endpoint is `me`.
+describe("GET /api/agents/me/runtime-config", () => {
+  test("returns compiled prompt + identity for the bound agent (200)", async () => {
+    // Activate the seeded agent and stamp a compiled prompt so the response
+    // is meaningful.
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          compiledInstructions: "You are GlowBox concierge. Be helpful.",
+          compiledAt: new Date(),
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.slug).toBeString();
+    expect(body.name).toBeString();
+    expect(body.modality).toBe("voice");
+    expect(body.modelFamily).toBeString();
+    expect(body.instructions).toBe("You are GlowBox concierge. Be helpful.");
+    expect(body.compiledAt).toBeString();
+  });
+
+  test("returns null instructions when agent has not been compiled yet (200)", async () => {
+    // Create a fresh, never-compiled agent for this test so we don't trample
+    // the seeded one's compiled prompt for other tests in the file.
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ name: "Uncompiled Runtime Config Agent" }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    await forApp((tx) =>
+      tx.update(agents).set({ isActive: true }).where(eq(agents.id, agentId)),
+    );
+
+    const headers = await agentHeadersFor(agentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe(agentId);
+    expect(body.instructions).toBeNull();
+    expect(body.compiledAt).toBeNull();
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me/runtime-config");
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects user (JWT) auth — endpoint is for agent workers only (401)", async () => {
+    // Workers MUST authenticate with their own API key, not a logged-in
+    // user JWT. This guards against a UI dev wiring the dashboard to this
+    // endpoint and accidentally leaking compiled prompts.
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAdminHeaders,
+    });
+    expect(response.status).toBe(401);
   });
 });
 

--- a/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
@@ -18,6 +18,7 @@ import { buildVoiceTestDispatchMetadata } from "../../../src/features/agents/age
 describe("buildVoiceTestDispatchMetadata", () => {
   test("carries agentName = agent.slug for multi-profile routing", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: "banknowa_v1",
       sessionId: "sess-abc",
       callerEmail: "admin@example.com",
@@ -28,6 +29,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
 
   test("mode is a literal 'voice-test' marker", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: "x",
       sessionId: "s",
       callerEmail: "c@e.com",
@@ -37,6 +39,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
 
   test("session_id + user_identifier + email carry caller context", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: "tenant_a",
       sessionId: "sess-xyz",
       callerEmail: "tester@corp.com",
@@ -46,14 +49,36 @@ describe("buildVoiceTestDispatchMetadata", () => {
     expect(md.email).toBe("tester@corp.com");
   });
 
-  test("shape is stable — exactly these 5 keys, nothing else", () => {
+  test("agentId is forwarded so the worker can fetch runtime-config", () => {
+    // The runtime-prompt-fetch flow (ADR-006) lets the worker pull the
+    // freshest compiledInstructions for the agent it's been routed to.
+    // It needs both the slug (for profile selection) and the UUID (for
+    // unambiguous lookup against /api/agents/{id} / /me/runtime-config).
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-2222-3333-4444-555555555555",
+      agentSlug: "banknowa_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect(md.agentId).toBe("11111111-2222-3333-4444-555555555555");
+  });
+
+  test("shape is stable — exactly these 6 keys, nothing else", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: "x",
       sessionId: "s",
       callerEmail: "c@e.com",
     });
     expect(Object.keys(md).sort()).toEqual(
-      ["agentName", "email", "mode", "session_id", "user_identifier"].sort(),
+      [
+        "agentId",
+        "agentName",
+        "email",
+        "mode",
+        "session_id",
+        "user_identifier",
+      ].sort(),
     );
   });
 
@@ -63,6 +88,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
     // equality, so any transform silently breaks routing.
     const weird = "Weird_Slug-v1";
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: weird,
       sessionId: "s",
       callerEmail: "c@e.com",
@@ -74,6 +100,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
     // The dispatch layer JSON-stringifies this payload. Confirm nothing is
     // a Symbol, function, or other unserializable value.
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "00000000-0000-0000-0000-000000000001",
       agentSlug: "banknowa_v2",
       sessionId: "s",
       callerEmail: "c@e.com",


### PR DESCRIPTION
## Summary

Closes the **Compile → Voice Test → Talk** loop for LiveKit agents. Today, clicking "Compile" then "Voice Test" mechanically works — but the call runs against whatever prompt the worker was packaged with, so prompt edits don't surface until the next worker redeploy. This PR makes the worker fetch `agents.compiled_instructions` at every job-start, matching the iteration speed admins already get on ElevenLabs sync.

## Demo flow

1. Pick a LiveKit agent in the dashboard.
2. Click **Compile** (existing flow — writes `compiled_instructions`).
3. Click **Voice Test** (existing flow — mints LK token, dispatches worker).
4. Worker (this PR) calls `GET /api/agents/me/runtime-config`, takes the freshly-compiled prompt, and starts the `AgentSession` with it.
5. Talk — the agent reflects the just-compiled prompt within ~2 s of the click.

```
                    ┌─────────────────┐
                    │   Dashboard UI  │
                    └────────┬────────┘
        Click Compile        │        Click Voice Test
                ▼            │            ▼
     ┌──────────────────┐    │    ┌──────────────────┐
     │ POST /agents/:id │    │    │  POST /agents/:id│
     │     /compile     │────┼───▶│ /voice-test-token│
     └──────────────────┘    │    └────────┬─────────┘
                             │             │ dispatch
                             │             ▼
                             │    ┌──────────────────────┐
                             └───▶│  this worker         │
       GET /agents/me/runtime-cfg │  ↳ resolves prompt   │
                                  │  ↳ AgentSession()    │
                                  └──────────────────────┘
```

## What's in the PR

**API**
- New `GET /api/agents/me/runtime-config` (API-key auth) — returns `{ id, slug, name, modality, modelFamily, instructions, compiledAt }`. Bound agent comes from auth context, so a leaked worker key can't pull a different agent's prompt.
- `buildVoiceTestDispatchMetadata` now also forwards `agentId` (6 keys, was 5).

**Worker — new example `examples/agents/modelguide-voice-agent/`**
- Minimal LiveKit agent (no MCP tools, no SIP, no tracing) focused on the prompt-fetch loop. Sibling to the BuildPro Sam example, not a replacement.
- Prompt precedence: compiled prompt → `DEFAULT_INSTRUCTIONS` env → built-in fallback. Worker boots even when ModelGuide is unreachable.

**Tests (TDD red→green)**
- `tests/unit/agents/voice-test-dispatch.test.ts` — locks the 6-key dispatch shape including `agentId`.
- `tests/integration/agents.test.ts` — covers success, uncompiled-agent, unauth, and JWT-rejection paths.
- `examples/agents/modelguide-voice-agent/tests/` — 15 Python unit tests covering dispatch parsing, runtime-config HTTP fetch (mocked with `respx`), and prompt-precedence resolution.

**Docs**
- `docs/decisions/015-livekit-runtime-prompt-fetch.md` — design + alternatives we rejected (env-stamp, dispatch-metadata injection, MCP resource, push-on-compile).
- `examples/agents/modelguide-voice-agent/README.md` — diagrams + quick-start.

## Test plan

- [x] `bun test --preload ./tests/setup/unit-preload.ts tests/unit/agents/` → 19 pass
- [x] `bun run typecheck` → clean
- [x] `bun run lint:check` → clean
- [x] `pytest -q` in the new example → 15 pass
- [ ] `bun test:integration tests/integration/agents.test.ts` (CI) — local Postgres not available in this environment
- [ ] End-to-end manual: configure LiveKit on a voice agent, generate API key, run worker, click Compile → Voice Test → talk
- [ ] Smoke-test: edit a SOP, recompile, click Voice Test again, confirm new behavior surfaces in the next call without redeploying the worker

## Out of scope (called out in ADR-015)

- Multi-agent worker (one process serving many agents) — POC is one-key-one-agent.
- Pushing prompt updates into a live call.
- Including tool definitions in runtime-config.
- Versioning / pinning a compile across a long-running session.

https://claude.ai/code/session_01Sex51miEwL2XPMJk5P9tuy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sex51miEwL2XPMJk5P9tuy)_