### PR TITLE
feat(livekit): POC agent that loads its compiled prompt from MG on every session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help quickstart api-install api-dev api-build api-start api-test api-test-unit api-test-integration api-typecheck api-lint api-lint-check api-format sync-connectors ui-install ui-dev ui-test ui-typecheck ui-lint ui-format db-up db-down db-generate db-migrate db-push db-studio db-seed demo-enable demo-disable clean reset tunnel logs docker-up docker-down docker-logs docker-rebuild docker-reset docker-expose lk-agent-setup lk-agent-console lk-agent-dev livekit-up livekit-up-docker livekit-down livekit-token
+.PHONY: help quickstart api-install api-dev api-build api-start api-test api-test-unit api-test-integration api-typecheck api-lint api-lint-check api-format sync-connectors ui-install ui-dev ui-test ui-typecheck ui-lint ui-format db-up db-down db-generate db-migrate db-push db-studio db-seed demo-enable demo-disable clean reset tunnel logs docker-up docker-down docker-logs docker-rebuild docker-reset docker-expose lk-agent-setup lk-agent-console lk-agent-dev livekit-up livekit-up-docker livekit-down livekit-token lk-poc-setup lk-poc-dev lk-poc-test
 
 .DEFAULT_GOAL := help
 
@@ -195,3 +195,20 @@ livekit-down: ## [LiveKit] Stop Docker LiveKit server
 
 livekit-token: ## [LiveKit] Generate token and open meet.livekit.io (NAME=yourname)
 	lk token create --api-key devkey --api-secret secret --room test-room --identity $(or $(NAME),artur) --join --valid-for 1h --agent $(LK_AGENT_NAME) --open meet
+
+# =============================================================================
+# LiveKit POC Agent — dashboard-driven prompt (ADR-015)
+# (examples/agents/modelguide-livekit-poc-agent)
+# =============================================================================
+
+LK_POC_DIR := examples/agents/modelguide-livekit-poc-agent
+LK_POC_NAME ?= modelguide-poc
+
+lk-poc-setup: ## [LK POC] Install deps and download model files
+	cd $(LK_POC_DIR) && uv sync && uv run python src/agent.py download-files
+
+lk-poc-dev: ## [LK POC] Run in WebRTC dev mode (uses compiled prompt from MG dashboard)
+	cd $(LK_POC_DIR) && uv run python src/agent.py dev --log-level $(LK_LOG_LEVEL)
+
+lk-poc-test: ## [LK POC] Run Python unit tests for the POC agent
+	cd $(LK_POC_DIR) && uv run pytest tests/ -v

--- a/docs/decisions/015-livekit-dynamic-prompt-loading.md
+++ b/docs/decisions/015-livekit-dynamic-prompt-loading.md
@@ -1,0 +1,168 @@
+# ADR-015: LiveKit Worker Fetches Compiled Prompt at Session Start
+
+**Status:** Accepted
+
+## Context
+
+ADR-014 shipped the "Talk to agent" voice-test flow but deliberately left
+the prompt out of dispatch metadata. The reasoning was sound: putting a
+prompt into the dispatch payload creates "works in voice-test, broke in
+prod" drift, plus the dispatch metadata is byte-bounded.
+
+That left a real gap. From the operator's perspective:
+
+1. Edit the SOP / persona in the dashboard.
+2. Hit **Compile**. A fresh `compiledInstructions` lands in the DB.
+3. Hit **Talk to agent**. The browser joins a room with the dispatched
+   worker.
+4. The worker speaks using the prompt that was **baked into its container
+   image** the last time the worker was deployed. The compile in step 2
+   is invisible to the call.
+
+The closed feedback loop the operator expected — edit, compile, talk,
+hear the change — never happened. The only way to actually exercise a
+new prompt against the live worker was to build a new image, redeploy,
+and re-dispatch. That's a 5+ minute cycle for what is supposed to be a
+< 30 second iteration.
+
+We need a way to test the latest compiled prompt from the dashboard
+without redeploying the worker, **without** reintroducing the failure
+modes ADR-014 rejected.
+
+## Decision
+
+Add a new endpoint, `GET /api/agents/me/runtime-config`, and have the
+LiveKit worker call it once at the top of each session entrypoint.
+"Sync" in the operator's mental model maps to the existing Compile
+action: compiling persists `compiledInstructions`; the very next
+"Talk to agent" click dispatches a fresh worker; that worker fetches
+and uses the fresh prompt.
+
+### The endpoint
+
+| Property        | Value                                                                  |
+| --------------- | ---------------------------------------------------------------------- |
+| Method + path   | `GET /api/agents/me/runtime-config`                                    |
+| Auth            | Agent API key (`mgk_*`) via `requireAgent()` — user JWT is rejected   |
+| Agent identity  | Taken from the auth context — no path param to spoof                  |
+| Response shape  | `{ id, name, slug, modality, compiledInstructions, compiledAt, promptConfig }` |
+| Errors          | 401 (no/invalid key), 404 (agent deleted between key issue and fetch)  |
+
+The response is deliberately narrow. It excludes the secrets ref map,
+the full `metadata` blob (LiveKit URLs, ElevenLabs config, legacy
+`webhook_hmac_secret`), and the `organizationId`. A worker that logs its
+runtime config — for debugging — cannot accidentally leak sensitive
+material. The shape is locked by two unit tests
+(`tests/unit/agents/runtime-config.test.ts`) and an integration test that
+exercises both the happy path and the auth boundary
+(`tests/integration/agents.test.ts` → `GET /api/agents/me/runtime-config`).
+
+### The worker side
+
+The POC agent (`examples/agents/modelguide-livekit-poc-agent`) calls
+`fetch_runtime_config()` in parallel with `ctx.wait_for_participant()`,
+so the round-trip is hidden under the LiveKit connect/dispatch handshake
+that's already in flight. There is no baked-in system prompt; if the
+fetch returns `compiledInstructions: null` (operator hasn't compiled
+yet), the worker greets with a "your compiled prompt isn't loaded —
+hit Compile and try again" fallback so the call connects and the
+operator hears something actionable rather than dead air.
+
+Existing workers (`examples/agents/livekit-agent` / BuildPro Sam) are
+unaffected — they continue to use their baked-in prompt + MCP tools.
+The POC is a separate scaffold, not a migration of the existing agent.
+
+### Why this is NOT what ADR-014 rejected
+
+ADR-014's rejected pattern was **injecting a prompt into dispatch
+metadata** as a one-shot override. The concerns were:
+
+1. *Voice-test/prod drift.* The injected prompt only existed in the
+   metadata of the voice-test dispatch. The worker's "real" prompt was
+   different — what you tested wasn't what production ran.
+2. *Byte budgets.* Dispatch metadata has a 48 KB cap; bounded prompts
+   required ~100 LOC of size guards.
+3. *Authority lives in the wrong place.* The worker's profile is what
+   prod actually runs against; metadata-injected prompts were a
+   second source of truth that could disagree.
+
+The new pattern inverts that:
+
+- **The dashboard's `compiledInstructions` IS the authoritative prompt.**
+  Production traffic and voice-test traffic both consume the same value.
+  There is no second source of truth.
+- **The prompt never crosses the dispatch boundary.** It's pulled by
+  the worker over an authenticated HTTPS call, scoped by the worker's
+  own API key. No byte caps on metadata.
+- **There is no "voice-test override."** What the operator tests is what
+  every other caller of that worker sees, by construction.
+
+The trade-off this introduces — and ADR-014 didn't have to wrestle
+with — is that this pattern only works for workers built to fetch
+their prompt at runtime. The existing baked-prompt workers are unaffected
+and don't need to change.
+
+## Alternatives Considered
+
+**Push the prompt to the worker via a "deploy" call from the dashboard.**
+Rejected. Would require a control channel from the API back to the
+worker (or to LiveKit Cloud as an intermediary), adding state that has
+to be kept in sync. Pulling from a stateless endpoint is simpler and
+already happens during the dispatch handshake window.
+
+**Cache the prompt in the worker for N seconds across sessions.**
+Rejected for the POC. Adds a "wait, did the cache invalidate?" failure
+mode that breaks the "compile, talk, hear the change" promise. The
+fetch is one HTTPS call to the same network as MCP; it doesn't merit
+caching at this scale.
+
+**Embed the prompt in dispatch metadata with a size guard.**
+Rejected — exactly the pattern ADR-014 ruled out, and the operator
+ergonomics aren't materially better than a fetch.
+
+**Reuse `GET /api/agents/:id`.**
+Rejected. That endpoint is JWT-gated and leaks the secrets ref map,
+the full `metadata` blob, and the `organizationId`. Loosening it to
+accept agent API keys would widen the dashboard surface to worker
+identity, the opposite of what we want.
+
+## Consequences
+
+- **The "edit, compile, talk" iteration is now real.** From compile to
+  hearing the new prompt is one click + the LiveKit dispatch handshake
+  (~2s end-to-end), no redeploy.
+- **The worker becomes thinner.** With the prompt sourced from the
+  dashboard, building a new voice-agent persona becomes a dashboard
+  config exercise, not a code change + deploy.
+- **There's a new API surface to defend.** `/agents/me/runtime-config`
+  is agent-authenticated and returns prompt material. If we ever add
+  fields here (knowledge-base snippets, evaluator hints), they're
+  visible to the worker's API key — keep that in mind when picking
+  what to include.
+- **Existing baked-prompt workers are unaffected.** ADR-014's voice-test
+  flow continues to work as documented; this ADR adds a parallel path
+  for workers that opt into the fetch pattern.
+
+## Known limitations (this is a POC)
+
+- **No prompt cache, no etag.** Every session boot does a full fetch.
+  Fine at single-digit RPS; would want an etag + a few-second TTL at
+  10+ RPS to spare the DB.
+- **No fallback to a baked prompt.** If the MG API is unreachable at
+  session boot, the call fails. Production workers should layer a
+  baked-in last-known-good prompt under the fetch so an MG outage
+  doesn't black-hole voice traffic.
+- **No tool catalog in the runtime config.** This POC has no tools at
+  all. A future iteration will need to return enabled connector tools
+  in the same response so the worker doesn't have to wire that up
+  per-deploy.
+
+## Related
+
+- **ADR-014:** Browser Voice Testing via LiveKit Dispatch — the
+  "no prompt in metadata" decision this ADR works around (not
+  contradicts) via a fetch instead of an injection.
+- **ADR-011:** LiveKit Outbound Calls — the dispatch + token pattern
+  both this and ADR-014 extend.
+- **PR:** initial POC implementation — adds the endpoint, the POC
+  agent, the voice-test UI affordance, the ADR, and the tests.

