### PR TITLE
feat(agents): inject compiled prompt into LiveKit voice-test dispatch

### DIFF
--- a/docs/decisions/015-livekit-compiled-prompt-override.md
+++ b/docs/decisions/015-livekit-compiled-prompt-override.md
@@ -1,0 +1,90 @@
+# ADR-015: Compiled-Prompt Override for LiveKit Voice Testing
+
+**Status:** Accepted — POC (supersedes ADR-014 §"What this deliberately does NOT do")
+
+## Context
+
+ADR-014 established the browser voice-test flow: click "Talk to agent", the API mints a short-lived token and dispatches the configured LiveKit worker into a fresh room, the browser joins via WebRTC. The worker uses whatever system prompt is baked into its profile module (`prompts/base.py` in `examples/agents/livekit-agent`).
+
+That was good enough when ModelGuide was a thin shim around an externally-developed worker. It is **not** good enough as the dashboard becomes the source of truth for agent configuration:
+
+1. The dashboard exposes a "Prompt" section (`prompt-section.tsx`) where operators edit `promptConfig` (persona, language, filler phrases).
+2. The "Compile" button (`compile-dialog.tsx`) runs the compiler pipeline (SOPs + guardrails + promptConfig → `compiledInstructions`) and persists the result on the agent row.
+3. Until this ADR, that `compiledInstructions` field was **dead data** in the voice-test loop. The worker never read it. Operators had to redeploy a profile to test their edit, which kills the iteration loop the dashboard exists to enable.
+
+ADR-014 explicitly rejected prompt injection. The original rejection rested on three premises that no longer hold:
+
+| Premise (ADR-014) | What changed |
+|---|---|
+| "The worker's profile is the authoritative source of prompt + tools." | No longer true for the platform path. The MG agent record (with `promptConfig` + `compiledInstructions`) is the source of truth; the worker's baked profile is a fallback for raw/local development. |
+| "Creates a 'works in voice-test but broke in prod' failure mode." | Only true if production uses a different prompt than voice-test. With this ADR, the **same** `compiledInstructions` is used by voice-test and (once redeployed) by production. The override is the rehearsal, not a divergence. |
+| "Build a new profile on the worker to test a new prompt." | Acceptable for first-party demo work, hostile to platform users who never touch worker code. |
+
+## Decision
+
+When dispatching a voice-test session, include the agent's current `compiledInstructions` in the dispatch metadata under the key `instructions`. The worker checks for that field at startup and, when present, uses it instead of its baked profile prompt for the duration of the call.
+
+### Dispatch contract (extends ADR-014)
+
+```jsonc
+// POST /agents/:id/voice-test-token → LiveKit AgentDispatchClient metadata
+{
+  "mode": "voice-test",
+  "agentName": "<agent.slug>",          // worker-profile routing (ADR-014)
+  "session_id": "<session.id>",
+  "user_identifier": "<caller.email>",
+  "email": "<caller.email>",
+  "instructions": "<compiled prompt>"   // NEW — optional, omitted when:
+                                         //   - agent.compiledInstructions is null
+                                         //   - the string is empty/whitespace
+                                         //   - the UTF-8 byte length exceeds
+                                         //     VOICE_TEST_INSTRUCTIONS_MAX_BYTES (32 KB)
+}
+```
+
+The contract is locked behind `tests/unit/agents/voice-test-dispatch.test.ts` on the API side and `tests/test_instructions_override.py` on the worker side. The two sides must agree on what counts as "no override" — a whitespace-only string falls back to the baked prompt on both sides.
+
+### Why a size guard
+
+LiveKit's dispatch metadata is JSON-stringified and shipped over the control channel. There's no published hard limit, but practical payloads should stay well under ~32 KB to avoid risking dispatch fragmentation. A typical compiled prompt is 3-8 KB; 32 KB is comfortable headroom. When the guard trips, the API logs a structured warning (`"voice-test: compiled prompt dropped from dispatch metadata (size guard)"`) and the worker falls back to its baked prompt — operator hears the **previous** prompt rather than no audio at all.
+
+The guard sizes by UTF-8 byte length, not JS character count: a single emoji is 1-2 chars in JS but 4 bytes on the wire. A naive `.length` check would let a 64KB-on-the-wire payload sail through.
+
+### Worker side
+
+`MCPAgent.__init__` gains an optional `instructions_override: str | None` parameter. The base class wires it through a pure helper, `resolve_instructions(default, override) → str`, that mirrors the API's "no override" rules. The override path logs a single info-level breadcrumb ("Using compiled-prompt override from dispatch metadata (N chars, baked default ignored)") so operators triaging "did my edit go through?" can grep the worker log.
+
+The entrypoint (`agent.py`) extracts the field via another pure helper, `extract_instructions_override(metadata) → str | None`, that defends against missing keys, wrong types, and non-dict metadata. Same shape as the API guard so the two sides agree on what to do with garbage input.
+
+### UI surface
+
+`VoiceTestPanel` gains a `CompiledPromptIndicator` line that shows either:
+- "Will use prompt compiled <timestamp>" (when `compiledInstructions` is set), or
+- "No compiled prompt — worker will use its baked-in profile" (when null).
+
+This closes the feedback loop. Operators see exactly which compile cycle they're about to test before they click Talk.
+
+## Alternatives Considered
+
+**Add a `POST /agents/:id/voice-test-token?override=true` query flag** to opt into prompt injection.  Rejected — the dashboard is the source of truth; the override should be the default, not an opt-in. A flag would invite "I always forget to set the flag and wonder why my edit doesn't show up" friction.
+
+**Ship the override via a server-sent event or websocket** after the agent joins the room.  Rejected — dispatch metadata is already JSON-serialized and atomic with the join. Adding a second channel doubles the failure surface (what happens if the SSE drops before the prompt arrives?) for no benefit.
+
+**Store the override in a Redis cache and pass an ID via metadata.**  Rejected — adds an infrastructure dependency and a race window between dispatch and the agent's fetch. A 32 KB inline payload is well within what LiveKit dispatch is designed for.
+
+**Reject overrides above the size guard with a 400 from the API** instead of silently dropping.  Rejected — the operator would lose the ability to voice-test at all when their prompt is oversized. The dashboard already shows the compiled prompt size in `CompileSummaryBar`; a structured log warning is sufficient for the rare case where the guard trips. If oversized prompts become common, revisit by streaming the prompt over a side channel rather than blocking the user.
+
+## Consequences
+
+- The dashboard "Compile → Talk to agent" cycle now does what the labels suggest. Iteration time drops from a redeploy (minutes) to a click (seconds).
+- The 32 KB size guard is now load-bearing. If a future compiler emits prompts that routinely cross 32 KB, the silent-fallback behavior will be confusing ("my prompt is huge and I'm hearing an old version"). Mitigation: surface dropped-override warnings in the UI (future hardening; out of POC scope).
+- The worker still works fine without the override — `instructions_override=None` falls back to the baked prompt. Local development with `make lk-agent-dev` is unaffected: there's no MG dispatch in that path, so no metadata, so no override.
+- This ADR supersedes ADR-014's "no prompt injection" stance. The contract still lives in the same dispatch-metadata schema and the same pure-function unit tests — adding a field is a controlled extension, not a redesign.
+- ElevenLabs and other future platforms are unaffected: the override lives in LiveKit dispatch metadata, which has no analog on the ElevenLabs side. When/if we add the equivalent for ElevenLabs, it'll come with its own ADR.
+
+## Rollback
+
+To revert to the ADR-014 behavior:
+1. Drop the `instructions` field from `buildVoiceTestDispatchMetadata` (API).
+2. Drop the `instructions_override` parameter from `MCPAgent.__init__` (worker).
+3. Both sides' unit tests will fail loudly — the contract regression is caught by CI.

