### PR TITLE
feat(agents): livekit-prototype with runtime compiled-prompt fetch (ADR-015)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,3 +195,18 @@ livekit-down: ## [LiveKit] Stop Docker LiveKit server
 
 livekit-token: ## [LiveKit] Generate token and open meet.livekit.io (NAME=yourname)
 	lk token create --api-key devkey --api-secret secret --room test-room --identity $(or $(NAME),artur) --join --valid-for 1h --agent $(LK_AGENT_NAME) --open meet
+
+# =============================================================================
+# LiveKit Prototype Agent (examples/agents/livekit-prototype) — ADR-015
+# =============================================================================
+
+LK_PROTOTYPE_DIR := examples/agents/livekit-prototype
+
+lk-prototype-setup: ## [LK Prototype] Install deps and download model files
+	cd $(LK_PROTOTYPE_DIR) && uv sync && uv run python src/agent.py download-files
+
+lk-prototype-dev: ## [LK Prototype] Run in WebRTC dev mode (fetches prompt from MG at session start)
+	cd $(LK_PROTOTYPE_DIR) && uv run python src/agent.py dev --log-level $(LK_LOG_LEVEL)
+
+lk-prototype-test: ## [LK Prototype] Run unit tests (no LiveKit / network needed)
+	cd $(LK_PROTOTYPE_DIR) && uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Start with the LiveKit implementation for the fastest end-to-end path. Use the P
 | Runtime | Why it exists | Path |
 |---|---|---|
 | **LiveKit Agents** *(flagship)* | Fastest path to a production voice agent with telephony, MCP tool wiring, session tracking, eval tests, and deployment docs | [`examples/agents/livekit-agent/`](examples/agents/livekit-agent/) |
+| **LiveKit Prototype** *(POC)* | Runtime prompt + MCP-tool fetch so you can compile in the dashboard and hear the new prompt on the next "Talk to agent" click — no redeploy. Iteration-only; see [ADR-015](docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md) | [`examples/agents/livekit-prototype/`](examples/agents/livekit-prototype/) |
 | **Pipecat** | Same orchestration model for teams already committed to Pipecat | [`examples/agents/pipecat-agent/`](examples/agents/pipecat-agent/) |
 | **ElevenLabs Conversational AI** | Manage platform agent config, tools, and prompts from version-controlled local definitions | [`examples/agents/elevenlabs-agent/`](examples/agents/elevenlabs-agent/) |
 | **Mastra** | Email "Where Is My Order?" example showing the orchestration layer extends beyond voice when you need another customer-facing channel | [`examples/agents/mastra-wismo-email-agent/`](examples/agents/mastra-wismo-email-agent/) |