--- a/examples/agents/modelguide-livekit-poc-agent/.dockerignore
+++ b/examples/agents/modelguide-livekit-poc-agent/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.cache/
+tests/
+README.md

--- a/examples/agents/modelguide-livekit-poc-agent/.env.example
+++ b/examples/agents/modelguide-livekit-poc-agent/.env.example
@@ -1,0 +1,29 @@
+# Worker identity — set this to the `agentName` configured on the MG agent's
+# LiveKit panel. The MG voice-test dispatch routes by this name.
+AGENT_NAME=modelguide-poc
+
+# LiveKit Cloud injects these automatically. For local dev with
+# `livekit-server --dev`, the built-in devkey/secret on ws://localhost:7880
+# work as-is.
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# OpenAI LLM
+OPENAI_API_KEY=sk-your-openai-key
+# Override the default (gpt-4.1-mini) if you want.
+# LLM_MODEL=gpt-4.1-mini
+
+# Deepgram STT
+DEEPGRAM_API_KEY=your-deepgram-key
+
+# ElevenLabs TTS
+ELEVENLABS_API_KEY=your-elevenlabs-key
+# Optional voice override — defaults to "Chris" (iP95p4xoKVk53GoZ742B).
+# ELEVENLABS_VOICE_ID=
+
+# ModelGuide — the agent fetches its compiled prompt from this URL on every
+# session start. MODELGUIDE_API_KEY is the agent's `mgk_*` API key (shown
+# once at agent creation in the dashboard; rotate via Regenerate Key).
+MODELGUIDE_API_URL=http://localhost:3000
+MODELGUIDE_API_KEY=mgk_your-agent-key-here

--- a/examples/agents/modelguide-livekit-poc-agent/.gitignore
+++ b/examples/agents/modelguide-livekit-poc-agent/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.cache/

--- a/examples/agents/modelguide-livekit-poc-agent/Dockerfile
+++ b/examples/agents/modelguide-livekit-poc-agent/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Download VAD + turn-detector model files at build time so cold-starts
+# don't stall on a network fetch on first session.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/agent.py", "start"]