--- a/examples/agents/livekit-agent/README.md
+++ b/examples/agents/livekit-agent/README.md
@@ -114,6 +114,40 @@ docker logs -f livekit-agent-livekit-server-1
 | `make livekit-down` | Stop Docker LiveKit server |
 | `make livekit-token` | Generate token + open meet.livekit.io |
 
+## Prompt Override from the Dashboard (ADR-015)
+
+The dashboard's "Compile → Talk to agent" cycle is the fast feedback loop the platform exists to enable. To make it actually fast, the API ships the agent's currently-compiled prompt to this worker via dispatch metadata, and the worker uses it instead of its baked profile prompt for that one call.
+
+**What you need to know:**
+
+- When the MG voice-test endpoint dispatches this worker, the metadata blob may include an `instructions` field carrying the compiled system prompt. The base class `MCPAgent` checks for it and overrides the baked default if present (see `resolve_instructions` in `mcp_agent.py`).
+- Empty / whitespace / oversized prompts are silently ignored and the baked profile prompt is used — the override is opportunistic, not required.
+- Local dev (`make lk-agent-dev` + `make livekit-token`) does not go through MG dispatch, so no override happens. You're hearing the baked profile prompt, the same as before this change.
+- The worker logs a single line when the override fires: `"Using compiled-prompt override from dispatch metadata (N chars, baked default ignored)"`. Grep for that to confirm a dashboard test cycle made it through.
+
+**End-to-end flow:**
+
+```
+Dashboard (modelguide-ui)
+  │
+  ├── operator edits Configuration tab
+  ├── operator clicks "Compile" → POST /agents/:id/compile
+  │     └── compiledInstructions persisted on agent row
+  │
+  └── operator clicks "Talk to agent"
+        └── POST /agents/:id/voice-test-token
+              ├── buildVoiceTestDispatchMetadata({ instructions: agent.compiledInstructions, … })
+              └── AgentDispatchClient.createDispatch(roomName, agentName, metadata)
+                    │
+                    ▼
+            this worker entrypoint
+              ├── extract_instructions_override(dispatch_metadata)
+              └── BuildProAgent(…, instructions_override=…)
+                    └── MCPAgent picks override over baked default
+```
+
+The 32 KB size guard lives on the API side. The worker just trusts what it gets.
+
 ## Phone Calls (SIP)
 
 The agent supports phone calls via SIP in addition to browser WebRTC. See [`sip/README.md`](./sip/README.md) for setup and [`DEPLOY.md`](./DEPLOY.md) for deployment.