--- a/docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md
+++ b/docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md
@@ -1,0 +1,215 @@
+# ADR-015: LiveKit Prototype Agent — Runtime Compiled-Prompt Fetch
+
+**Status:** Accepted (prototype-only)
+
+## Context
+
+[ADR-014](./014-browser-voice-testing.md) shipped the one-click
+"Talk to agent" flow but kept the worker's prompt baked into its image.
+That decision was correct for production workers — it removes a drift-in-
+testing failure mode where the voice-test sounds right but the deployed
+worker is on a stale prompt. It also makes the dispatch-metadata blob
+small enough to round-trip through LiveKit's metadata caps safely.
+
+It is, however, terrible for **prompt iteration**. Today the loop is:
+
+1. Edit the SOP in the dashboard.
+2. Click **Compile Prompt**.
+3. Wait for the worker image to rebuild (Docker, CI, redeploy to LiveKit
+   Cloud) — minutes per attempt.
+4. Click **Talk to agent**.
+
+For a contractor tweaking persona language or trying out a new tool
+ordering, that loop is too slow to be useful. Several internal builders
+have asked: "can I just click *Compile* and then *Talk* and have the
+agent use what I just compiled?" — and the answer under ADR-014 is
+"no, redeploy first".
+
+We want a "yes" answer for prototypes, without subsidizing the failure
+mode that ADR-014 was paid to avoid.
+
+## Decision
+
+Ship a parallel **prototype worker** (`examples/agents/livekit-prototype/`)
+that fetches its prompt + tool catalog from ModelGuide at session start,
+backed by a new agent-authenticated REST endpoint:
+
+```
+GET /api/agents/me
+Authorization: Bearer mgk_<agent_api_key>
+```
+
+The endpoint returns the same shape as `GET /api/agents/:id` — including
+`compiledInstructions` and `compiledFrom` — but is scoped to the agent
+that owns the calling API key. No cross-org enumeration is possible
+because the key identifies the agent (and therefore the org) directly.
+
+The worker's session-start sequence becomes:
+
+```
+ctx.connect()
+   → GET /api/agents/me         (compiled prompt → system instructions)
+   → MCP ListTools              (tool catalog → dynamic @function_tool wrappers)
+   → ctx.wait_for_participant()
+   → AgentSession.start()
+```
+
+Both the prompt and the tool list refresh on every dispatch, so a
+"compile + click Talk to agent" iteration takes seconds, not minutes.
+
+### Why a separate worker (not a flag on the existing one)
+
+Adding a `RUNTIME_PROMPT_FETCH=true` flag to the BuildPro worker would
+mean every code path in `buildpro.py` needs to defend against the prompt
+not being baked-in (greeting strings, prompt-cache warmup, the tool map
+which is wired by hand to specific tool names). The blast radius is
+larger than the value. A separate, minimal worker:
+
+- Is short enough (<200 lines) that the runtime-fetch path is the whole
+  worker, not a branch within it.
+- Keeps the production BuildPro flow exactly as ADR-014 specified — no
+  conditional logic, no risk of a flag flip changing prod behavior.
+- Documents itself by existing as a stand-alone example.
+
+### Endpoint shape
+
+`GET /api/agents/me` — permission: `requireAgent()` (API key auth only).
+
+| Status | Condition |
+|---|---|
+| 200 | API key is valid, agent is active. Body matches `agentResponseSchema` (same as `GET /:id`). |
+| 401 | No auth header, invalid `mgk_…`, expired key, key revoked, or agent inactive. |
+| 404 | Agent record was deleted between key mint and call (rare). |
+
+The response intentionally has the **same shape** as `GET /:id` — the
+prototype Python client uses only `id` and `compiledInstructions`, but
+reusing the schema means UI code that already renders agents can be
+pointed at this endpoint without divergence. No new schema to drift.
+
+### Security posture
+
+The endpoint is strictly more conservative than `POST /api/sessions`
+(which agents already use) — it's read-only and returns nothing the
+caller doesn't already implicitly know:
+
+- The API key already proves "I am this agent". `/me` adds zero new
+  enumeration surface — there is no path to learn about agents other
+  than yourself.
+- Agent records contain **secret references** (`secrets` is a UUID→UUID
+  ref map) but **no decrypted values**. The integration test pins this:
+  every value in `secrets` must be a UUID, never a token-shaped string.
+- We strip `webhook_hmac_secret` from `metadata` (same as `GET /:id`),
+  so a worker that re-leaks the response to a less-trusted log target
+  doesn't disclose the HMAC.
+- Plaintext API key never appears in the response — only `keyPrefix`.
+
+### What this deliberately does NOT do
+
+- **Does not extend the production worker.** ADR-014's drift-in-testing
+  concern is real for production. Operators who want runtime updates
+  use the prototype; operators who want the safety of a vendored prompt
+  use the production worker.
+- **Does not pre-cache.** The worker pays one extra HTTP round-trip per
+  session start (~50ms LAN, ~200ms cross-region). Compared to the LLM
+  TTFT (typically 800ms+) this is negligible, and caching adds
+  invalidation complexity that would partially defeat the point ("but
+  I clicked Compile and it still sounds old").
+- **Does not surface in the dashboard as a feature toggle.** Picking
+  between workers happens at LiveKit-config time (set
+  `metadata.livekit.agentName` to the prototype's name vs. the
+  production worker's name). The UI doesn't need to know which kind
+  of worker it's dispatching into — both consume the same metadata.
+
+## Alternatives Considered
+
+**Inject the prompt into LiveKit dispatch metadata.** The ADR-014 closed
+issues (#234, #239) explored this. Rejected then for two reasons that
+still apply: (1) metadata byte caps require multi-kilobyte prompts to
+be chunked, and (2) the metadata-in-dispatch path is a different
+codepath than what production runs, so the test signal is weak. Going
+through the regular agent-auth REST endpoint reuses the same auth and
+the same response shape the rest of the platform already uses.
+
+**Mint a one-shot pre-signed URL per dispatch.** Considered for "the
+worker doesn't need a long-lived API key". Rejected because the worker
+already needs the API key for MCP calls — minting an additional
+short-lived credential just to read its own prompt would double the
+key-management surface without removing the underlying long-lived key.
+
+**Push prompts to the worker via a control-plane subscription** (NATS,
+Kafka, etc.). Rejected as massively over-engineered for a prototype.
+The pull model is fine — calls are infrequent (one fetch per session
+start), bandwidth is trivial.
+
+**Hot-swap the prompt mid-session if the user clicks Compile while
+talking.** Tempting, but mid-session swap creates a new failure mode
+("the agent suddenly changes character mid-call"). Pull-on-start is the
+right grain: one stable prompt per conversation.
+
+## Consequences
+
+- Iterating on a prompt against a deployed prototype worker is now
+  **edit → Compile → Talk** with no redeploy. Estimated 10-50× speedup
+  on the inner loop.
+- The `/api/agents/me` endpoint becomes a small but load-bearing surface.
+  If it ever returns the wrong agent's record (e.g. a JWT-vs-API-key
+  middleware mix-up), a worker would talk with the wrong prompt and
+  the wrong tools. Mitigation: the integration test in
+  `tests/integration/agents.test.ts` includes a cross-org isolation
+  check (`orgB key returns orgB agent`) and a no-JWT check (`401 for
+  user JWT auth`) — both are load-bearing.
+- The drift-in-testing risk ADR-014 named is now real for the prototype:
+  "the voice-test sounded good, then I deployed BuildPro and it
+  regressed." Mitigation: README explicitly scopes the prototype to
+  iteration use, not deployment, and lists what's missing vs the
+  production worker (SIP, transcript posting, Langfuse, hang-up state
+  machine).
+- The MCP tool wiring is dynamic — whatever connectors are assigned
+  show up. This means a tool added in the dashboard becomes available
+  on the next call without a code change. Useful for prototyping, but
+  it also means the LLM may try to call a tool whose backend has known
+  issues. Compared to the BuildPro worker's `STUBBED_TOOLS` env, this
+  is a regression in fault containment we accept for the prototype.
+- The endpoint passes through `compiledFrom` (SOPs, guardrail IDs,
+  tool count). If a future worker wants to refuse to start when, e.g.,
+  the compile is more than 30 days stale, it has the data it needs.
+
+## Test coverage
+
+**API side** (`tests/integration/agents.test.ts`):
+
+- `GET /api/agents/me` with a valid agent key → 200 + agent shape
+- secret material does not leak (no plaintext key, no HMAC, secrets
+  ref map contains only UUIDs)
+- orgB key returns orgB agent — never orgA (cross-org isolation)
+- user JWT → 401 (endpoint is agent-only)
+- no auth → 401
+- invalid `mgk_…` → 401
+- `/me` does not collide with `/:id` UUID-param route
+
+**Worker side** (`examples/agents/livekit-prototype/tests/`):
+
+- `fetch_agent_self` — happy path returns parsed `AgentSelf`
+- `fetch_compiled_prompt` — convenience wrapper returns the string
+- URL trailing-slash normalization (prevents `//api/...` 404s)
+- 401, 404 → `PromptFetchUnauthorized`
+- `compiledInstructions=None` or `""` → `MissingCompiledPrompt`
+  (workers fall back to a placeholder prompt)
+- 500, non-JSON body, array body → `PromptFetchError`
+- `mcp_url_for` builds `{api}/mcp/{agent_id}`
+- `build_tool_description` embeds the schema for LLM tool calls
+
+15 Python tests, 7 new API integration assertions. No new mocks beyond
+`httpx.MockTransport` in the worker tests.
+
+## Related
+
+- [ADR-011](./011-livekit-outbound-calls.md) — original outbound dispatch
+  pattern, shares `dispatchAgentToRoom`.
+- [ADR-014](./014-browser-voice-testing.md) — browser voice testing,
+  decided that prompts should NOT travel in dispatch metadata. This
+  ADR explicitly accepts that decision for production while offering
+  the prototype escape hatch.
+- `examples/agents/livekit-agent/` — the production BuildPro worker
+  that keeps the baked-prompt invariant.
+- `examples/agents/livekit-prototype/` — this prototype.

--- a/examples/agents/livekit-prototype/.env.example
+++ b/examples/agents/livekit-prototype/.env.example
@@ -1,0 +1,36 @@
+# LiveKit worker identity — must match the `agentName` configured on the
+# ModelGuide agent's `metadata.livekit` block (the dispatcher sends jobs
+# to this name).
+AGENT_NAME=mg-prototype
+
+# LiveKit
+# For local dev: livekit-server --dev ships these credentials by default.
+# For LiveKit Cloud: these are injected at deploy time and can be omitted.
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# OpenAI (LLM)
+OPENAI_API_KEY=sk-...
+# Optional model override (default: gpt-4.1-mini)
+# LLM_MODEL=gpt-4.1-mini
+
+# Deepgram (STT)
+DEEPGRAM_API_KEY=...
+
+# ElevenLabs (TTS)
+ELEVENLABS_API_KEY=...
+# Voice ID — defaults to "Chris" if unset
+# ELEVENLABS_VOICE_ID=
+
+# ModelGuide
+# Base URL of the API (no trailing slash). The worker calls:
+#   GET  {MODELGUIDE_API_URL}/api/agents/me     (compiled prompt)
+#   POST {MODELGUIDE_API_URL}/mcp/{agent-id}    (tool execution)
+MODELGUIDE_API_URL=http://localhost:3000
+
+# Agent API key (mgk_…). Shown once when the agent is created in the
+# dashboard; rotate via "Regenerate Key" if you lose it. This is the ONLY
+# secret the worker needs — both the prompt and the tool catalog are
+# scoped to the agent this key belongs to.
+MODELGUIDE_API_KEY=mgk_...

--- a/examples/agents/livekit-prototype/.gitignore
+++ b/examples/agents/livekit-prototype/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/examples/agents/livekit-prototype/Dockerfile
+++ b/examples/agents/livekit-prototype/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Download Silero VAD + EnglishModel weights at build time so the worker
+# can boot without pulling them on first start.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/agent.py", "start"]

--- a/examples/agents/livekit-prototype/README.md
+++ b/examples/agents/livekit-prototype/README.md
@@ -1,0 +1,129 @@
+# LiveKit Prototype Agent — Runtime Prompt Fetch
+
+A minimal LiveKit voice agent that **fetches its compiled prompt and tool
+catalog from ModelGuide at session start**. Unlike the production
+[`livekit-agent`](../livekit-agent) (BuildPro Sam) example — which bakes
+the prompt into the worker image — this prototype lets you:
+
+1. Edit the agent's SOP / persona in the ModelGuide dashboard
+2. Click **Compile Prompt**
+3. Click **Talk to agent**
+4. Hear the new prompt immediately, with no worker redeploy
+
+Status: **prototype only**. See [ADR-015](../../../docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md)
+for the design and the explicit trade-offs vs. the production pattern in
+[ADR-014](../../../docs/decisions/014-browser-voice-testing.md).
+
+---
+
+## How it works
+
+```
+LiveKit room (WebRTC, dispatched by the API's voice-test-token endpoint)
+   ↓
+entrypoint(ctx)
+   ├── GET /api/agents/me           — fetch compiledInstructions (system prompt)
+   ├── MCP ListTools                 — discover agent tools
+   ├── _build_dynamic_tools(...)     — wrap each MCP tool as a @function_tool
+   ↓
+AgentSession(STT → LLM(tools) → TTS)
+   ↓
+Caller talks to the agent. Every tool the operator assigned in the
+dashboard is available to the LLM, with the latest compiled prompt as
+its system instructions.
+```
+
+### The two ModelGuide endpoints the worker calls
+
+| Call | Method | Path | Auth | Returns |
+|---|---|---|---|---|
+| Prompt fetch | `GET` | `/api/agents/me` | Bearer `mgk_…` | The full agent record (uses only `compiledInstructions` + `id`) |
+| Tool execution | `POST` | `/mcp/:agent_id` | Bearer `mgk_…` | MCP streaming responses |
+
+Both are authenticated by the same `MODELGUIDE_API_KEY`. The agent UUID
+is read from `GET /me`'s response — the worker doesn't need to know it
+ahead of time.
+
+## Repository layout
+
+```
+src/
+  agent.py        # LiveKit entrypoint — fetch + wire + session lifecycle
+  config.py       # Env loading + FALLBACK_INSTRUCTIONS
+  mg_prompt.py    # GET /api/agents/me client (httpx)
+  mg_mcp.py       # MCP client + dynamic-tool description builder
+  providers.py    # Deepgram STT + ElevenLabs TTS factories
+tests/
+  test_mg_prompt.py  # Prompt fetcher contract tests (10 cases)
+  test_mg_mcp.py     # URL + tool-description format tests (5 cases)
+```
+
+## Quick start (local)
+
+Prereqs: Python 3.11+, [uv](https://docs.astral.sh/uv/), a running ModelGuide
+API with an agent that has been **compiled** at least once, and API keys for
+OpenAI / Deepgram / ElevenLabs.
+
+```bash
+cd examples/agents/livekit-prototype
+
+# Install deps + download VAD/turn-detector model weights
+uv venv && uv pip install -e ".[test]"
+
+# Configure
+cp .env.example .env
+# Edit .env — set MODELGUIDE_API_KEY to your agent's mgk_ key
+
+# Run unit tests (no network, no LiveKit needed)
+.venv/bin/pytest tests/ -v
+
+# Start the worker in dev mode (needs a running livekit-server)
+.venv/bin/python src/agent.py dev
+```
+
+Then from the dashboard, click **Talk to agent** on the agent whose API key
+matches `MODELGUIDE_API_KEY`. The worker picks up the dispatch, fetches
+the compiled prompt, and starts the call.
+
+## Deploying to LiveKit Cloud
+
+The Dockerfile is identical to the production worker's — same multi-stage
+uv build, same Silero/turn-detector weight pre-pull. Push the image and
+configure the worker name in LiveKit Cloud to match `AGENT_NAME` in `.env`.
+
+Reuse the existing `livekit.toml` pattern from `examples/agents/livekit-agent`
+if you want a single-command deploy.
+
+## What's NOT in scope
+
+The prototype intentionally drops some features from the production worker
+to keep the runtime-fetch loop legible:
+
+| Feature | Production (`livekit-agent`) | Prototype |
+|---|---|---|
+| System prompt | Baked into `prompts/` package | `GET /api/agents/me` at session start |
+| Tool wiring | Explicit `@function_tool` per tool | Dynamic from MCP `ListTools` |
+| SIP / phone in/out | Yes | Browser-only |
+| Hang-up state machine | Yes (`hangup.py`) | Caller hangs up the room |
+| Langfuse tracing | Yes (opt-in) | No |
+| Transcript posting | Yes | No (handled by the API session) |
+| Stubbed tools | Yes (`STUBBED_TOOLS` env) | No (only real MCP tools surface) |
+
+If you need any of those for a real deployment, copy the production worker
+and add the runtime-fetch step to its entrypoint instead — don't extend
+this prototype into production.
+
+## Testing
+
+```bash
+# Pure unit tests — no LiveKit, no network
+pytest tests/ -v
+```
+
+The tests cover the runtime-fetch contract end-to-end (happy path, every
+HTTP error class, missing compile, malformed responses) and pin the
+tool-description format the LLM sees. They use an in-process httpx
+`MockTransport`, so they run in well under a second.
+
+See [`test_mg_prompt.py`](tests/test_mg_prompt.py) and
+[`test_mg_mcp.py`](tests/test_mg_mcp.py) for the full inventory.

--- a/examples/agents/livekit-prototype/pyproject.toml
+++ b/examples/agents/livekit-prototype/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "livekit-modelguide-prototype"
+version = "0.1.0"
+description = "Prototype LiveKit voice agent that fetches its compiled prompt from ModelGuide at session start"
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "httpx",
+    "python-dotenv",
+    "mcp",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/agents/livekit-prototype/src/agent.py
+++ b/examples/agents/livekit-prototype/src/agent.py
@@ -1,0 +1,236 @@
+"""Prototype LiveKit voice agent — runtime prompt + MCP-tool fetch.
+
+This worker is intentionally minimal. Unlike ``examples/agents/livekit-agent``
+(BuildPro Sam), which bakes its system prompt and tool wiring into the worker
+image, this prototype fetches both from ModelGuide at session start:
+
+  1. ``GET /api/agents/me`` → compiled instructions (the system prompt)
+  2. ``ListTools`` on the agent's MCP endpoint → tool catalog
+  3. The LLM is given those tools dynamically — every connector tool the
+     operator has wired up in the dashboard shows up here automatically.
+
+Trade-off vs the BuildPro worker: see ADR-015. Short version — drift-in-
+testing risk vs. dramatically faster iteration when an operator wants to
+hear how a freshly-compiled prompt sounds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession, RunContext, function_tool
+from livekit.plugins import openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+import mg_prompt
+from mg_mcp import MCPClient, MCPTool, build_tool_description
+from providers import create_stt, create_tts
+
+VERSION = "0.1.0"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(name)s | %(levelname)s | %(message)s",
+)
+logger = logging.getLogger("prototype")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic tool wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_dynamic_tools(
+    tools: list[MCPTool],
+    mcp: MCPClient,
+    session_id_provider,
+):
+    """Wrap each MCP tool in a LiveKit ``@function_tool`` so the LLM sees it.
+
+    LiveKit's decorator inspects the wrapped coroutine's signature for
+    parameter introspection. Since MCP tools have JSON-schema args (not
+    Python signatures), we use a single ``args: dict`` parameter and lean
+    on the tool's *description* (which the API embeds the input schema
+    into) to teach the LLM how to call it. This is the trade-off the
+    prototype makes for "any tool the operator wires up shows up" — a
+    production worker would generate typed wrappers per tool from the
+    schema instead.
+    """
+    wrapped = []
+    for tool in tools:
+        # Closure-capture the tool name so each wrapper calls the right one.
+        description = build_tool_description(tool)
+
+        async def _impl(
+            context: RunContext,
+            arguments: dict[str, Any],
+            *,
+            _name: str = tool.name,
+        ) -> str:
+            try:
+                result = await mcp.call_tool(
+                    _name, arguments, session_id_provider()
+                )
+                return json.dumps(result)
+            except Exception as exc:
+                logger.exception("Tool %s failed", _name)
+                raise agents.ToolError(f"Tool {_name} failed: {exc}") from exc
+
+        # The decorator uses the wrapper's __name__ as the tool name, so
+        # set it before decorating.
+        _impl.__name__ = tool.name
+        _impl.__doc__ = description
+        wrapped.append(function_tool()(_impl))
+
+    return wrapped
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def entrypoint(ctx: agents.JobContext):
+    """Called once per LiveKit room. The prototype's one trick is between
+    ``await ctx.connect()`` and ``await session.start()`` below — that's
+    where the runtime prompt + tool fetch happens."""
+    config.validate()
+    logger.info("%s prototype agent v%s — entrypoint", config.AGENT_NAME, VERSION)
+
+    # Dispatch metadata is the same shape as the BuildPro worker so the
+    # API's ``createVoiceTestSession`` can dispatch either worker without
+    # changes. See ``buildVoiceTestDispatchMetadata`` in agents.service.ts.
+    dispatch_metadata: dict = {}
+    if ctx.job.metadata:
+        try:
+            dispatch_metadata = json.loads(ctx.job.metadata)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Invalid JSON in dispatch metadata: %s", ctx.job.metadata[:120]
+            )
+
+    session_id: str | None = dispatch_metadata.get("session_id")
+    user_identifier: str = (
+        dispatch_metadata.get("user_identifier")
+        or dispatch_metadata.get("email")
+        or "voice-caller"
+    )
+
+    await ctx.connect()
+
+    # --- Fetch compiled prompt + MCP tool catalog in parallel ---
+    # If the prompt fetch fails we still try to run with the fallback so
+    # the caller hears *something*. If the MCP listing fails we run with
+    # zero tools — the LLM can still hold a conversation.
+    try:
+        agent_self = await mg_prompt.fetch_agent_self(
+            config.MODELGUIDE_API_URL, config.MODELGUIDE_API_KEY
+        )
+        instructions = agent_self.compiled_instructions
+        agent_id = agent_self.id
+        logger.info(
+            "Loaded compiled prompt from ModelGuide (compiledAt=%s, length=%d)",
+            agent_self.compiled_at,
+            len(instructions),
+        )
+    except mg_prompt.MissingCompiledPrompt as exc:
+        logger.warning("No compiled prompt — using fallback (%s)", exc)
+        instructions = config.FALLBACK_INSTRUCTIONS
+        # Without /me we don't have an agent ID — skip MCP entirely.
+        agent_id = None
+    except Exception:
+        logger.exception("Prompt fetch failed — using fallback instructions")
+        instructions = config.FALLBACK_INSTRUCTIONS
+        agent_id = None
+
+    # --- MCP: list + wrap tools (only if we got a real agent_id) ---
+    mcp: MCPClient | None = None
+    dynamic_tools = []
+    if agent_id:
+        try:
+            mcp = MCPClient(
+                config.MODELGUIDE_API_URL,
+                agent_id,
+                config.MODELGUIDE_API_KEY,
+            )
+            await mcp._connect()
+            tools = await mcp.list_tools()
+            logger.info(
+                "Discovered %d MCP tool(s): %s",
+                len(tools),
+                ", ".join(t.name for t in tools) or "(none)",
+            )
+            dynamic_tools = _build_dynamic_tools(
+                tools, mcp, lambda: session_id
+            )
+        except Exception:
+            logger.exception(
+                "MCP discovery failed — running with zero tools"
+            )
+
+    # Wait for the human participant (browser caller) before we start
+    # the LLM — this matches the BuildPro flow.
+    participant = await ctx.wait_for_participant()
+    logger.info(
+        "Participant joined: %s (user_identifier=%s, session_id=%s)",
+        participant.identity,
+        user_identifier,
+        session_id,
+    )
+
+    agent = Agent(instructions=instructions, tools=dynamic_tools)
+
+    session = AgentSession(
+        stt=create_stt(),
+        llm=openai.LLM(
+            model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY
+        ),
+        tts=create_tts(),
+        vad=silero.VAD.load(),
+        turn_detection=EnglishModel(),
+        allow_interruptions=True,
+        min_interruption_duration=1.0,
+        min_endpointing_delay=0.5,
+    )
+
+    session_done = asyncio.Event()
+
+    @session.on("close")
+    def _on_close():
+        session_done.set()
+
+    @ctx.room.on("disconnected")
+    def _on_disconnect():
+        session_done.set()
+
+    await session.start(room=ctx.room, agent=agent)
+
+    # Brief greeting so the caller knows we're connected
+    name = participant.name or "there"
+    await session.say(
+        f"Hi {name}. I'm the prototype agent. How can I help you?"
+    )
+
+    try:
+        await session_done.wait()
+    finally:
+        if mcp is not None:
+            await mcp.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-prototype/src/config.py
+++ b/examples/agents/livekit-prototype/src/config.py
@@ -1,0 +1,90 @@
+"""Environment loading for the livekit-prototype worker.
+
+Only the bare minimum is required — the prompt and toolset come from
+ModelGuide at runtime, so there's no per-scenario `AGENT_NAME` /
+`CONNECTOR_PREFIX` coupling to configure.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Worker identity — used by LiveKit dispatch to route jobs to this worker
+# ---------------------------------------------------------------------------
+
+AGENT_NAME: str = os.getenv("AGENT_NAME", "mg-prototype")
+
+# ---------------------------------------------------------------------------
+# Required at runtime — checked by validate()
+# ---------------------------------------------------------------------------
+
+REQUIRED_VARS = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+# Populated by validate()
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+LLM_MODEL: str = "gpt-4.1-mini"
+STT_MODEL: str = "nova-3"
+ELEVENLABS_VOICE_ID: str = ""
+
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+
+# Fallback prompt used when MissingCompiledPrompt is raised. The worker
+# still has to start a turn (otherwise the call sits silent), so we ship
+# a tiny placeholder that tells the caller what's wrong instead.
+FALLBACK_INSTRUCTIONS: str = (
+    "You are a placeholder voice assistant. The operator has not yet "
+    "compiled a prompt for this agent in ModelGuide. Greet the caller "
+    "politely, tell them the agent's prompt has not been compiled yet, "
+    "and ask them to try again after the operator clicks Compile in "
+    "the dashboard."
+)
+
+
+_validated = False
+
+
+def validate() -> None:
+    """Populate module-level config from env. Idempotent."""
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    g = globals()
+    g.update({
+        "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+        "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+        "ELEVENLABS_API_KEY": os.getenv("ELEVENLABS_API_KEY", ""),
+        "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4.1-mini"),
+        "STT_MODEL": os.getenv("STT_MODEL", "nova-3"),
+        "ELEVENLABS_VOICE_ID": os.getenv(
+            "ELEVENLABS_VOICE_ID", "iP95p4xoKVk53GoZ742B"
+        ),
+        "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+        "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+    })
+
+    _validated = True

--- a/examples/agents/livekit-prototype/src/mg_mcp.py
+++ b/examples/agents/livekit-prototype/src/mg_mcp.py
@@ -1,0 +1,154 @@
+"""Talk to ModelGuide's MCP endpoint for tool discovery and execution.
+
+The prototype lists tools from MCP at session start and builds matching
+LiveKit ``@function_tool`` wrappers on the fly, so the worker doesn't have
+to declare them in code (the way ``buildpro.py`` does for the BuildPro
+demo). Whatever connectors the operator has wired to this agent in the
+dashboard show up automatically the next time a call connects.
+
+Kept tiny on purpose — schema-to-Python coercion is best-effort, since
+LiveKit's function-tool decorator infers parameters from Python signatures.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+logger = logging.getLogger("mg_mcp")
+
+
+@dataclass
+class MCPTool:
+    """A tool discovered via ``ListTools``. ``input_schema`` is a JSON
+    Schema dict (per MCP spec); LiveKit's function tool decorator does
+    its own argument inference, so we only carry the raw schema for
+    debugging / future strict-typing work."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+def mcp_url_for(api_url: str, agent_id: str) -> str:
+    return f"{api_url.rstrip('/')}/mcp/{agent_id}"
+
+
+def build_tool_description(tool: MCPTool) -> str:
+    """LLM-facing description for a dynamically wired tool.
+
+    The LLM doesn't see the JSON Schema directly (LiveKit's function-tool
+    decorator infers params from Python signatures, and our dynamic
+    wrappers take a single ``dict`` arg). So we embed the schema into
+    the description string instead — the LLM uses it to know what keys
+    to put in the args object.
+
+    Pure helper so tests can pin the format without spinning up LiveKit.
+    """
+    base = (tool.description or "").strip()
+    if not tool.input_schema:
+        return base
+    schema = json.dumps(tool.input_schema, separators=(",", ":"))
+    if base:
+        return f"{base}\n\nInput schema (JSON): {schema}"
+    return f"Input schema (JSON): {schema}"
+
+
+def _parse_call_result(result) -> dict:
+    """MCP returns content blocks; the API encodes JSON results into a
+    single text block, so unwrap and decode. Falls back to the raw text
+    if it isn't JSON (e.g. plaintext errors)."""
+    if result.content and len(result.content) > 0:
+        block = result.content[0]
+        if hasattr(block, "text"):
+            try:
+                return json.loads(block.text)
+            except (json.JSONDecodeError, TypeError):
+                return {"result": block.text}
+    return {"result": str(result.content)}
+
+
+class MCPClient:
+    """A short-lived persistent MCP connection scoped to one voice session.
+
+    Usage:
+
+        async with MCPClient(api_url, agent_id, api_key) as mcp:
+            tools = await mcp.list_tools()
+            out = await mcp.call_tool("connector_do_thing", {...}, sess_id)
+    """
+
+    def __init__(self, api_url: str, agent_id: str, api_key: str):
+        self._url = mcp_url_for(api_url, agent_id)
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+        self._session: ClientSession | None = None
+        self._transport_ctx = None
+        self._session_ctx = None
+
+    async def __aenter__(self) -> "MCPClient":
+        await self._connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def _connect(self) -> None:
+        start = time.monotonic()
+        self._transport_ctx = streamablehttp_client(self._url, headers=self._headers)
+        read, write, _ = await self._transport_ctx.__aenter__()
+
+        self._session_ctx = ClientSession(read, write)
+        self._session = await self._session_ctx.__aenter__()
+        await self._session.initialize()
+
+        elapsed = int((time.monotonic() - start) * 1000)
+        logger.info("MCP connected to %s in %dms", self._url, elapsed)
+
+    async def close(self) -> None:
+        if self._session_ctx is not None:
+            try:
+                await self._session_ctx.__aexit__(None, None, None)
+            except Exception:
+                logger.debug("MCP session close error (expected during shutdown)")
+            self._session = None
+            self._session_ctx = None
+        if self._transport_ctx is not None:
+            try:
+                await self._transport_ctx.__aexit__(None, None, None)
+            except Exception:
+                logger.debug("MCP transport close error (expected during shutdown)")
+            self._transport_ctx = None
+
+    async def list_tools(self) -> list[MCPTool]:
+        if self._session is None:
+            raise RuntimeError("MCPClient not entered — use 'async with' first")
+        result = await self._session.list_tools()
+        tools: list[MCPTool] = []
+        for tool in result.tools:
+            tools.append(
+                MCPTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=getattr(tool, "inputSchema", {}) or {},
+                )
+            )
+        return tools
+
+    async def call_tool(
+        self, name: str, args: dict, session_id: str | None
+    ) -> dict:
+        if self._session is None:
+            raise RuntimeError("MCPClient not entered — use 'async with' first")
+        # ModelGuide's MCP layer expects session_id alongside the tool args
+        # so it can attribute the call to a session_messages row.
+        payload = {**args}
+        if session_id:
+            payload["session_id"] = session_id
+        result = await self._session.call_tool(name, payload)
+        return _parse_call_result(result)