--- a/examples/agents/modelguide-livekit-poc-agent/README.md
+++ b/examples/agents/modelguide-livekit-poc-agent/README.md
@@ -1,0 +1,127 @@
+# ModelGuide LiveKit POC Agent
+
+A minimal LiveKit voice agent whose **entire system prompt comes from the
+ModelGuide dashboard**. There is no baked-in prompt in this image — on every
+session, the agent calls `GET /api/agents/me/runtime-config` and uses the
+agent's latest compiled prompt as its instructions.
+
+This closes the dashboard ⇄ deployed-agent loop:
+
+```
+┌──────────────────┐    Compile     ┌────────────────────┐
+│ ModelGuide UI    │  ───────────▶  │ agent.compiledInstr│
+│ (prompt editor)  │                │ (DB, authoritative)│
+└──────────────────┘                └─────────┬──────────┘
+                                              │ fetch on boot
+                                              ▼
+                                    ┌────────────────────┐
+                                    │ LiveKit POC worker │
+                                    │ (this package)     │
+                                    └─────────┬──────────┘
+                                              │ WebRTC
+                                              ▼
+                                       Operator's browser
+                                       ("Talk to agent")
+```
+
+**What "Sync" means here:** Hitting Compile in the dashboard persists a new
+`compiledInstructions` on the agent row. The next "Talk to agent" click in
+the voice-test panel dispatches this worker; the worker fetches the row;
+the call uses the freshest prompt. No redeploy, no dispatch-metadata round-trip.
+
+See **[ADR-015](../../../docs/decisions/015-livekit-dynamic-prompt-loading.md)**
+for the design rationale (and why this approach does not contradict
+[ADR-014](../../../docs/decisions/014-browser-voice-testing.md)'s "no prompt
+in dispatch metadata" stance).
+
+---
+
+## What this POC deliberately is and isn't
+
+**Is:**
+- A reference for the worker-fetches-prompt pattern
+- A scaffold you can fork to wire dashboard-driven prompts into any
+  LiveKit-based voice agent
+- Deployable to LiveKit Cloud as-is (Dockerfile + `livekit.toml`)
+
+**Isn't:**
+- A production agent — no MCP tools, no SOPs, no telephony, no retries
+- A replacement for `examples/agents/livekit-agent` (BuildPro Sam), which
+  still uses a baked-in prompt and ships an 11-tool MCP integration
+
+## Stack
+
+| Component       | Service                     |
+| --------------- | --------------------------- |
+| Transport       | LiveKit Cloud WebRTC        |
+| VAD             | Silero                      |
+| Turn detection  | English EOU model           |
+| STT             | Deepgram Nova-3             |
+| LLM             | OpenAI GPT-4.1-mini         |
+| TTS             | ElevenLabs Flash v2.5       |
+| Instructions    | **ModelGuide compiled prompt (fetched per session)** |
+
+## Quick start (local)
+
+```bash
+# 1. Install deps + download VAD/turn-detector models
+cd examples/agents/modelguide-livekit-poc-agent
+uv venv && uv pip install --python .venv/bin/python "."
+uv run --python .venv/bin/python python src/agent.py download-files
+
+# 2. Configure
+cp .env.example .env
+# Fill in OPENAI_API_KEY, DEEPGRAM_API_KEY, ELEVENLABS_API_KEY,
+# MODELGUIDE_API_URL, MODELGUIDE_API_KEY (the mgk_ key shown at agent
+# creation in the dashboard).
+
+# 3. Three terminals:
+#    Terminal 1: livekit-server --dev
+#    Terminal 2: uv run python src/agent.py dev
+#    Terminal 3: from the ModelGuide dashboard → Agent → Voice Test → Talk
+```
+
+In the dashboard:
+
+1. Open the agent.
+2. **Compile the prompt** from a SOP (Compiled tab → Compile Prompt).
+3. Click **Talk to agent** in the Voice Test panel.
+
+The worker will log a line like:
+
+```
+mg_client | INFO | Runtime config: agent=… slug=… compiled_at=2026-05-20T12:00:00Z has_prompt=True
+```
+
+confirming it fetched the prompt you just compiled.
+
+## Tests
+
+```bash
+.venv/bin/python -m pytest tests/ -v
+```
+
+Six unit tests covering the `RuntimeConfig` decoder, the compiled/fallback
+prompt selection, and the HTTP wiring (Authorization header, 401 handling).
+No network required — `respx` intercepts.
+
+## LiveKit Cloud deploy
+
+1. Fill in `livekit.toml` (subdomain).
+2. Set `OPENAI_API_KEY`, `DEEPGRAM_API_KEY`, `ELEVENLABS_API_KEY`,
+   `MODELGUIDE_API_URL`, `MODELGUIDE_API_KEY`, and `AGENT_NAME` in the
+   LiveKit Cloud secrets UI.
+3. `lk agent deploy` from this directory.
+4. In ModelGuide: open the agent → LiveKit panel → set the URL and the
+   `agentName` to match `AGENT_NAME` → Save.
+5. Compile a prompt → Talk to agent.
+
+## Where the magic lives
+
+| File              | Role                                                |
+| ----------------- | --------------------------------------------------- |
+| `src/agent.py`    | Entrypoint: fetch runtime config in parallel with `wait_for_participant`, then build the `AgentSession` with the compiled instructions. |
+| `src/mg_client.py`| HTTP client. `fetch_runtime_config()` + `RuntimeConfig.resolved_instructions()` are the two functions worth reading. |
+| `src/config.py`   | Env vars + the "no compiled prompt yet" fallback. |
+
+The whole "use dashboard prompt" loop is ~30 lines, end to end.

--- a/examples/agents/modelguide-livekit-poc-agent/livekit.toml
+++ b/examples/agents/modelguide-livekit-poc-agent/livekit.toml
@@ -1,0 +1,7 @@
+# LiveKit Cloud deploy config — replace `subdomain` with your project's and
+# leave `id` empty until first deploy (LiveKit fills it in).
+[project]
+  subdomain = ""
+
+[agent]
+  id = ""

--- a/examples/agents/modelguide-livekit-poc-agent/pyproject.toml
+++ b/examples/agents/modelguide-livekit-poc-agent/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "modelguide-livekit-poc-agent"
+version = "0.1.0"
+description = "POC LiveKit voice agent that loads its system prompt from ModelGuide on every session (no baked-in prompt)."
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/agents/modelguide-livekit-poc-agent/src/agent.py
+++ b/examples/agents/modelguide-livekit-poc-agent/src/agent.py
@@ -1,0 +1,121 @@
+"""POC LiveKit voice agent — dashboard-driven prompt, no tools.
+
+What this demonstrates:
+
+  1. On every session, the worker fetches the agent's compiled prompt from
+     ModelGuide via ``GET /api/agents/me/runtime-config``.  No prompt is
+     baked into this image.
+  2. "Sync" from the dashboard is the existing Compile action — once the
+     compiled prompt lands in the DB, the very next "Talk to agent" click
+     uses it.  No redeploy, no dispatch-metadata round-trip.
+  3. The flow is platform-agnostic: any STT/LLM/TTS combo works because
+     instructions are the only piece sourced from the dashboard.
+
+What this deliberately does NOT do:
+
+  - No MCP / tool execution.  The point is the prompt-sync loop; tool
+    orchestration is covered by ``examples/agents/livekit-agent``.
+  - No SIP / phone telephony.  WebRTC voice-test only.
+  - No outbound dispatch.  Inbound rooms only.
+
+See ADR-015 and the README.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import deepgram, elevenlabs, openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+import mg_client
+
+VERSION = "0.1.0"
+
+logging.basicConfig(
+    level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("agent")
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    """Per-room entrypoint — runs once per dispatched voice-test session."""
+    config.validate()
+    logger.info("ModelGuide POC agent v%s — entrypoint called", VERSION)
+
+    await ctx.connect()
+
+    # Fetch the dashboard's latest compiled prompt and create a ModelGuide
+    # session in parallel — both hit the same API and shouldn't serialize.
+    runtime_task = asyncio.create_task(mg_client.fetch_runtime_config())
+    session_task = asyncio.create_task(mg_client.create_session("voice-test"))
+    participant_task = asyncio.create_task(ctx.wait_for_participant())
+
+    runtime_cfg = await runtime_task
+    session_id = await session_task
+    participant = await participant_task
+
+    logger.info(
+        "Booting session: agent=%s slug=%s session=%s participant=%s",
+        runtime_cfg.id,
+        runtime_cfg.slug,
+        session_id,
+        participant.identity,
+    )
+
+    # Build the LiveKit Agent with whatever the dashboard says today.
+    voice_agent = Agent(instructions=runtime_cfg.resolved_instructions())
+
+    session = AgentSession(
+        stt=deepgram.STT(model=config.STT_MODEL, api_key=config.DEEPGRAM_API_KEY),
+        llm=openai.LLM(model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY),
+        tts=elevenlabs.TTS(
+            api_key=config.ELEVENLABS_API_KEY,
+            voice_id=config.ELEVENLABS_VOICE_ID,
+        ),
+        vad=silero.VAD.load(),
+        turn_detection=EnglishModel(),
+        allow_interruptions=True,
+        min_interruption_duration=1.0,
+        min_endpointing_delay=0.5,
+    )
+
+    done = asyncio.Event()
+
+    @session.on("close")
+    def _on_close() -> None:
+        done.set()
+
+    @ctx.room.on("disconnected")
+    def _on_disconnect() -> None:
+        done.set()
+
+    await session.start(room=ctx.room, agent=voice_agent)
+
+    # Greet so the caller hears the agent immediately — distinguishes
+    # "compiled prompt loaded" from "compiled prompt missing" without
+    # waiting for the operator to speak first.
+    if runtime_cfg.compiled_instructions:
+        await session.say(f"Connected. {runtime_cfg.name} is listening.")
+    else:
+        await session.say(config.FALLBACK_GREETING)
+
+    try:
+        await done.wait()
+    finally:
+        if session_id:
+            await mg_client.complete_session(session_id)
+        await mg_client.close_http_client()
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/modelguide-livekit-poc-agent/src/config.py
+++ b/examples/agents/modelguide-livekit-poc-agent/src/config.py
@@ -1,0 +1,80 @@
+"""Environment for the POC agent.
+
+Deliberately small surface — five required vars, four optional.  If anything
+is missing, ``validate()`` raises with a single message naming the offenders
+so a fresh deploy fails fast and obviously.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+REQUIRED = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+# Read at import time so livekit.agents.WorkerOptions(agent_name=...) works
+# before validate() is called.
+AGENT_NAME: str = os.getenv("AGENT_NAME", "modelguide-poc")
+
+# Populated by validate()
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+ELEVENLABS_VOICE_ID: str = ""
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+LLM_MODEL: str = "gpt-4.1-mini"
+STT_MODEL: str = "nova-3"
+# Greeting used when the agent has no compiled prompt yet — keeps the demo
+# usable even before the operator hits Compile in the dashboard.
+FALLBACK_GREETING: str = "Hi — your compiled prompt isn't loaded yet."
+# Default instructions used when /me/runtime-config returns null. Lets the
+# call connect and the operator hear *something* instead of dead air.
+FALLBACK_INSTRUCTIONS: str = (
+    "You are a helpful voice assistant. The operator has not compiled a "
+    "prompt for you yet — tell them to open the dashboard, compile the "
+    "agent's prompt, and try again."
+)
+
+_validated = False
+
+
+def validate() -> None:
+    global _validated
+    if _validated:
+        return
+    missing = [v for v in REQUIRED if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+    g = globals()
+    g.update(
+        {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+            "ELEVENLABS_API_KEY": os.environ["ELEVENLABS_API_KEY"],
+            "ELEVENLABS_VOICE_ID": os.getenv(
+                "ELEVENLABS_VOICE_ID", "iP95p4xoKVk53GoZ742B"
+            ),
+            "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+            "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+            "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4.1-mini"),
+            "STT_MODEL": os.getenv("STT_MODEL", "nova-3"),
+        }
+    )
+    _validated = True

--- a/examples/agents/modelguide-livekit-poc-agent/src/mg_client.py
+++ b/examples/agents/modelguide-livekit-poc-agent/src/mg_client.py
@@ -1,0 +1,176 @@
+"""ModelGuide REST client for the POC agent.
+
+Two responsibilities:
+  1. ``fetch_runtime_config`` — pull the agent's latest compiled prompt and
+     metadata via ``GET /api/agents/me/runtime-config`` on every session boot.
+     This is the "sync from the dashboard without redeploy" hook.
+  2. ``create_session`` / ``complete_session`` — minimal session lifecycle
+     so transcripts and feedback can attribute the call.
+
+A shared httpx.AsyncClient lives for the agent process so we get connection
+reuse across sessions.  Tests inject a stub client via ``set_http_client``
+to avoid network in CI.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+import config
+
+logger = logging.getLogger("mg_client")
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    """Mirror of the ``AgentRuntimeConfig`` TypeScript shape (see
+    ``modelguide-api/src/features/agents/runtime-config.ts``).  Kept as a
+    dataclass so tests can construct one directly without round-tripping
+    through HTTP."""
+
+    id: str
+    name: str
+    slug: str
+    modality: str
+    compiled_instructions: str | None
+    compiled_at: str | None
+    prompt_config: dict[str, Any]
+
+    @classmethod
+    def from_api(cls, payload: dict[str, Any]) -> "RuntimeConfig":
+        return cls(
+            id=payload["id"],
+            name=payload["name"],
+            slug=payload["slug"],
+            modality=payload["modality"],
+            compiled_instructions=payload.get("compiledInstructions"),
+            compiled_at=payload.get("compiledAt"),
+            prompt_config=payload.get("promptConfig") or {},
+        )
+
+    def resolved_instructions(self) -> str:
+        """Compiled prompt, or the fallback if the operator hasn't compiled.
+
+        Keeping the fallback here (rather than in agent.py) means tests can
+        assert the "no compiled prompt yet" UX without booting a session.
+        """
+        if self.compiled_instructions and self.compiled_instructions.strip():
+            return self.compiled_instructions
+        return config.FALLBACK_INSTRUCTIONS
+
+
+# ---------------------------------------------------------------------------
+# HTTP client lifecycle
+# ---------------------------------------------------------------------------
+
+_http_client: httpx.AsyncClient | None = None
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {config.MODELGUIDE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Lazy-init the shared client.  Pure-function on first call; reused
+    across sessions in the worker.
+
+    No ``base_url`` — callers pass absolute URLs.  Reason: httpx >=0.28
+    broke cookie extraction with a base_url + relative path combination
+    in some adapter paths (the urllib cookie compat layer chokes on
+    schemeless URLs).  Using absolute URLs everywhere sidesteps it and
+    is also clearer in logs.
+    """
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(
+            headers=_headers(),
+            timeout=15.0,
+        )
+    return _http_client
+
+
+def _url(path: str) -> str:
+    return f"{config.MODELGUIDE_API_URL}{path}"
+
+
+def set_http_client(client: httpx.AsyncClient | None) -> None:
+    """Tests inject a fake/closed client here."""
+    global _http_client
+    _http_client = client
+
+
+async def close_http_client() -> None:
+    global _http_client
+    if _http_client and not _http_client.is_closed:
+        await _http_client.aclose()
+    _http_client = None
+
+
+# ---------------------------------------------------------------------------
+# Runtime config (the "sync from dashboard" call)
+# ---------------------------------------------------------------------------
+
+
+async def fetch_runtime_config() -> RuntimeConfig:
+    """Fetch the calling agent's runtime config.
+
+    The agent is identified by its API key (sent in the Authorization
+    header); there's no path param to spoof.  Errors propagate so the
+    entrypoint can decide whether to bail or fall back — we don't want a
+    silent default that masks a misconfigured deploy.
+    """
+    client = get_http_client()
+    res = await client.get(_url("/api/agents/me/runtime-config"))
+    res.raise_for_status()
+    payload = res.json()
+    cfg = RuntimeConfig.from_api(payload)
+    logger.info(
+        "Runtime config: agent=%s slug=%s compiled_at=%s has_prompt=%s",
+        cfg.id,
+        cfg.slug,
+        cfg.compiled_at,
+        bool(cfg.compiled_instructions),
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def create_session(user_identifier: str | None = None) -> str | None:
+    """Create a ModelGuide session.  Returns the id, or None on failure
+    (so a session API hiccup doesn't take down the voice call)."""
+    try:
+        client = get_http_client()
+        res = await client.post(
+            _url("/api/sessions"),
+            json={
+                "channelType": "voice",
+                "userIdentifier": user_identifier or "poc-caller",
+            },
+        )
+        res.raise_for_status()
+        return res.json()["id"]
+    except Exception:
+        logger.exception("Failed to create ModelGuide session — running untracked")
+        return None
+
+
+async def complete_session(session_id: str, status: str = "completed") -> None:
+    try:
+        client = get_http_client()
+        await client.patch(
+            _url(f"/api/sessions/{session_id}"),
+            json={"status": status},
+        )
+    except Exception:
+        logger.exception("Failed to complete session %s", session_id)

--- a/examples/agents/modelguide-livekit-poc-agent/tests/test_mg_client.py
+++ b/examples/agents/modelguide-livekit-poc-agent/tests/test_mg_client.py
@@ -1,0 +1,167 @@
+"""Tests for the POC agent's ModelGuide client.
+
+Locked behaviors:
+  - The runtime-config response shape from the API decodes into the
+    ``RuntimeConfig`` dataclass without dropping fields.
+  - ``resolved_instructions()`` falls back to ``config.FALLBACK_INSTRUCTIONS``
+    when ``compiledInstructions`` is null or whitespace-only.  The "no
+    compiled prompt yet" UX is what the operator hears when they click
+    Talk before Compile, so we lock the wording at this layer.
+  - The Authorization header is the agent's API key (not a user JWT).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Make sure config import doesn't blow up on REQUIRED vars.
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DEEPGRAM_API_KEY", "test")
+os.environ.setdefault("ELEVENLABS_API_KEY", "test")
+os.environ.setdefault("MODELGUIDE_API_URL", "http://localhost:3000")
+os.environ.setdefault("MODELGUIDE_API_KEY", "mgk_test")
+
+import httpx
+import pytest
+import respx
+
+import config
+import mg_client
+
+# Tests rely on the module-level constants populated by config.validate() —
+# without this, MODELGUIDE_API_URL is "" and _url(path) returns just the path,
+# which fails respx URL matching and httpx cookie parsing alike.
+config.validate()
+
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig decoding
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_config_decodes_full_payload() -> None:
+    payload = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Glowbox Voice",
+        "slug": "glowbox-voice",
+        "modality": "voice",
+        "compiledInstructions": "You are Sam.",
+        "compiledAt": "2026-05-20T12:00:00.000Z",
+        "promptConfig": {"persona": "Sam"},
+    }
+    cfg = mg_client.RuntimeConfig.from_api(payload)
+    assert cfg.id == "11111111-1111-1111-1111-111111111111"
+    assert cfg.slug == "glowbox-voice"
+    assert cfg.modality == "voice"
+    assert cfg.compiled_instructions == "You are Sam."
+    assert cfg.compiled_at == "2026-05-20T12:00:00.000Z"
+    assert cfg.prompt_config == {"persona": "Sam"}
+
+
+def test_runtime_config_tolerates_null_compiled_fields() -> None:
+    # The API returns nulls when the operator hasn't compiled yet.  The
+    # worker must not crash on the boot path — it falls back so the
+    # operator can hear the agent saying "I'm not configured."
+    cfg = mg_client.RuntimeConfig.from_api(
+        {
+            "id": "x",
+            "name": "x",
+            "slug": "x",
+            "modality": "voice",
+            "compiledInstructions": None,
+            "compiledAt": None,
+            "promptConfig": None,
+        }
+    )
+    assert cfg.compiled_instructions is None
+    assert cfg.compiled_at is None
+    assert cfg.prompt_config == {}
+
+
+def test_resolved_instructions_returns_compiled_when_present() -> None:
+    cfg = mg_client.RuntimeConfig(
+        id="x",
+        name="x",
+        slug="x",
+        modality="voice",
+        compiled_instructions="Use this prompt.",
+        compiled_at="2026-05-20T12:00:00Z",
+        prompt_config={},
+    )
+    assert cfg.resolved_instructions() == "Use this prompt."
+
+
+def test_resolved_instructions_falls_back_when_missing_or_blank() -> None:
+    # Empty / whitespace counts as missing — otherwise a "blank" prompt
+    # would silently override the fallback and the agent would have no
+    # instructions at all, leading to LLM-default behavior the operator
+    # didn't configure.
+    for value in (None, "", "   ", "\n\t"):
+        cfg = mg_client.RuntimeConfig(
+            id="x",
+            name="x",
+            slug="x",
+            modality="voice",
+            compiled_instructions=value,
+            compiled_at=None,
+            prompt_config={},
+        )
+        assert cfg.resolved_instructions() == config.FALLBACK_INSTRUCTIONS
+
+
+# ---------------------------------------------------------------------------
+# HTTP client wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_runtime_config_sends_bearer_api_key() -> None:
+    """The agent's API key authenticates the call — not a user JWT, not a
+    cookie.  If this regresses, every voice-test bootstrap returns 401."""
+
+    route = respx.get(
+        f"{config.MODELGUIDE_API_URL}/api/agents/me/runtime-config"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "agent-1",
+                "name": "Agent 1",
+                "slug": "agent-1",
+                "modality": "voice",
+                "compiledInstructions": "Hi",
+                "compiledAt": "2026-05-20T12:00:00.000Z",
+                "promptConfig": {},
+            },
+        )
+    )
+
+    mg_client.set_http_client(None)
+    try:
+        cfg = await mg_client.fetch_runtime_config()
+    finally:
+        await mg_client.close_http_client()
+
+    assert cfg.id == "agent-1"
+    assert route.called
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == f"Bearer {config.MODELGUIDE_API_KEY}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_runtime_config_raises_on_401() -> None:
+    """An invalid/revoked key should surface — don't fall back silently or
+    the operator thinks the prompt is just empty when actually auth broke."""
+
+    respx.get(
+        f"{config.MODELGUIDE_API_URL}/api/agents/me/runtime-config"
+    ).mock(return_value=httpx.Response(401, json={"error": "Unauthorized"}))
+
+    mg_client.set_http_client(None)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await mg_client.fetch_runtime_config()
+    finally:
+        await mg_client.close_http_client()

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRowForRuntime,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -45,6 +48,7 @@ import {
   type ModelFamily,
   getElevenLabsModelGroups,
 } from "./elevenlabs-models";
+import { formatAgentRuntimeConfig } from "./runtime-config";
 
 const router = createRouter();
 
@@ -459,6 +463,60 @@ router.openapi(platformModelsRoute, async (c) => {
   }
 
   throw Errors.invalidInput(`Unsupported platform: ${platform}`);
+});
+
+// ============================================================================
+// Agent Runtime Config (agent-auth — for external workers like LiveKit)
+//
+// GET /me/runtime-config returns the narrow view a voice-agent worker needs
+// to boot a session: latest compiled prompt, slug, modality, promptConfig.
+// Authenticated by the agent's own API key (`requireAgent`). The agent's
+// identity is taken from the auth context — there is no path param so a
+// stolen key can't be aimed at a different agent.
+//
+// Must be declared BEFORE `/:id` routes or Hono routes "me" into the :id
+// param.  See ADR-015 for the worker-fetches-prompt rationale.
+// ============================================================================
+
+router.get("/me/runtime-config", requireAgent(), requireOrganization());
+
+const runtimeConfigResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  modality: z.enum(["voice", "text"]),
+  compiledInstructions: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+  promptConfig: z.record(z.unknown()),
+});
+
+const runtimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me/runtime-config",
+  tags: ["Agents"],
+  summary: "Get the calling agent's runtime config",
+  description:
+    "Returns the latest compiled prompt and minimal config for the agent identified by the bearer API key. Used by external voice-agent workers (e.g. LiveKit) to boot a session against the freshest dashboard state without redeploy.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Runtime config for the calling agent",
+      content: {
+        "application/json": { schema: runtimeConfigResponseSchema },
+      },
+    },
+    401: errorResponse("Not authenticated as an agent"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(runtimeConfigRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  // Re-fetch via RLS-scoped transaction so the response reflects the latest
+  // compiledInstructions, not the row cached on the auth context at login.
+  const row = await getAgentRowForRuntime(orgId, agent.id);
+  return c.json(formatAgentRuntimeConfig(row), 200);
 });
 
 // ============================================================================

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -108,6 +108,27 @@ export async function listAgents(
   });
 }
 
+/**
+ * Load just the row that a worker calling /agents/me/runtime-config needs.
+ *
+ * Skips the extra joins `getAgentById` does (active API key prefix, eval
+ * suite count) — the worker has no use for either and they cost an extra
+ * round-trip per session boot.
+ */
+export async function getAgentRowForRuntime(orgId: string, agentId: string) {
+  return forOrg(orgId, async (tx) => {
+    const [agent] = await tx
+      .select()
+      .from(agents)
+      .where(eq(agents.id, agentId));
+
+    if (!agent) {
+      throw Errors.agentNotFound(agentId);
+    }
+    return agent;
+  });
+}
+
 export async function getAgentById(orgId: string, agentId: string) {
   return forOrg(orgId, async (tx) => {
     const [agent] = await tx

--- a/modelguide-api/src/features/agents/runtime-config.ts
+++ b/modelguide-api/src/features/agents/runtime-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Agent runtime config — the narrow view a LiveKit (or any external) worker
+ * needs to boot a voice session, fetched via `GET /agents/me/runtime-config`
+ * using the agent's own API key.
+ *
+ * Why a separate endpoint instead of reusing `GET /agents/:id`?
+ *   - `/agents/:id` is JWT-only (dashboard users). Agent API keys can't call
+ *     it without weakening auth on the management surface.
+ *   - The dashboard view leaks fields a worker has no business seeing:
+ *     `organizationId`, the full `metadata` blob (LiveKit/ElevenLabs config,
+ *     legacy `webhook_hmac_secret`), and the `secrets` ref map.
+ *   - Keeping the worker payload minimal means rotating a webhook secret or
+ *     adding a new dashboard-only field can't accidentally widen what the
+ *     worker observes — the shape is locked by tests in
+ *     `tests/unit/agents/runtime-config.test.ts`.
+ *
+ * See ADR-015 for the worker-fetches-prompt pattern.
+ */
+
+import type { Agent } from "@db/schema";
+
+export interface AgentRuntimeConfig {
+  id: string;
+  name: string;
+  slug: string;
+  modality: "voice" | "text";
+  compiledInstructions: string | null;
+  compiledAt: string | null;
+  promptConfig: Record<string, unknown>;
+}
+
+export function formatAgentRuntimeConfig(agent: Agent): AgentRuntimeConfig {
+  return {
+    id: agent.id,
+    name: agent.name,
+    slug: agent.slug,
+    modality: agent.modality,
+    compiledInstructions: agent.compiledInstructions ?? null,
+    compiledAt: agent.compiledAt?.toISOString() ?? null,
+    promptConfig: (agent.promptConfig ?? {}) as Record<string, unknown>,
+  };
+}

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,7 +8,12 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
@@ -264,6 +269,76 @@ describe("GET /api/agents/:id", () => {
     ]);
     expect(body.compiledFrom.toolCount).toBe(2);
     expect(body.compiledFrom.guardrailIds).toEqual([]);
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me/runtime-config — agent-auth runtime config (ADR-015)
+//
+// This is the endpoint a LiveKit (or any external) voice-agent worker hits
+// on every session boot to pick up the dashboard's latest compiled prompt.
+// Critical properties we lock in here:
+//   - agent's own API key works; user JWT does not
+//   - the calling agent's identity is taken from the key — no `:id` to spoof
+//   - the response is narrow: no secrets, no orgId, no full metadata blob
+// ============================================================================
+
+describe("GET /api/agents/me/runtime-config", () => {
+  test("returns runtime config when called with the agent's API key (200)", async () => {
+    // Stamp a compiled prompt so we exercise the "fresh prompt is visible
+    // to the worker" path, not just the null fallback.
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          compiledInstructions: "You are a runtime-config test agent.",
+          compiledAt: new Date("2026-05-20T12:00:00Z"),
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.compiledInstructions).toBe(
+      "You are a runtime-config test agent.",
+    );
+    expect(body.compiledAt).toBe("2026-05-20T12:00:00.000Z");
+    expect(body.modality).toBeDefined();
+    expect(body.slug).toBeDefined();
+    expect(body.promptConfig).toBeDefined();
+  });
+
+  test("rejects user JWT (401) — agent-auth only", async () => {
+    // Dashboard admins use /agents/:id, not /me. Locking this prevents a
+    // future "let admins call this for convenience" change from quietly
+    // widening the surface to user sessions.
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAdminHeaders,
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me/runtime-config");
+    expect(response.status).toBe(401);
+  });
+
+  test("does NOT leak secrets, organizationId, or full metadata", async () => {
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers,
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.secrets).toBeUndefined();
+    expect(body.organizationId).toBeUndefined();
+    expect(body.metadata).toBeUndefined();
   });
 });
 

--- a/modelguide-api/tests/unit/agents/runtime-config.test.ts
+++ b/modelguide-api/tests/unit/agents/runtime-config.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Runtime config — the shape returned by `GET /agents/me/runtime-config`,
+ * which the POC LiveKit worker fetches on every voice-test session to pick
+ * up the dashboard's latest compiled prompt without redeploying.
+ *
+ * `formatAgentRuntimeConfig` is the pure helper that builds the payload from
+ * a loaded agent row. Locking the shape with a unit test means a refactor
+ * that drops/renames a field is caught at CI rather than at "the agent
+ * silently uses an empty prompt and the call goes silent."
+ *
+ * See ADR-015 for the worker-fetches-prompt rationale.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Agent } from "../../../src/db/schema";
+import { formatAgentRuntimeConfig } from "../../../src/features/agents/runtime-config";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  // Minimal fixture — we only assert the fields the runtime config emits.
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    organizationId: "00000000-0000-0000-0000-0000000000ff",
+    name: "Test Agent",
+    slug: "test-agent",
+    description: null,
+    modality: "voice",
+    modelFamily: "gpt",
+    promptConfig: {},
+    agentPlatform: "livekit",
+    metadata: {},
+    secrets: {},
+    isActive: true,
+    compiledInstructions: null,
+    compiledAt: null,
+    compiledFrom: null,
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    updatedAt: new Date("2026-05-02T00:00:00Z"),
+    createdBy: null,
+    ...overrides,
+  } as unknown as Agent;
+}
+
+describe("formatAgentRuntimeConfig", () => {
+  test("exposes the fields a LiveKit worker needs to boot a session", () => {
+    const cfg = formatAgentRuntimeConfig(
+      makeAgent({
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Glowbox Voice",
+        slug: "glowbox-voice",
+        modality: "voice",
+        compiledInstructions: "You are Sam. Be helpful.",
+        compiledAt: new Date("2026-05-20T12:00:00Z"),
+        promptConfig: { persona: "Sam", language: "en-US" },
+      }),
+    );
+
+    expect(cfg.id).toBe("11111111-1111-1111-1111-111111111111");
+    expect(cfg.name).toBe("Glowbox Voice");
+    expect(cfg.slug).toBe("glowbox-voice");
+    expect(cfg.modality).toBe("voice");
+    expect(cfg.compiledInstructions).toBe("You are Sam. Be helpful.");
+    expect(cfg.compiledAt).toBe("2026-05-20T12:00:00.000Z");
+    expect(cfg.promptConfig).toEqual({ persona: "Sam", language: "en-US" });
+  });
+
+  test("emits null/empty when the agent has never been compiled", () => {
+    // Worker must tolerate this — operator hasn't hit Compile yet.
+    const cfg = formatAgentRuntimeConfig(
+      makeAgent({ compiledInstructions: null, compiledAt: null }),
+    );
+    expect(cfg.compiledInstructions).toBeNull();
+    expect(cfg.compiledAt).toBeNull();
+  });
+
+  test("promptConfig defaults to {} when not set (never undefined)", () => {
+    // The worker reads .persona / .language defensively; an undefined object
+    // would force every caller to guard. We normalize to {}.
+    // Cast through unknown so a future schema tightening doesn't allow null
+    // here without us re-deciding what to emit.
+    const cfg = formatAgentRuntimeConfig(
+      makeAgent({ promptConfig: null as unknown as Agent["promptConfig"] }),
+    );
+    expect(cfg.promptConfig).toEqual({});
+  });
+
+  test("never leaks secrets, api keys, or org id", () => {
+    // The agent's own API key authenticates this call. We deliberately keep
+    // the response narrow so a misconfigured worker can't echo sensitive
+    // material into a log or trace.
+    const cfg = formatAgentRuntimeConfig(
+      makeAgent({
+        secrets: { livekit_api_key: "sec-1", platform_api_key: "sec-2" },
+        metadata: { webhook_hmac_secret: "shhh", livekit: { url: "wss://x" } },
+        organizationId: "00000000-0000-0000-0000-0000000000ff",
+      }),
+    );
+    const json = JSON.stringify(cfg);
+    expect(json).not.toContain("sec-1");
+    expect(json).not.toContain("sec-2");
+    expect(json).not.toContain("shhh");
+    expect(json).not.toContain("0000000000ff");
+    // Defensive on field names too — a future "include everything" refactor
+    // should fail this test, not silently leak.
+    expect((cfg as unknown as Record<string, unknown>).secrets).toBeUndefined();
+    expect(
+      (cfg as unknown as Record<string, unknown>).organizationId,
+    ).toBeUndefined();
+    expect(
+      (cfg as unknown as Record<string, unknown>).metadata,
+    ).toBeUndefined();
+  });
+
+  test("round-trips through JSON without dropping fields", () => {
+    // The worker fetches this over HTTP; non-serializable values would
+    // explode at .json() instead of returning a useful error.
+    const cfg = formatAgentRuntimeConfig(
+      makeAgent({
+        compiledInstructions: "instructions",
+        compiledAt: new Date("2026-05-20T12:00:00Z"),
+      }),
+    );
+    expect(JSON.parse(JSON.stringify(cfg))).toEqual(cfg);
+  });
+});

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
@@ -169,6 +169,41 @@ describe('VoiceTestPanel', () => {
     })
   })
 
+  // -------------------------------------------------------------------------
+  // Prompt sync indicator (ADR-015)
+  //
+  // The POC worker calls /agents/me/runtime-config at session boot and uses
+  // agent.compiledInstructions as the system prompt. These tests lock the
+  // operator-facing UX for that contract: a confirmation that the next call
+  // will use a recently-compiled prompt vs. a warning that nothing has been
+  // compiled yet.
+  // -------------------------------------------------------------------------
+
+  it('shows a "worker uses compiled prompt" indicator when a compiled prompt is present', () => {
+    render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+    const indicator = screen.getByTestId('prompt-sync-indicator')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator.textContent).toMatch(/compiled prompt/i)
+    expect(indicator.textContent).toMatch(/recompile/i)
+  })
+
+  it('warns and points to Compile when no prompt has been compiled yet', () => {
+    const noPrompt = { ...configuredAgent, compiledInstructions: null, compiledAt: null } as Agent
+    render(<VoiceTestPanel agent={noPrompt} canMutate />, { wrapper })
+    expect(screen.queryByTestId('prompt-sync-indicator')).not.toBeInTheDocument()
+    expect(screen.getByText(/no compiled prompt yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/compile prompt/i)).toBeInTheDocument()
+  })
+
+  it('omits the sync indicator entirely until LiveKit is configured', () => {
+    // If LiveKit isn't configured, the call can't happen at all — showing a
+    // "synced" badge then is misleading.
+    const unconfigured = { ...baseAgent } as Agent
+    render(<VoiceTestPanel agent={unconfigured} canMutate />, { wrapper })
+    expect(screen.queryByTestId('prompt-sync-indicator')).not.toBeInTheDocument()
+    expect(screen.queryByText(/no compiled prompt yet/i)).not.toBeInTheDocument()
+  })
+
   it('surfaces a clear error when mic permission is denied', async () => {
     stubMicPermission(false)
     render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
@@ -23,7 +23,7 @@
 
 import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
 import { useMutation } from '@tanstack/react-query'
-import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, FileCode, Mic, Radio } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -164,6 +164,13 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
           </div>
         )}
 
+        {livekitConfigured ? (
+          <PromptSyncIndicator
+            compiledAt={agent.compiledAt}
+            hasCompiledPrompt={!!agent.compiledInstructions}
+          />
+        ) : null}
+
         <div className="mt-4 flex flex-wrap items-center gap-3">
           {showStartButton ? (
             <Button
@@ -213,4 +220,73 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
       </CardContent>
     </Card>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Prompt sync indicator
+//
+// Surfaces whether the worker will pick up a dashboard-edited prompt on the
+// next Talk click.  See ADR-015: a LiveKit POC worker calls
+// `/agents/me/runtime-config` at session start and uses the agent's
+// `compiledInstructions`.  This indicator translates that contract into UX:
+//   - has compiled prompt  →  green "synced …" line with the relative timestamp
+//   - no compiled prompt   →  warning row pointing the user at the Prompt tab
+//
+// We deliberately do NOT add a "Sync" button here.  Compile is the canonical
+// action and it lives one card up (Prompt tab → Compile). A duplicate button
+// here would diverge UX and become a second source of truth.
+// ---------------------------------------------------------------------------
+
+function PromptSyncIndicator({
+  compiledAt,
+  hasCompiledPrompt,
+}: {
+  compiledAt: string | null | undefined
+  hasCompiledPrompt: boolean
+}) {
+  if (!hasCompiledPrompt) {
+    return (
+      <div className="mt-4 flex items-start gap-2 rounded-lg border border-fg-subtle/15 bg-bg-subtle/40 p-3 text-xs text-fg-secondary">
+        <FileCode className="mt-0.5 h-3.5 w-3.5 shrink-0 text-fg-muted" />
+        <span>
+          No compiled prompt yet — open the <strong>Prompt</strong> tab and click{' '}
+          <strong>Compile Prompt</strong>. The worker fetches the latest compiled prompt on every
+          call.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <p
+      className="mt-4 flex items-center gap-1.5 text-xs text-fg-secondary"
+      data-testid="prompt-sync-indicator"
+    >
+      <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+      <span>
+        Worker uses the compiled prompt {compiledAt ? formatRelativeSync(compiledAt) : 'on file'}.
+        Recompile to push a new version.
+      </span>
+    </p>
+  )
+}
+
+/**
+ * Render the compiled-at timestamp as a short relative string so the
+ * operator can glance and confirm the call will use what they just
+ * compiled. Falls back to the ISO string if Date parsing fails — better to
+ * show something machine-readable than nothing.
+ */
+function formatRelativeSync(iso: string): string {
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return `(compiled ${iso})`
+  const seconds = Math.round((Date.now() - then) / 1000)
+  if (seconds < 5) return '(compiled just now)'
+  if (seconds < 60) return `(compiled ${seconds}s ago)`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `(compiled ${minutes}m ago)`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `(compiled ${hours}h ago)`
+  const days = Math.round(hours / 24)
+  return `(compiled ${days}d ago)`
 }


### PR DESCRIPTION
## Summary

Closes the dashboard ⇄ deployed-LiveKit-agent loop. Compile a prompt in the UI, click **Talk to agent**, hear the new prompt — no worker redeploy, no second dispatch hop.

Built so it does **not** contradict [ADR-014](docs/decisions/014-browser-voice-testing.md)'s "no prompt in dispatch metadata" stance. The worker fetches its instructions from a new agent-authenticated endpoint instead of receiving them via the dispatch payload. The dashboard's `compiledInstructions` remains the single authoritative source for both voice-test and production traffic.

- **New endpoint:** `GET /api/agents/me/runtime-config` — agent-auth (`requireAgent()`), narrow shape (no secrets, no org id, no metadata blob). Unit test locks the shape; integration tests lock the auth boundary and the no-leak guarantee.
- **New POC agent:** `examples/agents/modelguide-livekit-poc-agent/` — minimal LiveKit worker (no MCP tools, just STT+LLM+TTS) that calls `/runtime-config` at session start and uses the returned `compiledInstructions`. Six `pytest` unit tests cover `RuntimeConfig` decoding, the compiled/fallback selection, and the HTTP wiring.
- **UI:** voice-test panel shows a "Worker uses the compiled prompt (compiled Xs ago) — Recompile to push a new version" indicator, or a "compile first" affordance if no prompt exists. Three new UI tests lock the wording and visibility.
- **[ADR-015](docs/decisions/015-livekit-dynamic-prompt-loading.md):** documents the worker-fetches-prompt pattern and explicitly contrasts it with the prompt-in-metadata pattern ADR-014 rejected.
- **Makefile:** `lk-poc-setup` / `lk-poc-dev` / `lk-poc-test`.

### Architecture in one diagram

```
┌──────────────────┐    Compile     ┌────────────────────┐
│ ModelGuide UI    │  ───────────▶  │ agent.compiledInstr│
│ (prompt editor)  │                │ (DB, authoritative)│
└──────────────────┘                └─────────┬──────────┘
                                              │ fetch on boot
                                              ▼
                                    ┌────────────────────┐
                                    │ LiveKit POC worker │
                                    │ (this PR)          │
                                    └─────────┬──────────┘
                                              │ WebRTC
                                              ▼
                                       Operator's browser
                                       ("Talk to agent")
```

### What "Sync" means in the UI

Compile is the canonical action — it lives one card up on the agent detail page (Prompt tab → Compile). The voice-test panel deliberately does **not** add a duplicate Sync button to avoid creating a second source of truth. Instead it surfaces whether the worker will pick up a dashboard-edited prompt on the next Talk click, with a relative timestamp.

## Test plan

- [x] **API unit tests:** `bun test --preload ./tests/setup/unit-preload.ts tests/unit` → **901 pass** (5 new for `formatAgentRuntimeConfig`).
- [x] **API typecheck:** `bun run typecheck` clean.
- [x] **UI unit tests:** `bun run test:ci` → **271 pass** (3 new for `PromptSyncIndicator`).
- [x] **UI typecheck:** `bun run typecheck` clean.
- [x] **Python unit tests:** `cd examples/agents/modelguide-livekit-poc-agent && .venv/bin/python -m pytest tests/ -v` → **6 pass** (covers `RuntimeConfig` decode, compiled/fallback selection, bearer-key Authorization, 401 surface).
- [x] **Lint:** API + UI biome clean.
- [ ] **API integration tests:** new `GET /api/agents/me/runtime-config` block in `tests/integration/agents.test.ts` covers (a) happy path with the agent's API key, (b) user-JWT rejected (401), (c) unauthenticated rejected (401), (d) response excludes secrets/orgId/metadata. Requires Docker (Testcontainers Postgres) — will run in CI.
- [ ] **Manual end-to-end (recommended before merge):**
  - Configure LiveKit on a voice agent in the dashboard.
  - Deploy the POC worker (`lk agent deploy` from the new agent dir) and set `MODELGUIDE_API_KEY` to the agent's key.
  - Edit the agent's persona, hit **Compile**, then **Talk to agent**.
  - Confirm the call uses the freshly compiled prompt (worker logs `Runtime config: agent=… compiled_at=… has_prompt=True`).

## Known limitations (POC scope, called out in the ADR)

- No prompt cache / etag — every session boot does a full fetch. Fine at single-digit RPS.
- No baked-in fallback — if MG API is unreachable at boot, the call fails. Production workers should layer a last-known-good prompt under the fetch.
- No tool catalog in the runtime config — POC has no tools at all. Future work.

## Related

- [ADR-014](docs/decisions/014-browser-voice-testing.md) — voice-test dispatch flow (this builds on it without breaking it)
- [ADR-015](docs/decisions/015-livekit-dynamic-prompt-loading.md) — new ADR shipped in this PR
- `examples/agents/livekit-agent` (BuildPro Sam) — unchanged; continues to use its baked-in prompt + MCP tools

https://claude.ai/code/session_01KdiSrVc8z4nk81Rgjac3Kw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdiSrVc8z4nk81Rgjac3Kw)_