--- a/examples/agents/livekit-agent/src/agent.py
+++ b/examples/agents/livekit-agent/src/agent.py
@@ -34,6 +34,29 @@ logger = logging.getLogger("agent")
 
 
 # ---------------------------------------------------------------------------
+# Dispatch metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_instructions_override(metadata: object) -> str | None:
+    """Pull a compiled-prompt override out of dispatch metadata.
+
+    The ModelGuide API may include an ``instructions`` field in the
+    voice-test dispatch metadata so this worker uses the latest compiled
+    prompt instead of its baked profile (see ADR-015). We accept the
+    field defensively: missing/wrong-typed/whitespace-only inputs all
+    return ``None`` so the worker falls back to the baked prompt rather
+    than crashing the call.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    val = metadata.get("instructions")
+    if not isinstance(val, str) or not val.strip():
+        return None
+    return val
+
+
+# ---------------------------------------------------------------------------
 # SIP detection
 # ---------------------------------------------------------------------------
 
@@ -158,7 +181,13 @@ async def entrypoint(ctx: agents.JobContext):
     logger.info("ModelGuide session: %s (user: %s)", session_id, user_identifier)
 
     # Build agent + session
-    agent = BuildProAgent(session_id=session_id, user_email=user_identifier, mcp=mcp)
+    instructions_override = extract_instructions_override(dispatch_metadata)
+    agent = BuildProAgent(
+        session_id=session_id,
+        user_email=user_identifier,
+        mcp=mcp,
+        instructions_override=instructions_override,
+    )
     stt = create_stt()
     tts = create_tts()
 

--- a/examples/agents/livekit-agent/src/buildpro.py
+++ b/examples/agents/livekit-agent/src/buildpro.py
@@ -36,14 +36,24 @@ class BuildProAgent(MCPAgent):
     ]
 
     def __init__(
-        self, *, session_id: str | None, user_email: str, mcp: mg_client.MCPConnection | None = None
+        self,
+        *,
+        session_id: str | None,
+        user_email: str,
+        mcp: mg_client.MCPConnection | None = None,
+        instructions_override: str | None = None,
     ) -> None:
         self._active_cart_id: str | None = None
         self._cart_ready = asyncio.Event()
         self._reorder_product_ids: list[str] = []
 
         instructions = build_system_prompt(session_id or "", user_email=user_email)
-        super().__init__(session_id=session_id, mcp=mcp, instructions=instructions)
+        super().__init__(
+            session_id=session_id,
+            mcp=mcp,
+            instructions=instructions,
+            instructions_override=instructions_override,
+        )
 
     # ------------------------------------------------------------------
     # 11 @function_tool methods (camelCase params to match MCP)

--- a/examples/agents/livekit-agent/src/mcp_agent.py
+++ b/examples/agents/livekit-agent/src/mcp_agent.py
@@ -39,6 +39,21 @@ def _get_stubbed_tools() -> set[str]:
     return {t.strip() for t in raw.split(",") if t.strip()}
 
 
+def resolve_instructions(default: str, override: str | None) -> str:
+    """Pick the effective system prompt for the agent.
+
+    Returns ``override`` verbatim when it's a non-empty, non-whitespace
+    string. Otherwise falls back to the baked profile prompt
+    (``default``). Mirrors the API-side guard in
+    ``buildVoiceTestDispatchMetadata`` so the two sides agree on what
+    counts as "no override" — a whitespace-only override must NOT replace
+    the baked prompt with whitespace.
+    """
+    if isinstance(override, str) and override.strip():
+        return override
+    return default
+
+
 class MCPAgent(Agent):
     """Voice agent base class with MCP tool execution, tracing, and transcripts.
 
@@ -58,12 +73,20 @@ class MCPAgent(Agent):
         session_id: str | None,
         mcp: mg_client.MCPConnection | None = None,
         instructions: str,
+        instructions_override: str | None = None,
     ) -> None:
         self._session_id = session_id
         self._transcript = TranscriptCollector()
         self._mcp = mcp
         self._tool_map = {name: f"{config.CONNECTOR_PREFIX}_{name}" for name in self.TOOL_NAMES}