--- a/examples/agents/livekit-prototype/src/mg_prompt.py
+++ b/examples/agents/livekit-prototype/src/mg_prompt.py
@@ -1,0 +1,167 @@
+"""Fetch the calling agent's compiled prompt from ModelGuide at runtime.
+
+The prototype's whole reason to exist is to skip the "redeploy the worker to
+test a new prompt" step. Instead of baking the prompt into the worker image,
+the worker calls ``GET /api/agents/me`` with its own API key at session start
+and uses ``compiledInstructions`` as the system prompt.
+
+This module is intentionally tiny and dependency-light — only ``httpx`` — so
+it can be unit-tested without standing up a LiveKit worker. The contract:
+
+    prompt = await fetch_compiled_prompt(api_url, api_key)
+
+Returns the compiled instructions verbatim, or raises ``MissingCompiledPrompt``
+if the agent has not been compiled yet. The worker layer decides what to do
+when the prompt is missing (we currently fall back to a placeholder so the
+agent still answers, but does so with a clear "please compile first" line).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class PromptFetchError(RuntimeError):
+    """Network / 5xx / unexpected response when calling /api/agents/me."""
+
+
+class PromptFetchUnauthorized(PromptFetchError):
+    """API key is invalid, expired, or the agent is inactive."""
+
+
+class MissingCompiledPrompt(PromptFetchError):
+    """The agent record was returned but ``compiledInstructions`` is null.
+
+    Raised so the worker can show a clear error instead of dispatching with
+    an empty system prompt (which silently degrades to a generic assistant).
+    """
+
+
+@dataclass(frozen=True)
+class AgentSelf:
+    """Subset of ``GET /api/agents/me`` the worker actually consumes.
+
+    Kept narrow so unrelated fields in the API response can change without
+    breaking the prototype. If the worker starts needing a new field, add
+    it here and to the parser below — both sides stay typed.
+    """
+
+    id: str
+    name: str
+    slug: str
+    modality: str
+    agent_platform: str
+    is_active: bool
+    compiled_instructions: str
+    compiled_at: str | None
+
+
+def _parse_agent_self(payload: dict[str, Any]) -> AgentSelf:
+    instructions = payload.get("compiledInstructions")
+    if not instructions or not isinstance(instructions, str):
+        # We treat both `null` and empty string as "not compiled yet". An
+        # empty string would otherwise propagate to the LLM as an empty
+        # system prompt and produce a generic assistant — worse UX than
+        # failing loudly.
+        raise MissingCompiledPrompt(
+            f"Agent {payload.get('slug', payload.get('id', '?'))} has no "
+            "compiledInstructions. Compile the agent in the dashboard "
+            "(Prompt → Compile) before starting a voice test."
+        )
+    return AgentSelf(
+        id=str(payload["id"]),
+        name=str(payload["name"]),
+        slug=str(payload["slug"]),
+        modality=str(payload["modality"]),
+        agent_platform=str(payload["agentPlatform"]),
+        is_active=bool(payload["isActive"]),
+        compiled_instructions=instructions,
+        compiled_at=payload.get("compiledAt"),
+    )
+
+
+async def fetch_agent_self(
+    api_url: str,
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+) -> AgentSelf:
+    """Call ``GET {api_url}/api/agents/me`` and return the parsed agent.
+
+    ``client`` lets the worker reuse a shared httpx pool. Tests pass a
+    transport-mocked client so the real network is never touched.
+    """
+    url = f"{api_url.rstrip('/')}/api/agents/me"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+
+    own_client = client is None
+    if own_client:
+        client = httpx.AsyncClient(timeout=timeout)
+
+    try:
+        resp = await client.get(url, headers=headers)
+    finally:
+        if own_client:
+            await client.aclose()
+
+    if resp.status_code == 401:
+        raise PromptFetchUnauthorized(
+            "ModelGuide rejected the agent API key (401). Confirm "
+            "MODELGUIDE_API_KEY is the active key for this agent and the "
+            "agent is marked active."
+        )
+    if resp.status_code == 404:
+        # Spec: /me only 404s if the API key's owning agent was deleted
+        # after the key was minted but before its `isActive` flag flipped.
+        raise PromptFetchUnauthorized(
+            "ModelGuide returned 404 for /api/agents/me — the agent this "
+            "key belongs to no longer exists."
+        )
+    if resp.status_code >= 500:
+        raise PromptFetchError(
+            f"ModelGuide /api/agents/me returned {resp.status_code}: "
+            f"{resp.text[:200]}"
+        )
+    if resp.status_code != 200:
+        raise PromptFetchError(
+            f"ModelGuide /api/agents/me returned unexpected status "
+            f"{resp.status_code}: {resp.text[:200]}"
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise PromptFetchError(
+            f"ModelGuide /api/agents/me returned non-JSON body: "
+            f"{resp.text[:200]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise PromptFetchError(
+            f"ModelGuide /api/agents/me returned {type(payload).__name__}, "
+            "expected an object"
+        )
+
+    return _parse_agent_self(payload)
+
+
+async def fetch_compiled_prompt(
+    api_url: str,
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> str:
+    """Thin wrapper that returns just the compiled instructions string.
+
+    Use this when the worker only cares about the prompt itself — most call
+    sites in ``agent.py`` won't need the rest of the AgentSelf shape.
+    """
+    self_ = await fetch_agent_self(api_url, api_key, client=client)
+    return self_.compiled_instructions

--- a/examples/agents/livekit-prototype/src/providers.py
+++ b/examples/agents/livekit-prototype/src/providers.py
@@ -1,0 +1,41 @@
+"""STT and TTS factories. Defaults match the BuildPro demo so the prototype
+can be A/B'd against it without provider drift skewing latency/quality."""
+
+from __future__ import annotations
+
+import logging
+
+import config
+
+logger = logging.getLogger("providers")
+
+
+def create_stt():
+    from livekit.plugins import deepgram
+
+    logger.info("STT model: %s", config.STT_MODEL)
+    return deepgram.STT(
+        model=config.STT_MODEL,
+        api_key=config.DEEPGRAM_API_KEY,
+        interim_results=True,
+        endpointing_ms=300,
+    )
+
+
+def create_tts():
+    from livekit.agents import tokenize
+    from livekit.plugins import elevenlabs
+
+    logger.info(
+        "TTS provider: elevenlabs (voice=%s)", config.ELEVENLABS_VOICE_ID
+    )
+    return elevenlabs.TTS(
+        voice_id=config.ELEVENLABS_VOICE_ID,
+        model="eleven_flash_v2_5",
+        api_key=config.ELEVENLABS_API_KEY,
+        inactivity_timeout=30,
+        word_tokenizer=tokenize.blingfire.SentenceTokenizer(
+            min_sentence_len=8,
+            stream_context_len=5,
+        ),
+    )

