### PR TITLE
feat(prompt-lab): voice-test with live prompt override POC (ADR-015)

### DIFF
--- a/docs/decisions/015-prompt-lab-poc.md
+++ b/docs/decisions/015-prompt-lab-poc.md
@@ -1,0 +1,183 @@
+# ADR-015: Prompt Lab — Voice Test with Live Prompt Override (POC)
+
+**Status:** Accepted (POC, time-boxed). Supersedes the "no prompt injection"
+clause of ADR-014 for this single opt-in surface only.
+
+## Context
+
+ADR-014 (`docs/decisions/014-browser-voice-testing.md`) shipped a one-click
+"Talk to agent" button on the agent detail page. It deliberately does **not**
+let the operator inject a prompt at dispatch time — the worker's profile is
+the authoritative source of prompt + tools, and an override path creates the
+"works in voice-test but broke in prod" failure mode.
+
+That decision is right for the production button. It's the wrong default for
+the workflow we actually do day-to-day:
+
+> Edit the SOP → recompile → redeploy the worker → wait for the deploy →
+> click "Talk to agent" → discover the prompt change is bad → repeat.
+
+The redeploy step alone is 60–120 seconds (Railway pull + image start +
+worker boot + LiveKit dispatch warm-up). Five iterations is ten minutes of
+deploys for thirty seconds of evaluation. The current Studio-grade voice
+agent platforms (voiceblox.ai, Vapi, Retell) all expose a "test with this
+prompt" surface for exactly this reason.
+
+We want the same iteration loop without giving up the ADR-014 invariants on
+the production path.
+
+## Decision
+
+Add a **second** voice-test surface, the "Prompt Lab", that:
+
+1. Reuses the entire ADR-014 plumbing (session creation, dispatch, token
+   mint, `<LiveKitRoom>` mount) verbatim.
+2. Accepts a `prompt` field on the new endpoint
+   `POST /api/agents/:id/voice-test-prompt`.
+3. Carries that prompt into the dispatch metadata as `prompt_override`.
+4. The LiveKit worker reads `prompt_override` from metadata and uses it
+   verbatim as the agent's `instructions` for this single session,
+   bypassing the baked-in profile prompt.
+5. Lives on the agent detail page alongside the existing "Talk to agent"
+   panel — labelled "Prompt Lab — POC" so operators see at a glance that
+   this is the iteration surface, not the production parity check.
+
+ADR-014's "Talk to agent" button is unchanged. The two surfaces have
+different intents and the UI keeps them visually separate.
+
+### Contract (pinned by unit tests on both sides)
+
+MG-side, `buildVoiceTestDispatchMetadata` (in
+`modelguide-api/src/features/agents/agents.service.ts`):
+
+```ts
+{
+  mode: "voice-test",
+  agentName: "<agent.slug>",
+  session_id: "<uuid>",
+  user_identifier: "<email>",
+  email: "<email>",
+  prompt_override?: "<verbatim prompt>"   // present iff Prompt Lab path
+}
+```
+
+Worker-side, `extract_prompt_override` (in
+`examples/agents/livekit-agent/src/dispatch.py`):
+
+```python
+prompt_override = extract_prompt_override(dispatch_metadata)  # str | None
+agent = BuildProAgent(..., instructions_override=prompt_override)
+```
+
+If `prompt_override` is missing, empty, whitespace-only, or not a string,
+the worker silently falls back to the baked-in profile prompt — i.e. it
+behaves exactly like the ADR-014 path. This is a deliberate fail-safe so a
+stale worker against a newer MG doesn't ship the agent without
+instructions.
+
+### Validation & size guards
+
+- **Empty / whitespace prompt:** rejected at both layers. The MG schema
+  uses `zod.string().min(1)`; `buildVoiceTestDispatchMetadata` re-checks
+  with `prompt.trim().length === 0`. The worker treats empty as "no
+  override" for defence in depth.
+- **Byte cap:** `PROMPT_LAB_MAX_BYTES = 50_000` (UTF-8 bytes, not JS
+  string length). Counted in `Buffer.byteLength(prompt, "utf8")` so a
+  4-byte emoji costs 4 bytes, not 2 (the JS `.length` answer). The route
+  schema sits at 60 000 chars for a cheap first-line reject before zod
+  pays the parse cost on multi-MB blobs.
+- LiveKit's own metadata cap (96 KB) is comfortably above 50 KB plus the
+  rest of the metadata fields.
+
+### Permissions
+
+Same as ADR-014: `agents:activate` (admin-only). The standard support
+role can't kick a Prompt Lab session — same blast radius as kicking the
+deployed worker.
+
+## What this is and is not
+
+### Is
+- An opt-in prompt iteration surface for developers and prompt operators.
+- A shared-state-free POC: every Prompt Lab dispatch creates a fresh
+  MG session, the override lives in that one dispatch's metadata, and
+  nothing is persisted past the session.
+- Compatible with multi-profile workers (the `agentName` routing field is
+  unchanged).
+
+### Is not
+- **Not a replacement for "Talk to agent".** The deployed worker's
+  profile is still the production source of truth. Use Prompt Lab to
+  iterate; promote the winning prompt by compiling + redeploying.
+- **Not for production parity tests.** A Prompt Lab session runs your
+  prompt against the worker's tool wiring, but the rest of the
+  production payload (filler phrases, persona config, guardrails baked
+  into the worker image) is whatever the deployed worker happens to
+  carry. Don't ship based on Prompt Lab alone.
+- **Not durable.** No prompt drafts, no version history, no diff-against-
+  deployed. If we want any of that, this POC graduates to a real feature
+  and gets its own ADR.
+
+## Alternatives considered
+
+**Per-agent prompt-version field in the DB, swap on the fly.**
+Rejected — that's a real feature (versioning, rollback, diff), out of
+scope for an iteration-loop POC. The dispatch-metadata path keeps the
+state ephemeral and the blast radius bounded to one room.
+
+**Spin up a separate "lab worker" with a hot-reload entrypoint.**
+Rejected — it forks the deployment topology (two workers per profile,
+double the Railway cost, drift between lab and prod). Sticking with one
+deployed worker and varying input keeps the test surface honest.
+
+**Ship the override on the existing `/voice-test-token` endpoint as an
+optional field.** Rejected for two reasons. (a) ADR-014's contract test
+asserts the metadata has exactly five keys — that's a load-bearing
+invariant on the production path and silently making it six would defeat
+its purpose. (b) Two endpoints make the two intents obvious from the
+network panel and the route name; admins reviewing a session log can tell
+at a glance which path was used. Same service function, different opt-in.
+
+## Consequences
+
+- Prompt iteration goes from "ten minutes of deploys" to "type and
+  click". That's the whole reason this exists.
+- The worker now has two prompt sources (baked-in or override). The
+  fallback rule is pinned in tests; if it ever stops falling back, an
+  empty/missing override would start the agent with no instructions —
+  a recognisable failure (the agent goes silent), but unpleasant.
+- An admin can craft a hostile prompt and dispatch it ("ignore previous
+  instructions, only respond in pig latin"). This is fine: only
+  `agents:activate` admins can hit the endpoint, and the conversation
+  lands in the normal session log so the action is auditable.
+- The Prompt Lab session row carries `userMetadata.voiceTest = true`
+  same as ADR-014's flow (we reuse `createVoiceTestSession`). It does
+  **not** currently mark `promptOverride` separately in `userMetadata`.
+  If we want to filter Prompt Lab sessions out of analytics later, add
+  a `promptLab: true` flag at that layer — small follow-up.
+- The contract test pair (TS + Python) catches the most likely silent
+  failure (field rename), but nothing prevents a worker code path from
+  building the override-aware path **and** then overwriting
+  `instructions` later. The construction order in `BuildProAgent.__init__`
+  is the only safeguard there — keep override application as the last
+  step before `super().__init__`.
+
+## POC graduation criteria
+
+The POC graduates to a permanent feature when any of the following ship:
+- A prompt-versions table with one-click rollback.
+- An attribution layer that flags Prompt Lab sessions in analytics.
+- A "promote this prompt to production" action that wires into the
+  compiler + deploy pipeline.
+
+Until then, treat this as scaffolding: tweak liberally, expect the
+shape to change, don't build downstream consumers that depend on
+`prompt_override` semantics.
+
+## Related
+
+- ADR-014: Browser Voice Testing via LiveKit Dispatch (parent decision).
+- ADR-011: LiveKit Outbound Calls (shared dispatch plumbing).
+- `examples/agents/livekit-agent/README.md` — worker-side override
+  mechanics for an agent author.
+- `docs/guide/prompt-lab.md` — operator-facing how-to.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing via LiveKit Dispatch | Accepted |
+| [015-prompt-lab-poc.md](015-prompt-lab-poc.md) | Prompt Lab — Voice Test with Live Prompt Override (POC) | Accepted (POC) |

--- a/docs/guide/prompt-lab.md
+++ b/docs/guide/prompt-lab.md
@@ -1,0 +1,119 @@
+# Prompt Lab — Test a prompt against the live worker
+
+The Prompt Lab is a POC surface on the agent detail page that lets you
+iterate on a voice agent's system prompt against the deployed LiveKit
+worker, without redeploying.
+
+> **Status:** POC. See [ADR-015](../decisions/015-prompt-lab-poc.md) for the
+> design decisions and trade-offs. The standard **Talk to agent** button
+> (ADR-014) is unchanged and remains the right tool for production parity
+> checks.
+
+## When to use it
+
+| You want to… | Surface |
+|---|---|
+| Hear how the deployed worker sounds with its current production prompt | **Talk to agent** (ADR-014) |
+| Iterate on a prompt edit and hear it in 5 seconds, not 5 minutes | **Prompt Lab** (this page) |
+| Verify a freshly-compiled prompt before promoting | **Prompt Lab** then redeploy |
+| Run a regression suite on a prompt change | Eval suites (out of scope here) |
+
+## What it does, in one sentence
+
+The Prompt Lab dispatches the **same deployed worker** as the standard
+voice test, but adds `prompt_override` to the dispatch metadata. The
+worker uses that string as the agent's instructions for that single
+session, then forgets it when the room closes.
+
+## Quick start
+
+1. Open the agent detail page (`/agents/<id>`) for a LiveKit voice agent.
+2. Scroll to the **Prompt Lab** card.
+3. The textarea is seeded with the agent's last compiled prompt
+   (`compiledInstructions`). If the agent has never been compiled, the
+   textarea starts empty.
+4. Edit the prompt freely.
+5. Click **Sync & Talk**.
+   - The browser checks for mic permission.
+   - The API creates a fresh session, dispatches the worker with your
+     prompt in metadata, mints a short-lived LiveKit token.
+   - The room mounts via WebRTC and the agent greets you using your
+     edited prompt.
+6. Talk to the agent. When you're done, click **Hang up**.
+7. The session lands in the normal **Sessions** view (look for the
+   timestamp that matches when you hit Sync & Talk).
+
+## Compile flow (optional)
+
+The Prompt Lab textarea is a free-form editor — paste anything you want.
+If you want to test a SOP-derived prompt, hit `POST /api/agents/:id/compile`
+first (or use the existing **Compile** UI), refresh the page, and the
+freshly compiled prompt seeds the textarea.
+
+We deliberately did not add an in-panel "compile" button — the existing
+compile UI already lives next door on the same page. Adding a second
+trigger would just be two ways to do the same thing.
+
+## Limits
+
+- **Prompt size:** 50 KB UTF-8 (any larger gets a 400 from the API).
+  The textarea shows the current size in characters; the server cap is
+  in bytes.
+- **Permissions:** admin-only (same as the standard voice test —
+  `agents:activate`).
+- **Worker requirement:** the agent must have `agentPlatform === "livekit"`,
+  a configured `metadata.livekit.{url, agentName}`, and the
+  `livekit_api_key` + `livekit_api_secret` secrets present. Otherwise
+  the panel renders a warning and disables the action.
+- **No persistence:** your edit is held in the browser only. Refresh the
+  page and it's gone (back to the seeded compiled prompt). If you want
+  to keep a prompt, paste it somewhere durable.
+
+## What gets logged
+
+A Prompt Lab session is a normal MG session — it shows up in the
+session list with `channelType = "voice"` and `userMetadata.voiceTest =
+true`. The injected prompt is **not** stored on the session row; only
+the conversation transcript lands in the dashboard.
+
+If you need to know "did this session use a Prompt Lab override?", check
+for the worker-side log line:
+
+```
+Prompt Lab override active (N chars) — skipping baked-in profile prompt
+```
+
+(this is the breadcrumb the worker logs in `agent.py` when it sees
+`prompt_override` in the dispatch metadata).
+
+## Promoting a prompt
+
+There is no "promote" button. The intended path:
+
+1. Iterate in Prompt Lab until you're happy.
+2. Copy the prompt out.
+3. Update the SOP / worker profile prompt source.
+4. Recompile / redeploy as usual.
+5. Verify with the standard **Talk to agent** button.
+
+We deliberately did not wire a one-click "ship this" — the production
+path goes through the compiler so we get versioning, diffs, and CI.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Button greyed out, "Configure the LiveKit URL…" warning | LiveKit not configured on the agent. Set it up first. |
+| Button greyed out, no warning | Textarea is empty / whitespace. Type something. |
+| Click does nothing, error "Microphone permission denied" | The browser blocked mic access. Allow it in your browser's site settings. |
+| Click → "Joining LiveKit room…" forever | Worker is offline, or `agentName` in agent metadata doesn't match the worker's profile registry. Check the worker logs. |
+| Agent greets you, then ignores your prompt edit | Worker is on an older image without the `prompt_override` code path. Redeploy the worker. |
+| 400 from the API | Most likely the prompt is over the 50 KB cap, or LiveKit isn't fully configured. The error body has the details. |
+
+## Related
+
+- [ADR-014](../decisions/014-browser-voice-testing.md) — parent feature
+  (browser voice testing, no override).
+- [ADR-015](../decisions/015-prompt-lab-poc.md) — this POC's design.
+- `examples/agents/livekit-agent/README.md` — worker-side override
+  implementation.

--- a/examples/agents/livekit-agent/README.md
+++ b/examples/agents/livekit-agent/README.md
@@ -162,6 +162,44 @@ ModelGuide API
 
 **Tool mapping:** The LLM uses short tool names (`list_products`, `add_to_cart`). These are mapped to connector-prefixed MCP names (`glowbox_store_list_products`, `glowbox_store_add_to_cart`) in the `BuildProAgent._call_mcp_tool()` method.
 
+## Prompt Lab override (ADR-015)
+
+When the MG dashboard dispatches us via the Prompt Lab surface, the
+dispatch metadata carries a `prompt_override` field. The worker uses
+that string as the agent's `instructions` for that single session
+instead of the baked-in profile prompt — no redeploy needed.
+
+The path is:
+
+```
+LiveKit dispatch metadata: { ..., "prompt_override": "..." }
+        │
+        ▼
+agent.py entrypoint   →   extract_prompt_override(metadata)
+        │                       (dispatch.py — pure, no livekit imports)
+        ▼
+BuildProAgent(..., instructions_override="...")
+        │
+        ▼
+select_instructions(override=..., default_factory=build_system_prompt)
+        │
+        ▼
+super().__init__(instructions=...)
+```
+
+If the metadata is missing, empty, whitespace, or not a string, the
+worker falls back to the baked-in profile prompt — i.e. it behaves
+exactly like the standard "Talk to agent" path (ADR-014). This makes a
+stale worker against a newer MG safe: the agent always has *some*
+instructions to start with.
+
+Tests for both the metadata extraction and the instruction-selection
+logic live in `tests/test_dispatch.py` and run without livekit
+installed.
+
+For the rest of the design (why two surfaces, byte caps, what's not
+done), see `docs/decisions/015-prompt-lab-poc.md`.
+
 ## Architecture
 
 ```
@@ -170,6 +208,7 @@ src/
   mcp_agent.py    # MCPAgent base class (tool execution, tracing, transcripts)
   buildpro.py     # BuildProAgent — tools + hooks for contractor supply scenario
   config.py       # Environment variables (AGENT_NAME, CONNECTOR_PREFIX, etc.)
+  dispatch.py     # Dispatch-metadata helpers (Prompt Lab override read path)
   providers.py    # STT/TTS factory functions (Deepgram, ElevenLabs, Cartesia)
   tracing.py      # Langfuse OpenTelemetry setup
   hangup.py       # Auto-hangup state machine

--- a/examples/agents/livekit-agent/src/agent.py
+++ b/examples/agents/livekit-agent/src/agent.py
@@ -22,6 +22,7 @@ from livekit.plugins.turn_detector.english import EnglishModel
 import config
 import mg_client
 from buildpro import BuildProAgent
+from dispatch import extract_prompt_override
 from hangup import HangupAction, HangupStateMachine
 from prompts import GREETING
 from providers import create_stt, create_tts
@@ -157,8 +158,23 @@ async def entrypoint(ctx: agents.JobContext):
             logger.exception("Failed to create ModelGuide session — running without tracking")
     logger.info("ModelGuide session: %s (user: %s)", session_id, user_identifier)
 
+    # Prompt Lab (ADR-015): when MG dispatched us with `prompt_override` in
+    # the metadata, use that string as the agent's instructions instead of
+    # the baked-in profile prompt. Falls back cleanly when absent.
+    prompt_override = extract_prompt_override(dispatch_metadata)
+    if prompt_override:
+        logger.info(
+            "Prompt Lab override active (%d chars) — skipping baked-in profile prompt",
+            len(prompt_override),
+        )
+
     # Build agent + session
-    agent = BuildProAgent(session_id=session_id, user_email=user_identifier, mcp=mcp)
+    agent = BuildProAgent(
+        session_id=session_id,
+        user_email=user_identifier,
+        mcp=mcp,
+        instructions_override=prompt_override,
+    )
     stt = create_stt()
     tts = create_tts()
 

--- a/examples/agents/livekit-agent/src/buildpro.py
+++ b/examples/agents/livekit-agent/src/buildpro.py
@@ -17,6 +17,7 @@ from livekit.agents import RunContext, function_tool
 
 import config
 import mg_client
+from dispatch import select_instructions
 from mcp_agent import MCPAgent
 from prompts import build_system_prompt
 
@@ -36,13 +37,25 @@ class BuildProAgent(MCPAgent):
     ]
 
     def __init__(
-        self, *, session_id: str | None, user_email: str, mcp: mg_client.MCPConnection | None = None
+        self,
+        *,
+        session_id: str | None,
+        user_email: str,
+        mcp: mg_client.MCPConnection | None = None,
+        instructions_override: str | None = None,
     ) -> None:
         self._active_cart_id: str | None = None
         self._cart_ready = asyncio.Event()
         self._reorder_product_ids: list[str] = []
 
-        instructions = build_system_prompt(session_id or "", user_email=user_email)
+        # Prompt Lab (ADR-015): when MG dispatched us with `prompt_override`,
+        # use it verbatim instead of building the baked-in profile prompt.
+        instructions = select_instructions(
+            override=instructions_override,
+            default_factory=lambda: build_system_prompt(
+                session_id or "", user_email=user_email
+            ),
+        )
         super().__init__(session_id=session_id, mcp=mcp, instructions=instructions)
 
     # ------------------------------------------------------------------

--- a/examples/agents/livekit-agent/src/dispatch.py
+++ b/examples/agents/livekit-agent/src/dispatch.py
@@ -1,0 +1,55 @@
+"""Dispatch-metadata helpers — pure, no livekit imports.
+
+The LiveKit worker reads a JSON metadata blob from ``ctx.job.metadata`` on
+each dispatch. The MG side puts a small contract there (mode, agentName,
+session_id, user_identifier, email — see
+``modelguide-api/src/features/agents/agents.service.ts``
+``buildVoiceTestDispatchMetadata``).
+
+For the Prompt Lab POC (ADR-015), the MG side may also pass
+``prompt_override``. When present, the worker uses that string as the
+agent's instructions for this one session instead of the baked-in profile
+prompt. Everything in this file is the worker-side read half of that
+contract. Keeping it pure means it's unit-testable without livekit
+installed, the same way the MG side has a pure unit test on the build
+half.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def extract_prompt_override(metadata: dict | None) -> str | None:
+    """Return a usable Prompt Lab override, or ``None`` to fall back.
+
+    Defensive against:
+    - ``None`` / missing ``metadata`` (older MG, no override path)
+    - non-string values (type-mismatched payload — we'd rather fall back
+      than start the agent with garbage instructions)
+    - empty / whitespace-only strings (MG-side validation rejects these,
+      but if a stale MG forwards an empty string, ignore it cleanly)
+    """
+    if not isinstance(metadata, dict):
+        return None
+    value: Any = metadata.get("prompt_override")
+    if not isinstance(value, str):
+        return None
+    if not value.strip():
+        return None
+    return value
+
+
+def select_instructions(
+    *, override: str | None, default_factory: Callable[[], str]
+) -> str:
+    """Pick the instructions string — override wins; otherwise build default.
+
+    ``default_factory`` is lazy on purpose: building the baked-in prompt
+    can involve file I/O and string assembly. A Prompt Lab caller has
+    already supplied the full instructions, so we skip the work entirely
+    when ``override`` is set.
+    """
+    if override is not None:
+        return override
+    return default_factory()

--- a/examples/agents/livekit-agent/tests/test_dispatch.py
+++ b/examples/agents/livekit-agent/tests/test_dispatch.py
@@ -1,0 +1,83 @@
+"""Tests for the dispatch-metadata helpers.
+
+These cover the Prompt Lab (ADR-015) override path on the worker side. The
+helpers are deliberately pure (no livekit imports) so this file runs in a
+plain Python environment — same pattern as test_prompts.py.
+
+The MG-side dispatch contract is locked in
+``modelguide-api/tests/unit/agents/prompt-lab-dispatch.test.ts``; this file
+locks the worker-side read.
+"""
+
+import pytest
+
+from dispatch import extract_prompt_override, select_instructions
+
+
+class TestExtractPromptOverride:
+    def test_missing_key_returns_none(self):
+        assert extract_prompt_override({}) is None
+        assert extract_prompt_override({"mode": "voice-test"}) is None
+
+    def test_present_string_returns_verbatim(self):
+        assert (
+            extract_prompt_override({"prompt_override": "You are a pirate."})
+            == "You are a pirate."
+        )
+
+    def test_preserves_multiline_unicode(self):
+        prompt = "Line 1\nLine 2 — ünicode\n\t• indented 🦜\n"
+        assert extract_prompt_override({"prompt_override": prompt}) == prompt
+
+    def test_empty_string_treated_as_no_override(self):
+        # Defensive: MG-side validation already rejects empty / whitespace,
+        # but a worker rolled forward against an older MG should still fall
+        # back cleanly to the baked-in profile prompt rather than starting
+        # the agent with no instructions.
+        assert extract_prompt_override({"prompt_override": ""}) is None
+        assert extract_prompt_override({"prompt_override": "   \n\t"}) is None
+
+    def test_non_string_returns_none(self):
+        # Type guard — accept anything callable that says it's metadata
+        # without crashing the worker.
+        assert extract_prompt_override({"prompt_override": 123}) is None
+        assert extract_prompt_override({"prompt_override": ["a"]}) is None
+        assert extract_prompt_override({"prompt_override": None}) is None
+
+    def test_none_metadata_returns_none(self):
+        # The entrypoint passes {} when ctx.job.metadata is missing, but a
+        # caller might pass None directly.
+        assert extract_prompt_override(None) is None  # type: ignore[arg-type]
+
+
+class TestSelectInstructions:
+    def test_uses_override_when_set(self):
+        result = select_instructions(
+            override="You are a pirate.",
+            default_factory=lambda: "default prompt",
+        )
+        assert result == "You are a pirate."
+
+    def test_falls_back_when_override_is_none(self):
+        called = {"n": 0}
+
+        def factory():
+            called["n"] += 1
+            return "default prompt"
+
+        result = select_instructions(override=None, default_factory=factory)
+        assert result == "default prompt"
+        assert called["n"] == 1
+
+    def test_lazy_factory_not_called_when_override_set(self):
+        # If the operator passes an override, we must not pay the cost of
+        # building the default prompt — important for any factory that does
+        # file I/O or template assembly.
+        called = {"n": 0}
+
+        def factory():
+            called["n"] += 1
+            return "default"
+
+        select_instructions(override="hi", default_factory=factory)
+        assert called["n"] == 0

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -1362,4 +1362,84 @@ router.openapi(voiceTestTokenRoute, async (c) => {
   return c.json(result, 201);
 });
 
+// ============================================================================
+// Prompt Lab (voice-test with an editor-supplied prompt — POC, ADR-015)
+//
+// Same dispatch pipeline as `/voice-test-token`, but the caller supplies a
+// `prompt` string that the worker uses as the agent's instructions for this
+// single session. The standard voice-test path stays as-is per ADR-014; this
+// is an opt-in surface for prompt iteration during development.
+// ============================================================================
+
+router.post(
+  "/:id/voice-test-prompt",
+  requireUser(),
+  requirePermission("agents:activate"),
+  requireOrganization(),
+);
+
+const voiceTestPromptBodySchema = z.object({
+  prompt: z
+    .string()
+    .min(1, "Prompt must not be empty")
+    // 50 KB matches PROMPT_LAB_MAX_BYTES in agents.service. Counted in chars
+    // here (cheap) and re-checked in bytes by buildVoiceTestDispatchMetadata
+    // — that is the actual contract. This is a friendlier first line of
+    // defence so the payload doesn't blow zod's parse cost on a 10 MB blob.
+    .max(60_000, "Prompt too large")
+    .openapi({
+      description: "System prompt to inject as the agent's instructions",
+    }),
+});
+
+const voiceTestPromptRoute = createRoute({
+  method: "post",
+  path: "/{id}/voice-test-prompt",
+  tags: ["Agents"],
+  summary: "Prompt Lab — voice-test with an editor-supplied prompt (POC)",
+  description:
+    "Same dispatch pipeline as POST /voice-test-token, plus a `prompt_override` field in the dispatch metadata so the LiveKit worker uses the editor's prompt as the agent's instructions for this single session. See ADR-015 for scope and trade-offs.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: agentIdParams,
+    body: {
+      content: { "application/json": { schema: voiceTestPromptBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Prompt Lab session created",
+      content: {
+        "application/json": { schema: voiceTestTokenResponseSchema },
+      },
+    },
+    400: errorResponse(
+      "LiveKit not configured, missing credentials, wrong modality, or prompt validation failed",
+    ),
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(voiceTestPromptRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const user = getCurrentUser(c);
+  const { id } = c.req.valid("param");
+  const { prompt } = c.req.valid("json");
+
+  const result = await createVoiceTestSession(
+    orgId,
+    id,
+    {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+    },
+    { promptOverride: prompt },
+  );
+
+  return c.json(result, 201);
+});
+
 export default router;

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -892,32 +892,70 @@ export function buildOutboundDispatchMetadata(input: {
 // ============================================================================
 
 /**
+ * Hard cap on the Prompt Lab `prompt_override` payload, in UTF-8 bytes.
+ *
+ * LiveKit job metadata has its own (larger) byte cap; 50 KB is plenty for
+ * any realistic system prompt and keeps a single Prompt Lab session from
+ * blowing the metadata envelope when combined with the other fields.
+ * Counted in bytes (not JS string length) because the worker measures the
+ * metadata JSON in bytes on receive.
+ *
+ * See ADR-015 for why this whole override path exists at all.
+ */
+export const PROMPT_LAB_MAX_BYTES = 50_000;
+
+/**
  * Build the dispatch-metadata payload for a voice-test session.
  *
  * Pure function so the MG-agent-slug ↔ worker-profile-slug coupling is
  * covered by a unit test. If the field names or shape ever drift, the
- * worker's entrypoint (demos/bank-nowa/voice-agent/src/agent.py —
- * `agentName = dispatch_metadata.get("agentName")`) stops routing to
- * the right profile and every dispatched call goes silent.
+ * worker's entrypoint (examples/agents/livekit-agent/src/agent.py —
+ * `dispatch_metadata.get("agentName")`) stops routing to the right
+ * profile and every dispatched call goes silent.
+ *
+ * When `promptOverride` is set (Prompt Lab POC, ADR-015), the worker uses
+ * that string as the agent's instructions for this single session instead
+ * of the baked-in profile prompt. Empty / whitespace-only / oversized
+ * overrides are rejected at this layer so the caller gets a clear error
+ * instead of silently falling through to the worker's default.
  */
 export function buildVoiceTestDispatchMetadata(input: {
   agentSlug: string;
   sessionId: string;
   callerEmail: string;
+  promptOverride?: string;
 }): {
   mode: "voice-test";
   agentName: string;
   session_id: string;
   user_identifier: string;
   email: string;
+  prompt_override?: string;
 } {
-  return {
+  const base = {
     mode: "voice-test" as const,
     agentName: input.agentSlug,
     session_id: input.sessionId,
     user_identifier: input.callerEmail,
     email: input.callerEmail,
   };
+
+  if (input.promptOverride === undefined) {
+    return base;
+  }
+
+  const prompt = input.promptOverride;
+  if (prompt.trim().length === 0) {
+    throw Errors.invalidInput("prompt_override must not be empty");
+  }
+  const bytes = Buffer.byteLength(prompt, "utf8");
+  if (bytes > PROMPT_LAB_MAX_BYTES) {
+    throw Errors.invalidInput(
+      `prompt_override exceeds ${PROMPT_LAB_MAX_BYTES} bytes (got ${bytes})`,
+    );
+  }
+
+  return { ...base, prompt_override: prompt };
 }
 
 export interface VoiceTestSession {
@@ -935,6 +973,7 @@ export async function createVoiceTestSession(
   orgId: string,
   agentId: string,
   caller: { userId: string; email: string; name: string },
+  opts: { promptOverride?: string } = {},
 ): Promise<VoiceTestSession> {
   const agent = await forOrg(orgId, async (tx) => {
     const a = await requireAgent(tx, agentId);
@@ -996,6 +1035,7 @@ export async function createVoiceTestSession(
     agentSlug: agent.slug,
     sessionId: session.id,
     callerEmail: caller.email,
+    promptOverride: opts.promptOverride,
   });
 
   let dispatchId: string;

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -1011,6 +1011,118 @@ describe("POST /api/agents/:id/voice-test-token", () => {
   });
 });
 
+// ============================================================================
+// POST /api/agents/:id/voice-test-prompt — Prompt Lab (ADR-015)
+// ============================================================================
+
+describe("POST /api/agents/:id/voice-test-prompt", () => {
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hi" }),
+      },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects support role (403) — agents:activate is admin-only", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgASupportHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hi" }),
+      },
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("org B cannot Prompt-Lab an org A agent (404)", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgBAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hi" }),
+      },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("returns 404 for unknown agent", async () => {
+    const response = await request(
+      "/api/agents/00000000-0000-0000-0000-000000000000/voice-test-prompt",
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hi" }),
+      },
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects empty prompt (400) — schema-level", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "" }),
+      },
+    );
+    // zod min(1) rejects at schema parse time before the route runs.
+    expect(response.status).toBe(400);
+  });
+
+  test("rejects oversized prompt (400) — schema-level", async () => {
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "x".repeat(60_001) }),
+      },
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 400 when LiveKit is not configured for the agent", async () => {
+    // Seeded orgA voice agent has no LiveKit config — same precondition as
+    // the standard /voice-test-token guard.
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "You are a pirate." }),
+      },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/LiveKit/i);
+  });
+
+  test("rejects whitespace-only prompt at service layer (400)", async () => {
+    // Spaces / tabs / newlines pass `min(1)` at the schema layer, so the
+    // service-layer trim() guard in buildVoiceTestDispatchMetadata is what
+    // catches them. Verify that error surfaces as 400, not 500.
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-prompt`,
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "   \n\t  " }),
+      },
+    );
+    // Either the LiveKit config guard trips first (most likely on the seeded
+    // agent — also 400) or the prompt guard does — both are 400 by design.
+    expect(response.status).toBe(400);
+  });
+});
+
 describe("Agent slug uniqueness", () => {
   test("creating agent with duplicate name (same slug) returns 409", async () => {
     const res1 = await request("/api/agents", {

--- a/modelguide-api/tests/unit/agents/prompt-lab-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/prompt-lab-dispatch.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Prompt Lab dispatch metadata — contract lock for the prompt-override path.
+ *
+ * This is the POC extension of ADR-014 documented in ADR-015. Where the
+ * standard voice-test path forbids prompt injection, the Prompt Lab opts
+ * in by sending `prompt_override` in the dispatch metadata so the worker
+ * uses the editor's prompt verbatim for that single session.
+ *
+ * If `prompt_override` is renamed, dropped, or silently truncated by the
+ * helper, the worker stops honoring the override and the lab silently
+ * tests the baked-in profile prompt instead — exactly the failure mode
+ * ADR-014 warned about, but invisible. This file is the contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  PROMPT_LAB_MAX_BYTES,
+  buildVoiceTestDispatchMetadata,
+} from "../../../src/features/agents/agents.service";
+
+describe("buildVoiceTestDispatchMetadata — prompt override", () => {
+  test("omits prompt_override when no override is supplied (back-compat)", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect("prompt_override" in md).toBe(false);
+  });
+
+  test("includes prompt_override verbatim when supplied", () => {
+    const prompt = "You are a pirate. Answer in pirate.";
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      promptOverride: prompt,
+    });
+    expect(md.prompt_override).toBe(prompt);
+  });
+
+  test("preserves multi-line / unicode / emoji prompts byte-for-byte", () => {
+    const prompt = "Line 1\nLine 2 — ünicode\n\t• indented 🦜\n";
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      promptOverride: prompt,
+    });
+    expect(md.prompt_override).toBe(prompt);
+  });
+
+  test("throws when promptOverride exceeds the byte cap", () => {
+    const tooBig = "a".repeat(PROMPT_LAB_MAX_BYTES + 1);
+    expect(() =>
+      buildVoiceTestDispatchMetadata({
+        agentSlug: "x",
+        sessionId: "s",
+        callerEmail: "c@e.com",
+        promptOverride: tooBig,
+      }),
+    ).toThrow(/prompt/i);
+  });
+
+  test("accepts a prompt at the exact byte cap", () => {
+    const justRight = "a".repeat(PROMPT_LAB_MAX_BYTES);
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      promptOverride: justRight,
+    });
+    expect(md.prompt_override?.length).toBe(PROMPT_LAB_MAX_BYTES);
+  });
+
+  test("byte cap counts UTF-8 bytes, not JS string length", () => {
+    // A 4-byte UTF-8 code point (🦜) used to fill exactly past the cap.
+    // 1 emoji = 4 bytes in UTF-8 but 2 UTF-16 code units in a JS string.
+    // We want to make sure we reject on bytes, not on string length, so the
+    // worker's metadata cap (which LiveKit measures in bytes) holds.
+    const emoji = "🦜"; // 4 bytes
+    const count = Math.floor(PROMPT_LAB_MAX_BYTES / 4) + 1;
+    const tooBig = emoji.repeat(count);
+    expect(Buffer.byteLength(tooBig, "utf8")).toBeGreaterThan(
+      PROMPT_LAB_MAX_BYTES,
+    );
+    expect(() =>
+      buildVoiceTestDispatchMetadata({
+        agentSlug: "x",
+        sessionId: "s",
+        callerEmail: "c@e.com",
+        promptOverride: tooBig,
+      }),
+    ).toThrow(/prompt/i);
+  });
+
+  test("rejects empty / whitespace-only overrides", () => {
+    // An empty override would silently fall through to the worker's baked-in
+    // profile prompt — confusing for the operator who thinks they're testing
+    // their edit. Surface it as a validation error instead.
+    for (const v of ["", "   ", "\n\n\t"]) {
+      expect(() =>
+        buildVoiceTestDispatchMetadata({
+          agentSlug: "x",
+          sessionId: "s",
+          callerEmail: "c@e.com",
+          promptOverride: v,
+        }),
+      ).toThrow(/prompt/i);
+    }
+  });
+
+  test("the rest of the metadata shape is unchanged when override is set", () => {
+    // Lock-in that adding promptOverride doesn't perturb the existing five
+    // fields — the worker's routing on `agentName` must keep working.
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "agent_slug_v1",
+      sessionId: "sess-123",
+      callerEmail: "lab@corp.com",
+      promptOverride: "hi",
+    });
+    expect(md.mode).toBe("voice-test");
+    expect(md.agentName).toBe("agent_slug_v1");
+    expect(md.session_id).toBe("sess-123");
+    expect(md.user_identifier).toBe("lab@corp.com");
+    expect(md.email).toBe("lab@corp.com");
+    expect(Object.keys(md).sort()).toEqual(
+      [
+        "agentName",
+        "email",
+        "mode",
+        "prompt_override",
+        "session_id",
+        "user_identifier",
+      ].sort(),
+    );
+  });
+
+  test("round-trips through JSON without dropping prompt_override", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      promptOverride: "carry me through JSON.stringify cleanly",
+    });
+    expect(JSON.parse(JSON.stringify(md))).toEqual(md);
+  });
+});

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/prompt-lab-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/prompt-lab-panel.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * PromptLabPanel — POC prompt-iteration surface (ADR-015).
+ *
+ * The standard VoiceTestPanel tests the "talk to the deployed worker"
+ * flow. This panel tests the override path: type a prompt, click
+ * "Sync & Talk", the dispatch metadata carries `prompt_override`, the
+ * worker uses it as the agent's instructions for the session.
+ *
+ * Mocks mirror voice-test-panel.test.tsx so both panels exercise the
+ * same LiveKit stubs.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '~/schemas/agents'
+import { PromptLabPanel } from './prompt-lab-panel'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPost = vi.fn()
+let lastPostBody: unknown = null
+
+const mockTokenResponse = {
+  livekitUrl: 'wss://test.livekit.cloud',
+  roomName: 'voice-test-abc',
+  token: 'test-token-123',
+  sessionId: '00000000-0000-0000-0000-000000000001',
+  dispatchId: 'disp_abc',
+  agentName: 'test-agent',
+  profileName: 'test-agent',
+  identity: 'user-xyz',
+}
+
+vi.mock('~/lib/api', () => ({
+  api: {
+    post: (url: string, options?: { json?: unknown }) => {
+      mockPost(url, options?.json)
+      lastPostBody = options?.json ?? null
+      return { json: () => Promise.resolve(mockTokenResponse) }
+    },
+  },
+}))
+
+vi.mock('livekit-client', () => ({
+  ParticipantKind: { AGENT: 'agent' },
+  RoomEvent: { ParticipantConnected: 'participantConnected' },
+}))
+
+vi.mock('@livekit/components-react', () => ({
+  LiveKitRoom: ({ children }: { children: ReactNode }) => (
+    <div data-testid="lk-room">{children}</div>
+  ),
+  RoomAudioRenderer: () => <div data-testid="lk-audio" />,
+  useRoomContext: () => ({
+    localParticipant: { setMicrophoneEnabled: vi.fn().mockResolvedValue(undefined) },
+    remoteParticipants: new Map([['agent-1', { kind: 'agent', identity: 'agent-1' }]]),
+    on: vi.fn().mockReturnThis(),
+    off: vi.fn().mockReturnThis(),
+    disconnect: vi.fn(),
+  }),
+  useVoiceAssistant: () => ({ state: 'listening', audioTrack: undefined }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const configuredAgent: Agent = {
+  id: 'agent-1',
+  name: 'Test Agent',
+  slug: 'test-agent',
+  description: null,
+  modality: 'voice',
+  modelFamily: 'gpt',
+  agentPlatform: 'livekit',
+  isActive: true,
+  evalSuiteCount: 0,
+  promptConfig: {},
+  metadata: { livekit: { url: 'wss://test.livekit.cloud', agentName: 'test-agent' } },
+  secrets: { livekit_api_key: 'sec-1', livekit_api_secret: 'sec-2' },
+  hasElevenLabsKey: false,
+  hasWebhookSecret: false,
+  keyPrefix: null,
+  integrationUrls: undefined,
+  compiledInstructions: 'You are a helpful assistant.',
+  compiledAt: '2026-04-01T00:00:00Z',
+  compiledFrom: null,
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+function stubMicPermission(grant = true) {
+  const state: PermissionState = grant ? 'granted' : 'denied'
+  const getUserMedia = grant
+    ? vi.fn().mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] })
+    : vi.fn().mockRejectedValue(Object.assign(new Error('denied'), { name: 'NotAllowedError' }))
+  // @ts-expect-error — jsdom lacks mediaDevices
+  navigator.mediaDevices = { getUserMedia }
+  // @ts-expect-error — jsdom lacks Permissions API
+  navigator.permissions = { query: vi.fn().mockResolvedValue({ state }) }
+  return getUserMedia
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastPostBody = null
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PromptLabPanel', () => {
+  it('renders nothing for non-livekit agents', () => {
+    const elevenAgent = { ...configuredAgent, agentPlatform: 'elevenlabs' } as Agent
+    const { container } = render(<PromptLabPanel agent={elevenAgent} canMutate />, { wrapper })
+    expect(container.textContent).toBe('')
+  })
+
+  it("seeds the textarea with the agent's compiledInstructions", () => {
+    render(<PromptLabPanel agent={configuredAgent} canMutate />, { wrapper })
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toBe('You are a helpful assistant.')
+  })
+
+  it('falls back to an empty textarea when the agent has no compiled prompt', () => {
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    render(<PromptLabPanel agent={noPrompt} canMutate />, { wrapper })
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toBe('')
+  })
+
+  it('disables Sync & Talk when the textarea is empty / whitespace', () => {
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    render(<PromptLabPanel agent={noPrompt} canMutate />, { wrapper })
+    const btn = screen.getByRole('button', { name: /sync & talk/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('disables Sync & Talk for viewers (canMutate=false)', () => {
+    render(<PromptLabPanel agent={configuredAgent} canMutate={false} />, { wrapper })
+    expect(screen.getByRole('button', { name: /sync & talk/i })).toBeDisabled()
+  })
+
+  it('warns when LiveKit is not configured and disables the action', () => {
+    const unconfigured = { ...configuredAgent, secrets: {} } as Agent
+    render(<PromptLabPanel agent={unconfigured} canMutate />, { wrapper })
+    expect(screen.getByText(/configure the livekit/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sync & talk/i })).toBeDisabled()
+  })
+
+  it('POSTs the edited prompt as the request body and mounts the room', async () => {
+    stubMicPermission(true)
+    render(<PromptLabPanel agent={configuredAgent} canMutate />, { wrapper })
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'You are a pirate. Answer in pirate.' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /sync & talk/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/voice-test-prompt', {
+        prompt: 'You are a pirate. Answer in pirate.',
+      })
+    })
+    expect(lastPostBody).toEqual({ prompt: 'You are a pirate. Answer in pirate.' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lk-room')).toBeInTheDocument()
+      expect(screen.getByTestId('lk-audio')).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces a clear error when mic permission is denied', async () => {
+    stubMicPermission(false)
+    render(<PromptLabPanel agent={configuredAgent} canMutate />, { wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /sync & talk/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/microphone permission denied/i)
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/modelguide-ui/src/features/agents/components/prompt-lab-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/prompt-lab-panel.tsx
@@ -1,0 +1,224 @@
+/**
+ * Prompt Lab — POC voice-test surface with a live prompt editor (ADR-015).
+ *
+ * The standard VoiceTestPanel dispatches the worker against its baked-in
+ * profile prompt. This panel additionally sends the textarea content as
+ * `prompt_override` in dispatch metadata so the worker uses it as the
+ * agent's instructions for the session.
+ *
+ * Same room / mic / state-machine plumbing as VoiceTestPanel — the only
+ * differences are the POST body, the seeded textarea, and the button copy.
+ */
+
+import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
+import { useMutation } from '@tanstack/react-query'
+import { AlertTriangle, FlaskConical, Mic } from 'lucide-react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
+import { api } from '~/lib/api'
+import type { Agent, VoiceTestTokenResponse } from '~/schemas/agents'
+
+import { ensureMicPermission } from './voice-test/mic-permission'
+import { RoomController } from './voice-test/room-controller'
+import { PHASE_LABEL, type WidgetState } from './voice-test/state'
+
+interface PromptLabPanelProps {
+  agent: Agent
+  canMutate: boolean
+}
+
+export function PromptLabPanel({ agent, canMutate }: PromptLabPanelProps) {
+  const [state, setState] = useState<WidgetState>('IDLE')
+  const [token, setToken] = useState<string | null>(null)
+  const [wsUrl, setWsUrl] = useState<string | null>(null)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [prompt, setPrompt] = useState<string>(agent.compiledInstructions ?? '')
+
+  const endingRef = useRef(false)
+  const disconnectRef = useRef<(() => void) | null>(null)
+
+  const isLivekit = agent.agentPlatform === 'livekit'
+  const lkMeta = ((agent.metadata ?? {}) as Record<string, unknown>).livekit as
+    | Record<string, unknown>
+    | undefined
+  const secretsMap = agent.secrets ?? {}
+  const livekitConfigured =
+    !!lkMeta?.url &&
+    !!lkMeta?.agentName &&
+    !!secretsMap.livekit_api_key &&
+    !!secretsMap.livekit_api_secret
+
+  const promptTrimmedEmpty = useMemo(() => prompt.trim().length === 0, [prompt])
+  // Mirror the server's 60 KB max (PROMPT_LAB_MAX_BYTES = 50 000 bytes, with
+  // the route schema sitting at 60 000 chars for an early reject). Use chars
+  // here — cheap, and slightly stricter than bytes for a UI guard.
+  const promptTooLong = prompt.length > 60_000
+
+  const reset = useCallback(() => {
+    endingRef.current = false
+    setToken(null)
+    setWsUrl(null)
+    setSessionId(null)
+    setErrorMsg(null)
+    setState('IDLE')
+  }, [])
+
+  const startMutation = useMutation({
+    mutationFn: async (): Promise<VoiceTestTokenResponse> => {
+      setErrorMsg(null)
+      setState('CHECKING_MIC')
+      await ensureMicPermission()
+      setState('REQUESTING_TOKEN')
+      return api
+        .post(`agents/${agent.id}/voice-test-prompt`, { json: { prompt } })
+        .json<VoiceTestTokenResponse>()
+    },
+    onSuccess: (resp) => {
+      setSessionId(resp.sessionId)
+      setToken(resp.token)
+      setWsUrl(resp.livekitUrl)
+      setState('CONNECTING')
+    },
+    onError: (err) => {
+      setState('ERROR')
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to start Prompt Lab session')
+    },
+  })
+
+  const handleHangUp = useCallback(() => {
+    endingRef.current = true
+    setState('ENDING')
+    disconnectRef.current?.()
+  }, [])
+
+  const handleDisconnected = useCallback(() => {
+    setToken(null)
+    setWsUrl(null)
+    setState('ENDED')
+  }, [])
+
+  const handleRoomError = useCallback(
+    (err: Error) => {
+      if (endingRef.current || state === 'ENDED' || state === 'IDLE') return
+      const name = (err as unknown as { name?: string })?.name
+      const msg =
+        name === 'NotAllowedError'
+          ? 'Microphone access was revoked.'
+          : (err?.message ?? 'Connection lost.')
+      setErrorMsg(msg)
+      setState('ERROR')
+    },
+    [state],
+  )
+
+  if (!isLivekit) return null
+
+  const inCall =
+    state === 'CHECKING_MIC' ||
+    state === 'REQUESTING_TOKEN' ||
+    state === 'CONNECTING' ||
+    state === 'CONNECTED' ||
+    state === 'ENDING'
+
+  const showStartButton = state === 'IDLE' || state === 'ENDED' || state === 'ERROR'
+
+  const disabled = !canMutate || !livekitConfigured || promptTrimmedEmpty || promptTooLong
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <FlaskConical className="h-4 w-4" />
+            Prompt Lab
+            <Badge variant="warning">POC</Badge>
+          </CardTitle>
+          <Badge variant={state === 'CONNECTED' ? 'success' : 'default'} dot>
+            {PHASE_LABEL[state]}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {livekitConfigured ? (
+          <p className="text-sm text-fg-muted">
+            Edit the prompt, click <strong>Sync &amp; Talk</strong>, and the deployed LiveKit worker
+            will use your edits as the agent's instructions for this session — no redeploy. See
+            ADR-015 for trade-offs.
+          </p>
+        ) : (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-fg-secondary">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            Configure the LiveKit URL, API key, and secret for this agent before testing.
+          </div>
+        )}
+
+        <textarea
+          aria-label="Prompt"
+          className="mt-4 w-full min-h-[280px] rounded-lg border border-bg-subtle bg-bg-subtle p-3 font-mono text-xs text-fg-primary placeholder:text-fg-muted focus:border-brand-500/60 focus:outline-none"
+          value={prompt}
+          placeholder="You are a helpful voice assistant…"
+          onChange={(e) => setPrompt(e.target.value)}
+          spellCheck={false}
+          disabled={inCall}
+        />
+
+        <div className="mt-2 flex items-center justify-between text-[11px] text-fg-muted">
+          <span className="font-mono">{prompt.length.toLocaleString()} chars</span>
+          {promptTooLong ? (
+            <span className="text-error">Too long — keep under 60,000 chars.</span>
+          ) : null}
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          {showStartButton ? (
+            <Button
+              onClick={() => {
+                reset()
+                startMutation.mutate()
+              }}
+              loading={startMutation.isPending}
+              disabled={disabled}
+            >
+              <Mic className="h-4 w-4" />
+              {state === 'ENDED' ? 'Sync & talk again' : 'Sync & Talk'}
+            </Button>
+          ) : null}
+
+          {token && wsUrl ? (
+            <LiveKitRoom
+              serverUrl={wsUrl}
+              token={token}
+              connect={true}
+              audio={true}
+              video={false}
+              onDisconnected={handleDisconnected}
+              onError={handleRoomError}
+            >
+              <RoomAudioRenderer />
+              <RoomController
+                state={state}
+                setState={setState}
+                onHangUp={handleHangUp}
+                endingRef={endingRef}
+                disconnectRef={disconnectRef}
+              />
+            </LiveKitRoom>
+          ) : null}
+        </div>
+
+        {errorMsg ? (
+          <p className="mt-3 text-xs text-error" role="alert">
+            {errorMsg}
+          </p>
+        ) : null}
+
+        {inCall && sessionId ? (
+          <p className="mt-3 font-mono text-[11px] text-fg-muted">Session {sessionId}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
+++ b/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
@@ -26,6 +26,7 @@ import { DetailsCard } from '~/features/agents/components/details-card'
 import { IntegrationCard } from '~/features/agents/components/integration-card'
 import { OutboundCallDialog } from '~/features/agents/components/outbound-call-dialog'
 import { PlatformCard } from '~/features/agents/components/platform-card'
+import { PromptLabPanel } from '~/features/agents/components/prompt-lab-panel'
 import { PromptSection } from '~/features/agents/components/prompt-section'
 import { VoiceTestPanel } from '~/features/agents/components/voice-test-panel'
 import { api } from '~/lib/api'
@@ -464,6 +465,9 @@ function AgentDetailPage() {
 
           {/* Row 3b: Voice test (LiveKit agents only, rendered by the panel) */}
           <VoiceTestPanel agent={agent} canMutate={isAdmin} />
+
+          {/* Row 3c: Prompt Lab — POC, ADR-015 (LiveKit agents only) */}
+          <PromptLabPanel agent={agent} canMutate={isAdmin} />
 
           {/* Row 4: Integration (full width) */}
           <IntegrationCard agent={agent} isAdmin={isAdmin} onRegenerateSuccess={setNewApiKey} />


### PR DESCRIPTION
## Summary

Adds a "Prompt Lab" panel on the agent detail page that lets an admin edit a system prompt and immediately hear it on the deployed LiveKit worker — no redeploy. Iteration goes from a Railway round-trip (60–120s) to roughly the WebRTC connect time.

ADR-014's "Talk to agent" button is unchanged and remains the production parity check. The Prompt Lab is a separate opt-in surface; ADR-015 documents the intentional deviation, validation rules, and POC graduation criteria.

Inspired by the prompt-iteration loop on the public website (and surfaces like voiceblox.ai / Vapi).

## What ships

| Layer | Change |
|---|---|
| API | New `POST /api/agents/:id/voice-test-prompt` accepting `{ prompt }`. Pure helper `buildVoiceTestDispatchMetadata` gains an optional `promptOverride` with empty-string and 50 KB UTF-8 byte cap validation. Reuses existing `createVoiceTestSession` plumbing. |
| Worker | New pure `dispatch.py` (no livekit imports) exposes `extract_prompt_override` + `select_instructions`. `agent.py` reads the override from dispatch metadata; `BuildProAgent` accepts `instructions_override` and uses it verbatim instead of the baked-in profile prompt. Defensive fallback when missing/empty/wrong type. |
| UI | New `PromptLabPanel` reusing voice-test's room controller and mic pre-flight. Textarea seeded with `agent.compiledInstructions`. Sits next to `VoiceTestPanel`, labelled **POC**. |
| Docs | **ADR-015**, operator guide `docs/guide/prompt-lab.md`, worker README section with data-flow diagram, ADR index update. |

## TDD

Built red→green per layer. New tests:

- `modelguide-api/tests/unit/agents/prompt-lab-dispatch.test.ts` — locks the MG-side metadata contract for the override path (mirrors the existing `voice-test-dispatch.test.ts` shape lock).
- `modelguide-api/tests/integration/agents.test.ts` — 7 new cases on the new endpoint (401 / 403 / 404 cross-org / 404 unknown / 400 empty / 400 oversized / 400 LiveKit not configured / 400 whitespace).
- `examples/agents/livekit-agent/tests/test_dispatch.py` — 9 pure-python tests locking the worker-side read half of the contract (fallback rules, type guards, lazy default factory).
- `modelguide-ui/src/features/agents/components/prompt-lab-panel.test.tsx` — 8 component tests covering seed, validation gating, mic pre-flight, request body shape, and the LiveKit-unconfigured warning.

## Test plan

- [x] API unit tests: `bun run test:unit` — 905/905 pass
- [x] API typecheck: `bun run typecheck` — clean
- [x] API lint: `bun run lint:check` — clean
- [x] UI tests: `bunx vitest run` — 276/276 pass
- [x] UI typecheck: `bun run typecheck` — clean
- [x] UI lint: `bun run lint` — clean
- [x] Worker pure-python tests: `pytest tests/test_dispatch.py tests/test_prompts.py` — 22/22 pass
- [x] Python syntax check on modified files (agent.py, buildpro.py, dispatch.py)
- [ ] Integration test suite (`bun run test:integration`) — needs Docker; will run in CI
- [ ] Manual end-to-end with a deployed worker — needs a LiveKit-configured agent in a real org

## What this deliberately is not

- Not a replacement for "Talk to agent" — production prompt source is still the worker's profile.
- Not durable — no prompt drafts, no version history, no diff. By design (see ADR-015 graduation criteria).
- Does not auto-compile from a SOP — the existing **Compile** UI already lives on the same page; this is a free-form editor that seeds from `compiledInstructions`.

## Related

- ADR-014 — Browser Voice Testing (parent decision)
- ADR-011 — LiveKit Outbound Calls (shared dispatch plumbing)
- `docs/guide/prompt-lab.md` — operator how-to


---
_Generated by [Claude Code](https://claude.ai/code/session_01PGX2ubi1iuGUrLCVRnsegb)_