-        super().__init__(instructions=instructions)
+        effective = resolve_instructions(instructions, instructions_override)
+        if effective is not instructions:
+            logger.info(
+                "Using compiled-prompt override from dispatch metadata "
+                "(%d chars, baked default ignored)",
+                len(effective),
+            )
+        super().__init__(instructions=effective)
 
     # ------------------------------------------------------------------
     # MCP execution core

--- a/examples/agents/livekit-agent/tests/test_instructions_override.py
+++ b/examples/agents/livekit-agent/tests/test_instructions_override.py
@@ -1,0 +1,121 @@
+"""Tests for the compiled-prompt override flow.
+
+The worker normally uses the system prompt baked into its profile module
+(see ``prompts/base.py``). When MG ships a freshly-compiled prompt in
+dispatch metadata, the worker overrides the baked prompt for the
+duration of that call so the user can test the *latest* prompt without
+redeploying. See ADR-015 and ``buildVoiceTestDispatchMetadata`` on the
+API side.
+
+These tests pin the two pure helpers that make the override safe:
+
+  * ``extract_instructions_override(metadata)`` — pulls the field out
+    of the dispatch-metadata dict (and rejects garbage shapes)
+  * ``resolve_instructions(default, override)`` — picks which prompt
+    wins, falling back to the baked default when the override is empty
+
+The agent.py / mcp_agent.py wiring layers on top of these. If either
+helper drifts, every call either silently keeps the old prompt or
+explodes on construction — both far worse than a unit test failure.
+"""
+
+from __future__ import annotations
+
+from agent import extract_instructions_override
+from mcp_agent import resolve_instructions
+
+
+# ---------------------------------------------------------------------------
+# resolve_instructions — picks the effective system prompt
+# ---------------------------------------------------------------------------
+
+
+class TestResolveInstructions:
+    def test_override_wins_when_non_empty(self):
+        assert (
+            resolve_instructions("baked", "from-metadata") == "from-metadata"
+        )
+
+    def test_falls_back_when_override_is_none(self):
+        assert resolve_instructions("baked", None) == "baked"
+
+    def test_falls_back_when_override_is_empty_string(self):
+        assert resolve_instructions("baked", "") == "baked"
+
+    def test_falls_back_when_override_is_whitespace(self):
+        # A whitespace-only override would silently nuke the agent's
+        # persona — keep the baked prompt instead.
+        assert resolve_instructions("baked", "   \n\t  ") == "baked"
+
+    def test_preserves_internal_whitespace_in_override(self):
+        # We trim for the "is this real content?" check but the prompt
+        # itself must be returned verbatim so newlines/code-fences survive.
+        override = "You are Sam.\n\n  Greet the user."
+        assert resolve_instructions("baked", override) == override
+
+    def test_override_can_be_much_longer_than_default(self):
+        # No length cap on the worker side — the API already enforced
+        # the 32KB ceiling before putting it on the wire.
+        override = "x" * 30_000
+        assert resolve_instructions("baked", override) == override
+
+
+# ---------------------------------------------------------------------------
+# extract_instructions_override — pulls the field out of dispatch metadata
+# ---------------------------------------------------------------------------
+
+
+class TestExtractInstructionsOverride:
+    def test_returns_string_when_present(self):
+        md = {"mode": "voice-test", "instructions": "You are Sam."}
+        assert extract_instructions_override(md) == "You are Sam."
+
+    def test_returns_none_when_key_missing(self):
+        md = {"mode": "voice-test", "agentName": "buildpro_v1"}
+        assert extract_instructions_override(md) is None
+
+    def test_returns_none_when_metadata_is_empty(self):
+        assert extract_instructions_override({}) is None
+
+    def test_returns_none_when_metadata_is_not_a_dict(self):
+        # Dispatch metadata sometimes arrives as ``None`` (job has no
+        # metadata) or — paranoid — as a list if a broken sender ever
+        # PUT-s the wrong shape. Don't crash the entrypoint over it.
+        assert extract_instructions_override(None) is None  # type: ignore[arg-type]
+        assert extract_instructions_override([]) is None  # type: ignore[arg-type]
+        assert extract_instructions_override("not-a-dict") is None  # type: ignore[arg-type]
+
+    def test_returns_none_when_value_is_not_a_string(self):
+        # A misconfigured sender that puts an object or number under
+        # "instructions" must not crash the worker — fall back to the
+        # baked prompt.
+        assert extract_instructions_override({"instructions": 42}) is None
+        assert extract_instructions_override({"instructions": ["a"]}) is None
+        assert extract_instructions_override({"instructions": None}) is None
+
+    def test_returns_none_when_value_is_empty_or_whitespace(self):
+        # Matches the API-side guard so the two sides agree on "no
+        # override" (otherwise a whitespace override would replace the
+        # baked prompt with literal whitespace).
+        assert extract_instructions_override({"instructions": ""}) is None
+        assert (
+            extract_instructions_override({"instructions": "   \n\t  "}) is None
+        )
+
+    def test_preserves_internal_whitespace(self):
+        # We strip for the emptiness check but the returned value keeps
+        # its newlines/spacing so the prompt formatting survives.
+        prompt = "Line 1.\n\nLine 3 with    spaces."
+        assert extract_instructions_override({"instructions": prompt}) == prompt
+
+    def test_returns_none_for_whitespace_padded_input(self):
+        # Surrounding whitespace alone (no real content after strip) is
+        # treated as empty.
+        assert extract_instructions_override({"instructions": "\n  "}) is None
+
+    def test_keeps_leading_whitespace_when_content_exists(self):
+        # If the prompt has real content but is padded, return the
+        # original value — don't silently mutate the prompt the operator
+        # compiled.
+        prompt = "  You are Sam.  "
+        assert extract_instructions_override({"instructions": prompt}) == prompt

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -892,32 +892,64 @@ export function buildOutboundDispatchMetadata(input: {
 // ============================================================================
 
 /**
+ * Hard ceiling on the compiled prompt we pump through LiveKit dispatch
+ * metadata. LiveKit's dispatch RPC has no published size limit, but the
+ * metadata blob is sent over the control channel as a JSON string and
+ * we'd rather drop the override than risk fragmenting the dispatch
+ * (which would silently abort the call). 32KB comfortably fits any
+ * reasonable compiled system prompt — a typical one is 3-8KB.
+ */
+export const VOICE_TEST_INSTRUCTIONS_MAX_BYTES = 32 * 1024;
+
+/**
  * Build the dispatch-metadata payload for a voice-test session.
  *
  * Pure function so the MG-agent-slug ↔ worker-profile-slug coupling is
  * covered by a unit test. If the field names or shape ever drift, the
- * worker's entrypoint (demos/bank-nowa/voice-agent/src/agent.py —
+ * worker's entrypoint (examples/agents/livekit-agent/src/agent.py —
  * `agentName = dispatch_metadata.get("agentName")`) stops routing to
  * the right profile and every dispatched call goes silent.
+ *
+ * Optional `instructions` overrides the worker's baked-in profile prompt
+ * for the duration of the call (ADR-015). Omitted when the input is
+ * null/empty/whitespace-only or exceeds VOICE_TEST_INSTRUCTIONS_MAX_BYTES;
+ * the worker falls back to its profile prompt in those cases.
  */
 export function buildVoiceTestDispatchMetadata(input: {
   agentSlug: string;
   sessionId: string;
   callerEmail: string;
+  instructions?: string | null;
 }): {
   mode: "voice-test";
   agentName: string;
   session_id: string;
   user_identifier: string;
   email: string;
+  instructions?: string;
 } {
-  return {
+  const base = {
     mode: "voice-test" as const,
     agentName: input.agentSlug,
     session_id: input.sessionId,
     user_identifier: input.callerEmail,
     email: input.callerEmail,
   };
+
+  const instructions = input.instructions;
+  if (typeof instructions !== "string" || instructions.trim() === "") {
+    return base;
+  }
+
+  // Size guard uses byte length, not character count — a single emoji is
+  // 4 bytes in UTF-8 and would otherwise sail past a naive .length check.
+  if (
+    Buffer.byteLength(instructions, "utf8") > VOICE_TEST_INSTRUCTIONS_MAX_BYTES
+  ) {
+    return base;
+  }
+
+  return { ...base, instructions };
 }
 
 export interface VoiceTestSession {
@@ -996,7 +1028,23 @@ export async function createVoiceTestSession(
     agentSlug: agent.slug,
     sessionId: session.id,
     callerEmail: caller.email,
+    instructions: agent.compiledInstructions,
   });
+
+  // Surface whether the override actually made it into metadata. If a
+  // compiled prompt exists but was dropped by the size guard, leave a
+  // breadcrumb so the operator can see why "I just compiled but the
+  // agent doesn't sound different" happened.
+  if (agent.compiledInstructions && !("instructions" in dispatchMetadata)) {
+    getLogger().warn(
+      {
+        orgId,
+        agentId,
+        compiledLength: agent.compiledInstructions.length,
+      },
+      "voice-test: compiled prompt dropped from dispatch metadata (size guard)",
+    );
+  }
 
   let dispatchId: string;
   try {

--- a/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
@@ -2,18 +2,25 @@
  * Voice-test dispatch metadata — locks in the MG-agent-slug ↔ worker-profile
  * coupling. The LiveKit worker's entrypoint reads `agentName` from the
  * JSON metadata blob to pick a profile from its registry (see
- * `demos/bank-nowa/voice-agent/src/agent.py`:
+ * `examples/agents/livekit-agent/src/agent.py`:
  *
  *     agent_name = dispatch_metadata.get("agentName")
- *     if not agent_name or agent_name not in _clients: ...
  *
  * If the field name or shape ever drifts, every dispatched call goes
  * silent at the worker. There's no type system connecting the two sides,
  * so this test IS the contract.
+ *
+ * The same contract also covers the optional `instructions` override
+ * (POC: edit prompt → compile → talk). When MG ships a compiled prompt,
+ * the worker overrides its baked-in profile prompt with the one from
+ * metadata. See ADR-015.
  */
 
 import { describe, expect, test } from "bun:test";
-import { buildVoiceTestDispatchMetadata } from "../../../src/features/agents/agents.service";
+import {
+  VOICE_TEST_INSTRUCTIONS_MAX_BYTES,
+  buildVoiceTestDispatchMetadata,
+} from "../../../src/features/agents/agents.service";
 
 describe("buildVoiceTestDispatchMetadata", () => {
   test("carries agentName = agent.slug for multi-profile routing", () => {
@@ -46,7 +53,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
     expect(md.email).toBe("tester@corp.com");
   });
 
-  test("shape is stable — exactly these 5 keys, nothing else", () => {
+  test("shape is stable — exactly the 5 required keys when no instructions", () => {
     const md = buildVoiceTestDispatchMetadata({
       agentSlug: "x",
       sessionId: "s",
@@ -80,5 +87,123 @@ describe("buildVoiceTestDispatchMetadata", () => {
     });
     const roundTripped = JSON.parse(JSON.stringify(md));
     expect(roundTripped).toEqual(md);
+  });
+
+  // ----------------------------------------------------------------------
+  // Compiled-prompt override (ADR-015)
+  //
+  // The worker's MCPAgent base reads ``dispatch_metadata.get("instructions")``
+  // and uses it instead of the baked profile prompt when present. This is
+  // what lets the dashboard "Compile" + "Talk to agent" cycle test the
+  // *latest* prompt without redeploying the worker.
+  // ----------------------------------------------------------------------
+
+  test("includes `instructions` when a compiled prompt is provided", () => {
+    const compiled = "You are Sam, the BuildPro assistant. Be brief.";
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: compiled,
+    });
+    expect(md.instructions).toBe(compiled);
+  });
+
+  test("omits `instructions` when no compiled prompt is provided", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect("instructions" in md).toBe(false);
+  });
+
+  test("omits `instructions` when an explicit null is provided", () => {
+    // compiledInstructions is `text | null` in the DB — null and "no prompt
+    // configured" must behave identically so the worker falls back to its
+    // baked profile prompt.
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: null,
+    });
+    expect("instructions" in md).toBe(false);
+  });
+
+  test("omits `instructions` when an empty/whitespace prompt is provided", () => {
+    // A compiled prompt that's just whitespace would silently break the
+    // agent — fall back to the baked profile prompt instead.
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: "   \n\t  ",
+    });
+    expect("instructions" in md).toBe(false);
+  });
+
+  test("omits `instructions` when the prompt exceeds the LiveKit metadata size guard", () => {
+    // LiveKit dispatch metadata is JSON-stringified and sent over the
+    // control channel. Practical payloads should stay well under ~32KB
+    // to avoid hitting platform limits and TLS-fragmenting the dispatch
+    // RPC. If a compiled prompt is too big, drop it from metadata so the
+    // call still goes through with the baked prompt (we'd rather hear
+    // the *previous* prompt than no audio at all).
+    const oversized = "x".repeat(VOICE_TEST_INSTRUCTIONS_MAX_BYTES + 1);
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: oversized,
+    });
+    expect("instructions" in md).toBe(false);
+  });
+
+  test("keeps `instructions` exactly at the size boundary", () => {
+    const atLimit = "x".repeat(VOICE_TEST_INSTRUCTIONS_MAX_BYTES);
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: atLimit,
+    });
+    expect(md.instructions).toBe(atLimit);
+  });
+
+  test("sizes by byte length, not character count (handles multibyte)", () => {
+    // A naive .length check passes a string of "🚀" — each emoji is a
+    // 2-char surrogate pair in JS but 4 bytes on the wire — that's under
+    // .length=32k but well over 32KB once JSON.stringify'd. Pick a count
+    // that's deliberately small in JS char terms but oversized in UTF-8.
+    const fourByteEmoji = "🚀";
+    const repeats = 10_000; // length=20k chars, bytes=40k → triggers guard
+    const multibyte = fourByteEmoji.repeat(repeats);
+    expect(multibyte.length).toBeLessThan(VOICE_TEST_INSTRUCTIONS_MAX_BYTES);
+    expect(Buffer.byteLength(multibyte, "utf8")).toBeGreaterThan(
+      VOICE_TEST_INSTRUCTIONS_MAX_BYTES,
+    );
+
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: multibyte,
+    });
+    expect("instructions" in md).toBe(false);
+  });
+
+  test("instructions field round-trips cleanly through JSON.stringify", () => {
+    // The dispatch layer JSON.stringify's the whole metadata. Verify
+    // that newlines, quotes, and unicode in a compiled prompt survive.
+    const prompt = 'You are "Sam". Greet the user with: \n"Hi! 👋"';
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "buildpro_v1",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      instructions: prompt,
+    });
+    const roundTripped = JSON.parse(JSON.stringify(md));
+    expect(roundTripped.instructions).toBe(prompt);
   });
 });

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
@@ -169,6 +169,41 @@ describe('VoiceTestPanel', () => {
     })
   })
 