--- a/examples/agents/livekit-prototype/tests/test_mg_mcp.py
+++ b/examples/agents/livekit-prototype/tests/test_mg_mcp.py
@@ -1,0 +1,89 @@
+"""Tests for ``mg_mcp`` — only the pure helpers are unit-testable.
+
+The persistent ``MCPClient`` needs a live HTTP streaming endpoint to
+``__aenter__``, so we don't exercise it here — that's covered by the
+backend's ``tests/integration/mcp.test.ts``. The URL builder, on the
+other hand, is the contract between worker config and the API and IS
+worth pinning.
+"""
+
+from mg_mcp import MCPTool, build_tool_description, mcp_url_for
+
+
+def test_mcp_url_builds_from_api_url_and_agent_id():
+    """The path shape ``/mcp/{agent_id}`` is the API's contract — if
+    routing ever moves to ``/api/mcp/{id}`` or ``/mcp?agent_id=…`` the
+    worker would silently fail to call any tool."""
+    url = mcp_url_for("https://api.modelguide.test", "agent-uuid")
+    assert url == "https://api.modelguide.test/mcp/agent-uuid"
+
+
+def test_mcp_url_strips_trailing_slash():
+    """Operators set MODELGUIDE_API_URL either way — normalize so the
+    resulting URL is always single-slashed (some reverse proxies 404
+    paths with `//`)."""
+    url = mcp_url_for("https://api.modelguide.test/", "agent-uuid")
+    assert url == "https://api.modelguide.test/mcp/agent-uuid"
+
+
+# ---------------------------------------------------------------------------
+# build_tool_description
+#
+# Pinning the format of the LLM-facing tool description matters because:
+#   1. The dynamic-wrapper signature is just `arguments: dict`, so the
+#      LLM cannot infer parameter names from Python — it has to read the
+#      schema from this string.
+#   2. If this format ever drifts (e.g. switches to YAML, or drops the
+#      schema entirely), the LLM will start calling tools with missing
+#      or wrong arg keys and the failures will look like "the model is
+#      bad" instead of "we changed the description format".
+# ---------------------------------------------------------------------------
+
+
+def test_description_carries_summary_and_schema():
+    tool = MCPTool(
+        name="zendesk_create_ticket",
+        description="Create a new Zendesk support ticket.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string"},
+                "body": {"type": "string"},
+            },
+            "required": ["subject", "body"],
+        },
+    )
+    out = build_tool_description(tool)
+    assert "Create a new Zendesk support ticket." in out
+    # The full schema must be present (LLM uses it to know which keys
+    # to put in the ``arguments`` dict).
+    assert '"subject"' in out
+    assert '"body"' in out
+    assert "Input schema (JSON):" in out
+
+
+def test_description_handles_missing_summary():
+    """If the tool publishes no description at all, the LLM still needs
+    the schema — emit just the schema block rather than ``None`` or
+    an empty string."""
+    tool = MCPTool(
+        name="anonymous_tool",
+        description="",
+        input_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+    )
+    out = build_tool_description(tool)
+    assert out.startswith("Input schema (JSON):")
+    assert '"x"' in out
+
+
+def test_description_handles_missing_schema():
+    """A no-arg tool produces just the human description — no dangling
+    'Input schema:' line."""
+    tool = MCPTool(
+        name="ping",
+        description="Check service health.",
+        input_schema={},
+    )
+    out = build_tool_description(tool)
+    assert out == "Check service health."
+    assert "Input schema" not in out