+  // -------------------------------------------------------------------------
+  // Compiled-prompt indicator (ADR-015)
+  //
+  // The dashboard "Compile" button writes `compiledInstructions` on the
+  // agent. The voice-test panel surfaces *which* prompt the user is
+  // about to hear so they aren't guessing whether their last edit made
+  // it through the cycle.
+  // -------------------------------------------------------------------------
+
+  it('shows the compiled-prompt timestamp when the agent has compiled instructions', () => {
+    const compiled: Agent = {
+      ...configuredAgent,
+      compiledInstructions: 'You are Sam.',
+      compiledAt: '2026-04-01T12:34:00Z',
+    }
+    render(<VoiceTestPanel agent={compiled} canMutate />, { wrapper })
+    // Tells the operator which compile cycle they're about to test.
+    expect(screen.getByText(/will use prompt compiled/i)).toBeInTheDocument()
+  })
+
+  it('warns when no compiled prompt exists (worker falls back to baked profile)', () => {
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    render(<VoiceTestPanel agent={noPrompt} canMutate />, { wrapper })
+    // The talk button still works — the worker has its own baked prompt —
+    // but the operator should know the dashboard's compile cycle isn't
+    // the source of truth for this call.
+    expect(screen.getByText(/no compiled prompt/i)).toBeInTheDocument()
+  })
+
+  it('hides the compiled-prompt indicator entirely for non-livekit agents', () => {
+    const elevenAgent = { ...configuredAgent, agentPlatform: 'elevenlabs' } as Agent
+    render(<VoiceTestPanel agent={elevenAgent} canMutate />, { wrapper })
+    expect(screen.queryByText(/compiled prompt/i)).not.toBeInTheDocument()
+  })
+
   it('surfaces a clear error when mic permission is denied', async () => {
     stubMicPermission(false)
     render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
@@ -23,7 +23,7 @@
 
 import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
 import { useMutation } from '@tanstack/react-query'
-import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { AlertTriangle, FileCode, Mic, Radio } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -38,6 +38,41 @@ import { PHASE_LABEL, type WidgetState } from './voice-test/state'
 interface VoiceTestPanelProps {
   agent: Agent
   canMutate: boolean
+}
+
+/**
+ * Tells the operator which compiled prompt the worker will use for the
+ * call they're about to start. Mirrors the API-side dispatch contract:
+ * when `compiledInstructions` exists, the API ships it in dispatch
+ * metadata and the worker overrides its baked profile prompt with it
+ * (ADR-015). Without this label, operators couldn't tell whether their
+ * last edit actually made it into the test cycle.
+ */
+function CompiledPromptIndicator({
+  compiledInstructions,
+  compiledAt,
+}: {
+  compiledInstructions: string | null
+  compiledAt: string | null
+}) {
+  if (compiledInstructions && compiledAt) {
+    const when = new Date(compiledAt)
+    const label = Number.isNaN(when.getTime())
+      ? 'this agent'
+      : when.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+    return (
+      <p className="mt-3 flex items-center gap-1.5 text-xs text-fg-muted">
+        <FileCode className="h-3.5 w-3.5" />
+        Will use prompt compiled {label}
+      </p>
+    )
+  }
+  return (
+    <p className="mt-3 flex items-center gap-1.5 text-xs text-fg-muted">
+      <FileCode className="h-3.5 w-3.5" />
+      No compiled prompt — worker will use its baked-in profile.
+    </p>
+  )
 }
 
 export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
@@ -163,6 +198,11 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
             Configure the LiveKit URL, API key, and secret for this agent before testing.
           </div>
         )}