--- a/examples/agents/livekit-prototype/tests/test_mg_prompt.py
+++ b/examples/agents/livekit-prototype/tests/test_mg_prompt.py
@@ -1,0 +1,255 @@
+"""Tests for ``mg_prompt`` — the runtime compiled-prompt fetcher.
+
+The prototype agent's whole point is to fetch the latest compiled prompt at
+session start, so every error path here corresponds to a visible failure in
+the "Talk to agent" dashboard flow:
+
+  * 401 → "your API key is wrong, fix it in the env"
+  * 404 → "the agent that owns this key is gone"
+  * compiledInstructions=None → "click Compile in the dashboard"
+  * 5xx / non-JSON → "ModelGuide is misbehaving — surface and retry"
+
+We mock httpx with an in-process transport so the tests never touch a
+real network and run synchronously fast in CI.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mg_prompt import (
+    AgentSelf,
+    MissingCompiledPrompt,
+    PromptFetchError,
+    PromptFetchUnauthorized,
+    fetch_agent_self,
+    fetch_compiled_prompt,
+)
+
+API_URL = "https://api.modelguide.test"
+API_KEY = "mgk_test_key_for_unit_tests"
+
+
+def _client(handler) -> httpx.AsyncClient:
+    """Build an AsyncClient backed by an in-process MockTransport.
+
+    Each test calls this with a callable that receives the request and
+    returns an ``httpx.Response`` — no real socket is opened.
+    """
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _agent_payload(**overrides):
+    """A complete /api/agents/me response. Override individual fields
+    per test instead of duplicating the shape everywhere."""
+    base = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "Prototype Agent",
+        "slug": "prototype_v1",
+        "description": None,
+        "modality": "voice",
+        "modelFamily": "gpt",
+        "promptConfig": {},
+        "agentPlatform": "livekit",
+        "isActive": True,
+        "evalSuiteCount": 0,
+        "secrets": {},
+        "hasElevenLabsKey": False,
+        "hasWebhookSecret": False,
+        "keyPrefix": None,
+        "compiledInstructions": "You are a helpful prototype assistant.",
+        "compiledAt": "2025-01-01T00:00:00.000Z",
+        "compiledFrom": None,
+        "createdAt": "2025-01-01T00:00:00.000Z",
+        "updatedAt": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_agent_self_on_200():
+    """The fetcher parses the API response into AgentSelf verbatim."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # Verify the request shape the worker sends — if this drifts, the
+        # API's auth middleware won't accept the request.
+        assert req.method == "GET"
+        assert req.url.path == "/api/agents/me"
+        assert req.headers["authorization"] == f"Bearer {API_KEY}"
+        return httpx.Response(200, json=_agent_payload())
+
+    async with _client(handler) as c:
+        result = await fetch_agent_self(API_URL, API_KEY, client=c)
+
+    assert isinstance(result, AgentSelf)
+    assert result.id == "00000000-0000-0000-0000-000000000001"
+    assert result.slug == "prototype_v1"
+    assert result.modality == "voice"
+    assert result.agent_platform == "livekit"
+    assert result.is_active is True
+    assert result.compiled_instructions == "You are a helpful prototype assistant."
+    assert result.compiled_at == "2025-01-01T00:00:00.000Z"
+
+
+@pytest.mark.asyncio
+async def test_fetch_compiled_prompt_returns_just_the_string():
+    """The convenience wrapper returns the instructions, not the full object."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_agent_payload(compiledInstructions="ROLE: hard-coded prompt"),
+        )
+
+    async with _client(handler) as c:
+        prompt = await fetch_compiled_prompt(API_URL, API_KEY, client=c)
+
+    assert prompt == "ROLE: hard-coded prompt"
+
+
+@pytest.mark.asyncio
+async def test_strips_trailing_slash_from_api_url():
+    """Operators set MODELGUIDE_API_URL either with or without a trailing slash.
+
+    The fetcher normalizes both — otherwise the request URL has a duplicate
+    slash and some reverse proxies will 404 it.
+    """
+    seen_paths: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen_paths.append(req.url.path)
+        return httpx.Response(200, json=_agent_payload())
+
+    async with _client(handler) as c:
+        await fetch_agent_self(f"{API_URL}/", API_KEY, client=c)
+
+    assert seen_paths == ["/api/agents/me"]
+
+
+# ---------------------------------------------------------------------------
+# Auth failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raises_unauthorized_on_401():
+    """A bad API key surfaces as PromptFetchUnauthorized — a distinct type
+    so the worker can show "fix your env key" instead of "retry later"."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid token"})
+
+    async with _client(handler) as c:
+        with pytest.raises(PromptFetchUnauthorized):
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+
+
+@pytest.mark.asyncio
+async def test_raises_unauthorized_on_404():
+    """If /me returns 404 the agent record is gone (deleted after the key
+    was minted). We map 404 to Unauthorized because, from the worker's
+    perspective, it's the same "your key no longer identifies a valid
+    agent" condition."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "agent not found"})
+
+    async with _client(handler) as c:
+        with pytest.raises(PromptFetchUnauthorized):
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+
+
+# ---------------------------------------------------------------------------
+# Missing compile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raises_missing_compiled_when_instructions_null():
+    """The agent exists but has never been compiled — the dashboard's
+    Compile button wasn't clicked. Raise so the worker can tell the
+    operator exactly what to do instead of dispatching a generic LLM."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_agent_payload(compiledInstructions=None, compiledAt=None),
+        )
+
+    async with _client(handler) as c:
+        with pytest.raises(MissingCompiledPrompt):
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+
+
+@pytest.mark.asyncio
+async def test_raises_missing_compiled_when_instructions_empty():
+    """Defensive: treat an empty string the same as None. An empty system
+    prompt silently degrades the LLM to a generic assistant — worse UX
+    than a clear failure."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_agent_payload(compiledInstructions=""))
+
+    async with _client(handler) as c:
+        with pytest.raises(MissingCompiledPrompt):
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+
+
+# ---------------------------------------------------------------------------
+# Bad responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raises_on_500():
+    """5xx is a server problem, not an auth problem. Use the generic
+    PromptFetchError so the worker can apply a different retry policy
+    than for 401s."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="internal error")
+
+    async with _client(handler) as c:
+        with pytest.raises(PromptFetchError) as info:
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+        # Auth-class errors are PromptFetchUnauthorized; 500 must not
+        # accidentally route through that branch.
+        assert not isinstance(info.value, PromptFetchUnauthorized)
+
+
+@pytest.mark.asyncio
+async def test_raises_on_non_json_body():
+    """A misrouted request that hits the UI's index.html instead of the
+    API would return 200 + HTML. Catch this here instead of letting the
+    JSON parser explode mid-LLM-init."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"<html>not the api</html>",
+            headers={"content-type": "text/html"},
+        )
+
+    async with _client(handler) as c:
+        with pytest.raises(PromptFetchError):
+            await fetch_agent_self(API_URL, API_KEY, client=c)
+
+
+@pytest.mark.asyncio
+async def test_raises_on_array_body():
+    """The /me endpoint must return an object — if it ever returns a
+    list (refactor regression), bail before treating it as a dict."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    async with _client(handler) as c:
+        with pytest.raises(PromptFetchError):
+            await fetch_agent_self(API_URL, API_KEY, client=c)

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -459,6 +461,53 @@ router.openapi(platformModelsRoute, async (c) => {
   }
 
   throw Errors.invalidInput(`Unsupported platform: ${platform}`);
+});
+
+// ============================================================================
+// Self-Introspection (Agent API key only)
+//
+// `GET /me` returns the agent identified by the calling `mgk_…` API key.
+// Used by the livekit-prototype worker (see examples/agents/livekit-prototype/)
+// to fetch the latest compiled prompt at session start so the worker picks up
+// new compiles without redeploying. Production workers should still bake the
+// prompt into their image (ADR-014); this endpoint is the runtime-fetch
+// escape hatch the prototype relies on. See ADR-015.
+//
+// Defined here (before the dynamic `:id` routes) so the literal "/me" path
+// is matched first by Hono's router. The route uses agent API key auth
+// (`requireAgent`), so user JWTs are rejected with 401.
+// ============================================================================
+
+router.get("/me", requireAgent(), requireOrganization());
+
+const meRoute = createRoute({
+  method: "get",
+  path: "/me",
+  tags: ["Agents"],
+  summary: "Get the calling agent (API key self-introspection)",
+  description:
+    "Returns the agent identified by the API key in the Authorization header. Intended for voice/chat workers that need their own compiled prompt at runtime. Rejects user JWTs — this endpoint is agent-only.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Agent detail for the API key's owning agent",
+      content: {
+        "application/json": { schema: agentResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated as an agent"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(meRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  // Reuse the same loader / formatter as `GET /:id` so the response shape is
+  // identical. The worker can treat `me` and `/:id` interchangeably.
+  const fullAgent = await getAgentById(orgId, agent.id);
+
+  return c.json(formatAgent(fullAgent), 200);
 });
 
 // ============================================================================

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,12 +8,19 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
 let orgASupportHeaders: Record<string, string>;
 let orgBAdminHeaders: Record<string, string>;
+let orgAAgentHeaders: Record<string, string>;
+let orgBAgentHeaders: Record<string, string>;
 
 /** IDs of agents created during tests (for cleanup) */
 const createdAgentIds: string[] = [];
@@ -27,6 +34,8 @@ beforeAll(async () => {
   orgAAdminHeaders = await authHeadersFor(s.orgAAdmin);
   orgASupportHeaders = await authHeadersFor(s.orgASupport);
   orgBAdminHeaders = await authHeadersFor(s.orgBAdmin);
+  orgAAgentHeaders = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+  orgBAgentHeaders = await agentHeadersFor(s.orgBAgentId, s.orgB.id);
 });
 
 afterAll(async () => {
@@ -190,6 +199,118 @@ describe("POST /api/agents", () => {
     });
 
     expect(response.status).toBe(422);
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me - Agent self-introspection (API key auth)
+//
+// Used by the livekit-prototype worker to fetch its own compiled prompt at
+// runtime so the worker can pick up the latest compile without redeploying.
+// See ADR-015 for the rationale (prototype-only — production agents still
+// bake the prompt into the worker image per ADR-014).
+// ============================================================================
+
+describe("GET /api/agents/me", () => {
+  test("returns the calling agent with API key auth (200)", async () => {
+    const response = await request("/api/agents/me", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.name).toBeDefined();
+    expect(body.slug).toBeDefined();
+    expect(body.modality).toBeDefined();
+    expect(body.agentPlatform).toBeDefined();
+    expect(body.isActive).toBe(true);
+    // Compile state — null is valid (agent may not have been compiled yet)
+    expect("compiledInstructions" in body).toBe(true);
+    expect("compiledAt" in body).toBe(true);
+    expect("compiledFrom" in body).toBe(true);
+    expect(body.promptConfig).toBeDefined();
+  });
+
+  test("does not leak secret material (api keys, secret refs only)", async () => {
+    const response = await request("/api/agents/me", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    // The agent's own response must never include a plaintext API key,
+    // decrypted secret values, or webhook HMAC. If any of these surface
+    // the worker (which runs in a less-trusted env than the API) becomes
+    // a credential exfil vector.
+    expect(body.apiKey).toBeUndefined();
+    expect(body.webhook_hmac_secret).toBeUndefined();
+    // `secrets` is a ref map of UUIDs only — never decrypted values
+    if (body.secrets) {
+      for (const value of Object.values(body.secrets)) {
+        expect(typeof value).toBe("string");
+        // UUIDs only — no raw key material
+        expect(value as string).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        );
+      }
+    }
+  });
+
+  test("isolates cross-org agents (orgB key returns orgB agent only)", async () => {
+    const response = await request("/api/agents/me", {
+      headers: orgBAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    // The orgB API key must return the orgB agent — never the orgA agent.
+    // This is the load-bearing isolation property: a leaked org-B key
+    // cannot enumerate org-A agents through this endpoint.
+    expect(body.id).toBe(s.orgBAgentId);
+    expect(body.id).not.toBe(s.orgAAgentId);
+  });
+
+  test("rejects user JWT auth (401)", async () => {
+    // Admin/support JWTs MUST NOT work here — this endpoint identifies
+    // the *agent*, not a user. A user JWT carries no agent context, so
+    // there is no "me" to return.
+    const response = await request("/api/agents/me", {
+      headers: orgAAdminHeaders,
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me");
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects malformed API key (401)", async () => {
+    const response = await request("/api/agents/me", {
+      headers: {
+        Authorization: "Bearer mgk_definitely_not_a_real_key_aaaaaaaa",
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("does not collide with GET /:id route (uuid-only param)", async () => {
+    // Sanity: confirm the literal "/me" path is not interpreted as an
+    // agent ID by the dynamic `/:id` route. If route ordering ever
+    // regresses, the request will fail validation against the UUID
+    // schema and return 422 instead of hitting the /me handler.
+    const response = await request("/api/agents/me", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
   });
 });
 

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
@@ -169,6 +169,30 @@ describe('VoiceTestPanel', () => {
     })
   })
 
+  it('shows the compile-freshness hint when a compiledAt is set', () => {
+    // The hint exists so operators using a runtime-fetch worker
+    // (livekit-prototype, ADR-015) can see at a glance whether the
+    // worker would dispatch with a stale or fresh prompt. Pinning the
+    // presence of the data-testid here so the hint can't be silently
+    // removed in a refactor.
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+    const hint = screen.getByTestId('voice-test-compile-hint')
+    expect(hint).toHaveTextContent(/latest compile/i)
+    expect(hint).toHaveTextContent(/runtime-fetch/i)
+  })
+
+  it('shows a no-compile warning when compiledAt is null', () => {
+    const noPrompt = {
+      ...configuredAgent,
+      compiledInstructions: null,
+      compiledAt: null,
+    } as Agent
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={noPrompt} canMutate />, { wrapper })
+    expect(screen.getByTestId('voice-test-compile-hint')).toHaveTextContent(/no compiled prompt/i)
+  })
+
   it('surfaces a clear error when mic permission is denied', async () => {
     stubMicPermission(false)
     render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
@@ -23,12 +23,13 @@
 
 import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
 import { useMutation } from '@tanstack/react-query'
-import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { AlertTriangle, FileCode, Mic, Radio } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { api } from '~/lib/api'
+import { formatDate } from '~/lib/utils'
 import type { Agent, VoiceTestTokenResponse } from '~/schemas/agents'
 
 import { ensureMicPermission } from './voice-test/mic-permission'
@@ -163,6 +164,35 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
             Configure the LiveKit URL, API key, and secret for this agent before testing.
           </div>
         )}
+
+        {livekitConfigured ? (
+          /*
+           * Compile freshness hint — surfaces compiledAt next to the
+           * "Talk to agent" button so the operator can see what the
+           * worker would pick up. Only meaningful for the prototype
+           * worker (livekit-prototype, ADR-015) which fetches the prompt
+           * at runtime; production workers (livekit-agent, ADR-014)
+           * still use their baked-in prompt regardless of what's shown
+           * here. We don't gate the hint on worker type because the UI
+           * doesn't know which worker is configured.
+           */
+          <div
+            className="mt-3 flex items-center gap-2 text-xs text-fg-muted"
+            data-testid="voice-test-compile-hint"
+          >
+            <FileCode className="h-3.5 w-3.5" />
+            {agent.compiledAt ? (
+              <span>
+                Latest compile: {formatDate(agent.compiledAt, { format: 'relative' })}
+                {' — '}runtime-fetch workers will use this prompt.
+              </span>
+            ) : (
+              <span className="text-warning">
+                No compiled prompt yet — runtime-fetch workers will fall back to a placeholder.
+              </span>
+            )}
+          </div>
+        ) : null}
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
           {showStartButton ? (


### PR DESCRIPTION
## Summary

POC for a LiveKit voice agent that picks up the **latest compiled prompt** on the next "Talk to agent" click — no worker redeploy. The existing dashboard flow (Compile → Talk to agent) keeps working unchanged; only the worker behind it differs.

Today, testing a freshly-compiled prompt requires rebuilding and redeploying the worker image (minutes per attempt). With the prototype, the loop is `Compile → Talk` and you hear the new prompt seconds later.

## What's in this PR

**1. New API endpoint** — `GET /api/agents/me`
- Agent-API-key self-introspection. Returns the same shape as `GET /:id`, scoped to the calling agent.
- Pinned by 7 new integration assertions: happy path, no secret leakage, cross-org isolation, JWT rejection, malformed-key handling, route-collision sanity vs `/:id`.

**2. New worker** — `examples/agents/livekit-prototype/` (~200 lines)
- On session start: `GET /api/agents/me` → use `compiledInstructions` as system prompt.
- MCP `ListTools` at session start → wrap each tool as a dynamic LiveKit `@function_tool`, so whatever connectors the operator has wired up just show up.
- Existing voice-test-token dispatch (ADR-014) routes here unchanged — just point `metadata.livekit.agentName` at this worker.
- 15 Python tests using `httpx.MockTransport` (no LiveKit, no network) covering every HTTP error class and pinning the LLM-facing tool-description format.

**3. UI tweak** — compile-freshness hint in `VoiceTestPanel`
- Small line under the Talk to agent button: `Latest compile: 2m ago — runtime-fetch workers will use this prompt.`
- 2 new tests pin this hint so it can't be silently removed.

**4. Documentation**
- [`docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md`](docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md) — full design, security posture, and explicit acceptance of the trade-off vs ADR-014's "no prompt in dispatch" position.
- `examples/agents/livekit-prototype/README.md` — quickstart, architecture, and a "what's NOT in scope" table vs the production worker.
- Root `README.md` — new row in the runtime table.

## Trade-off (key reason for an ADR)

[ADR-014](docs/decisions/014-browser-voice-testing.md) deliberately rejected shipping prompts via dispatch metadata, citing drift-in-testing risk. This PR doesn't reopen that decision — it adds a **separate prototype worker** for iteration that goes through the standard agent-auth REST surface instead of dispatch metadata. Production workers keep the baked-prompt invariant. The README and ADR both scope the prototype to iteration only and list what's missing vs the production worker (SIP, transcript posting, Langfuse, hang-up state machine, stubbed tools).

## Test plan

- [x] `make api-test-unit` — 896 tests pass (was 896, +0 unit tests since the new endpoint is integration-tested)
- [x] `make api-typecheck` — clean
- [x] `make api-lint-check` — clean
- [x] `make ui-test` — 270 tests pass (was 268, +2 for compile-hint)
- [x] `make ui-typecheck` — clean
- [x] `make ui-lint` — clean
- [x] `cd examples/agents/livekit-prototype && pytest tests/` — 15 tests pass
- [ ] `make api-test-integration` — needs running Postgres; CI to verify the 7 new `GET /api/agents/me` cases
- [ ] Manual: in dashboard, set `metadata.livekit.agentName` to `mg-prototype`, click Compile, then Talk to agent. Verify the worker picks up the new prompt (compare worker logs `Loaded compiled prompt from ModelGuide (compiledAt=…)`).

## Files

```
docs/decisions/015-livekit-prototype-runtime-prompt-fetch.md   (+157 NEW)
examples/agents/livekit-prototype/                              (+14 files NEW)
  src/{agent,config,mg_prompt,mg_mcp,providers}.py
  tests/{test_mg_prompt,test_mg_mcp}.py
  README.md, .env.example, Dockerfile, pyproject.toml, .gitignore
modelguide-api/src/features/agents/agents.routes.ts            (+52)
modelguide-api/tests/integration/agents.test.ts                (+110)
modelguide-ui/src/features/agents/components/voice-test-panel.tsx       (+30)
modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx  (+22)
Makefile                                                       (+14)
README.md                                                       (+1)
```

https://claude.ai/code/session_01SRhr5ZpFAjMoD5tvBxUV7h

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRhr5ZpFAjMoD5tvBxUV7h)_