+
+        <CompiledPromptIndicator
+          compiledInstructions={agent.compiledInstructions ?? null}
+          compiledAt={agent.compiledAt ?? null}
+        />
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
           {showStartButton ? (


### PR DESCRIPTION
## Summary

Closes the dashboard **"Edit prompt → Compile → Talk to agent"** loop end-to-end. Before this PR, the LiveKit worker ignored `agent.compiledInstructions` and used the prompt baked into its profile module. Operators had to redeploy the worker to test a prompt edit.

After this PR:
1. Operator edits the prompt config in `PromptSection` (already shipped).
2. Operator clicks **Compile** in the Compiled tab (already shipped).
3. Operator clicks **Talk to agent** in `VoiceTestPanel`.
4. The voice-test endpoint ships `compiledInstructions` in dispatch metadata.
5. The worker overrides its baked profile prompt for that one call.

No redeploy. Round-trip stays at ~2s click-to-audio. The override is opportunistic — when the field is absent (or whitespace, or oversized) the worker falls back to the baked prompt, so local `make lk-agent-dev` is unaffected.

## Changes

### API (`modelguide-api`)
- `buildVoiceTestDispatchMetadata` gains an optional `instructions` field. Drops it when null / empty / whitespace / over 32 KB UTF-8 bytes (a single emoji is 4 bytes — a naive `.length` check would silently let 64 KB payloads through).
- `createVoiceTestSession` reads `agent.compiledInstructions` and passes it in. If the size guard trips, logs a structured `"voice-test: compiled prompt dropped from dispatch metadata (size guard)"` warning so operators can grep for it.
- Exports `VOICE_TEST_INSTRUCTIONS_MAX_BYTES = 32 * 1024` so the test pins the constant, not a magic number.

### Worker (`examples/agents/livekit-agent`)
- New pure helper `mcp_agent.resolve_instructions(default, override) → str` — mirrors the API guard exactly (whitespace-only override falls back to baked). Logs one info-level breadcrumb when the override fires.
- New pure helper `agent.extract_instructions_override(metadata) → str | None` — defends against missing keys, wrong types, and non-dict metadata.
- `MCPAgent.__init__` gains `instructions_override: str | None`. `BuildProAgent` passes it through. Entrypoint wires dispatch metadata → override.

### UI (`modelguide-ui`)
- `VoiceTestPanel` shows a `CompiledPromptIndicator` line:
  - "Will use prompt compiled `<timestamp>`" when set
  - "No compiled prompt — worker will use its baked-in profile" otherwise

  Closes the "did my edit go through?" loop before the operator commits to a call.

### Tests (red-green TDD)

| Suite | New | Total |
|---|---|---|
| API unit (`voice-test-dispatch.test.ts`) | +9 cases | 14 |
| Worker unit (`test_instructions_override.py`) | +15 cases | 15 |
| UI unit (`voice-test-panel.test.tsx`) | +3 cases | 9 |

Coverage includes: size boundary, multibyte byte-vs-char, whitespace/null normalization, JSON round-trip preservation, defensive metadata handling, UI indicator states.

### Docs
- **`docs/decisions/015-livekit-compiled-prompt-override.md`** — explains why this supersedes ADR-014's explicit "no prompt injection" stance, the dispatch contract, the byte-size guard rationale, and the rollback path.
- **`examples/agents/livekit-agent/README.md`** — new "Prompt Override from the Dashboard" section with an end-to-end flow diagram.

## Test plan

- [x] `bun test --preload ./tests/setup/unit-preload.ts tests/unit` — 904 pass
- [x] `.venv/bin/pytest tests/test_instructions_override.py tests/test_prompts.py tests/test_transcript.py tests/test_mg_client.py tests/test_sip.py` — 64 pass
- [x] `bunx vitest run src/features/agents/components/voice-test-panel.test.tsx` — 9 pass
- [x] `bunx tsc --noEmit` (API) — clean
- [x] Lint (biome) — both API + UI clean
- [ ] Manual: edit a SOP-backed agent's prompt → Compile → Talk to agent → confirm worker log shows `"Using compiled-prompt override from dispatch metadata (N chars, baked default ignored)"` and the agent behaves per the new prompt.
- [ ] Manual: oversized prompt (>32 KB) — confirm API logs the size-guard warning and the worker falls back to the baked prompt (call still succeeds).
- [ ] Manual: agent with `compiledInstructions = null` — confirm UI shows the "No compiled prompt" warning and Talk still works.

## Out of scope / follow-ups

- Pre-existing test files `tests/test_agent.py` and `tests/test_evals.py` in the livekit-agent example import `TOOL_NAME_MAP` from `agent`, but the code lives in `buildpro.py` as `TOOL_NAMES`. Verified broken on `main` (pre-existing) — left alone in this PR.
- The size-guard fallback is currently log-only. If oversized prompts become common, surface the dropped-override warning in the UI so the operator knows their call won't reflect the latest edit.
- Equivalent override for ElevenLabs would come with its own ADR — different platform shape (no dispatch metadata analog).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6mmEwAbrDEnPxm4HMd3SC)_