### PR TITLE
feat(livekit): prompt-fetching agent prototype for click-compile-then-talk loop

### DIFF
--- a/docs/decisions/015-dynamic-prompt-livekit-agent.md
+++ b/docs/decisions/015-dynamic-prompt-livekit-agent.md
@@ -1,0 +1,82 @@
+# ADR-015: Dynamic Prompt-Fetching LiveKit Agent
+
+**Status:** Accepted (prototype)
+
+## Context
+
+[ADR-014](./014-browser-voice-testing.md) shipped one-click voice testing from the dashboard, but it explicitly opted **not** to inject the prompt into dispatch metadata. The rationale was sound: a worker is the authoritative source of its prompt + tools, and prompt injection at dispatch time creates a "works in voice-test, breaks in prod" drift mode.
+
+That decision left a gap in the actual UX we want: **edit a SOP → click Compile → click Talk to agent → hear the change**. Today that loop is broken by the worker's baked-in `prompts/` module. The buildpro example (`examples/agents/livekit-agent/`) interpolates a session ID into a template that is otherwise frozen at deploy time. Recompiling a prompt in the dashboard updates `agents.compiled_instructions` in the database, but the worker never reads it — so the operator hears yesterday's prompt no matter what.
+
+The platform also has no LiveKit-specific equivalent of the ElevenLabs "Sync" button. For ElevenLabs we push prompt + MCP config + webhook secret to the provider via `POST /agents/:id/sync`. For LiveKit there is no provider-side prompt store, so "sync" has to mean something else: **make the worker re-read the prompt at session start**.
+
+[voiceblox](https://github.com/voiceblox-ai/voiceblox) handles this by treating the worker as a stateless prompt executor — every call starts with a fresh fetch. We want the same pattern as a first-class option on this platform.
+
+## Decision
+
+Add a second LiveKit example, `examples/agents/livekit-prompt-test-agent/`, that fetches its system prompt from ModelGuide on every session via a new endpoint, **`GET /api/agents/me`**:
+
+- **Auth:** the calling agent's `mgk_*` API key in `Authorization: Bearer`. User JWTs are rejected — this endpoint exists for workers, not the dashboard.
+- **Response:** the same shape as `GET /api/agents/:id`, including `compiledInstructions`. Reuses `formatAgent()` so there is one canonical shape.
+- **Route ordering:** registered before `/:id` so the static `/me` segment wins over the UUID parameter.
+
+The worker, on every session:
+
+1. Parses dispatch metadata (carries `session_id` when the voice-test endpoint pre-created one — ADR-014's contract).
+2. Calls `load_prompt()` → `GET /api/agents/me` → uses the returned `compiledInstructions` as the LLM's system prompt.
+3. Falls back to a verbose `FALLBACK_PROMPT` on any error (no compiled prompt, 5xx, network blip). **Never raises**, because a voice call is already in flight by the time this runs and dead air is the worst outcome.
+
+### Why a new agent example, not a flag on the existing one
+
+The buildpro agent has cart tracking, reorder guardrails, and 11 MCP tools — production-shape concerns that would obscure the prompt-fetching diff. A separate `livekit-prompt-test-agent/` directory keeps the prototype small (~5 source files, ~250 LoC) and the comparison legible. Anyone who wants both behaviours can copy the `prompt_loader.py` into a fork of buildpro and override `instructions` in `__init__`; it's three lines.
+
+### What this changes vs ADR-014
+
+ADR-014 rejected putting prompts in **dispatch metadata**. That rejection still stands and was correct:
+
+- It capped metadata size at 48KB and required byte-size guards.
+- The MG TypeScript and the Python worker have no shared type system, so a prompt injected via dispatch could silently mismatch what the worker expected.
+- A new orgs's worker would have to learn the dispatch contract to be useful.
+
+This ADR moves the prompt source from dispatch metadata to a **dedicated authenticated REST call from the worker to the API**. That fixes all three concerns:
+
+- Size — the API response can hold a 100KB compiled prompt with no metadata caps.
+- Drift — `compiledInstructions` is a single column with a single writer (the compiler); both UI and worker read the same row.
+- Discoverability — `GET /api/agents/me` is in the OpenAPI spec and discoverable by any new worker implementation.
+
+### What this deliberately does NOT do
+
+- **No multi-agent routing.** This worker authenticates as a single ModelGuide agent (one `mgk_*` key → one agent). If you want one LiveKit worker process serving many MG agents, look at the buildpro example's profile registry pattern; the prompt fetch in this prototype works the same way per-profile, you just need to attach the right API key per profile.
+- **No tools.** The prototype is prompt-only. Adding `@function_tool` methods + an `MCPConnection` is a copy/paste from the buildpro example.
+- **No prompt diff / version pinning.** Every session fetches "whatever is current". An eval suite that wants to lock the prompt should snapshot it via the compiler endpoint into the eval row, not via this worker.
+
+## Alternatives Considered
+
+**Bake prompt into the worker image and redeploy on every change.** Current state. Cycle time is 2–10 minutes per change; this prototype takes it to <2 seconds.
+
+**Embed prompt in dispatch metadata.** Rejected by ADR-014 for the reasons quoted above. We considered revisiting it for the size-bounded compiled prompts only, but the metadata route still creates the drift mode (a different worker version could parse the metadata differently) without buying anything that a REST call doesn't.
+
+**Push prompts via a new `/livekit/sync` endpoint that updates worker config.** Rejected — LiveKit Cloud has no concept of per-worker config that the platform can write to. The closest thing is `lk agent update-secrets`, which requires the `lk` CLI in the API server and a deploy roundtrip. A worker-side fetch is strictly simpler.
+
+**Cache the prompt in the worker for N seconds.** Rejected for the prototype — the latency budget for `GET /api/agents/me` is well under 50ms against a co-located API, which is invisible compared to the ~300ms STT + 500ms LLM TTFT we already pay on the first turn. Add a cache if the API becomes a bottleneck for prod-scale workers; for the iterate-on-prompts use case, fresh-every-time is the entire point.
+
+## Consequences
+
+- **`GET /api/agents/me`** is a new public-shape endpoint. Its response reuses `agentResponseSchema` so any field added to the regular agent response automatically appears here. Tests guard the auth boundary (no user JWTs) and the freshness guarantee (a write must be visible on the next read).
+- **Two LiveKit examples now coexist.** The buildpro example remains the reference for tool-using production agents; the new `livekit-prompt-test-agent` is the reference for prompt-iteration loops and for new orgs that don't yet have tools wired up. Both speak the same dispatch contract (ADR-014) and can be A/B-tested against the same MG agent by flipping `metadata.livekit.agentName`.
+- **No new attack surface.** The `mgk_*` API key already scopes access to one agent's data; `GET /api/agents/me` returns strictly less than what a JWT-authed admin sees (no integration URLs that depend on user context, etc., all derived from the same `formatAgent()` helper, and no decrypted secrets — never were any).
+- **Operator footgun:** if the worker is running but the ModelGuide agent has no compiled prompt yet, the operator hears `FALLBACK_PROMPT`, which says exactly that. That's by design — silent default behaviour would be worse.
+
+## Tests
+
+- **API integration (`tests/integration/agents.test.ts`):** four new tests covering happy path, "fresh write is visible to the next read", missing auth → 401, and user JWT → 401.
+- **Worker unit (`livekit-prompt-test-agent/tests/`):** 17 tests across `prompt_loader` and `dynamic_agent`. The loader is tested with `httpx.MockTransport` — no network, no LiveKit. The agent's defensive `livekit.agents.Agent` import lets the tests run in bare environments (`python -m pytest`) without installing the LiveKit runtime.
+
+Written TDD red→green: the loader tests existed and failed (`ModuleNotFoundError`) before any source file in `src/` was created.
+
+## Related
+
+- ADR-014: Browser Voice Testing via LiveKit Dispatch — the dispatch contract this worker plugs into.
+- ADR-011: LiveKit Outbound Calls — same dispatch primitive, different metadata shape.
+- `examples/agents/livekit-agent/` — the production-shape BuildPro Sam example with baked prompts + MCP tools.
+- `examples/agents/livekit-prompt-test-agent/` — the prototype this ADR ships.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing via LiveKit Dispatch | Accepted |
+| [015-dynamic-prompt-livekit-agent.md](015-dynamic-prompt-livekit-agent.md) | Dynamic Prompt-Fetching LiveKit Agent | Accepted (prototype) |

--- a/examples/agents/livekit-prompt-test-agent/.dockerignore
+++ b/examples/agents/livekit-prompt-test-agent/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+tests/
+*.md
+livekit.toml

--- a/examples/agents/livekit-prompt-test-agent/.env.example
+++ b/examples/agents/livekit-prompt-test-agent/.env.example
@@ -1,0 +1,46 @@
+# LiveKit worker name. Must match what you set on the ModelGuide agent
+# (Settings → LiveKit → "Agent Name"). The voice-test endpoint dispatches
+# into a worker registered under this name.
+AGENT_NAME=modelguide-prompt-test
+
+# LiveKit
+# For local dev: use the built-in dev credentials (`livekit-server --dev`
+# uses these by default). For LiveKit Cloud, these are injected by the
+# platform and can be left blank.
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# ModelGuide
+# Base URL of your ModelGuide API (no trailing slash)
+MODELGUIDE_API_URL=http://localhost:3000
+# Agent API key (mgk_xxx) — shown once at agent creation in the dashboard.
+# The worker authenticates as this agent and fetches that agent's compiled
+# prompt via GET /api/agents/me.
+MODELGUIDE_API_KEY=mgk_your-agent-key-here
+
+# Optional: identifier used when MG didn't pre-create a session
+# (e.g. local CLI runs that aren't going through the voice-test endpoint).
+USER_EMAIL=voice-caller
+
+# Spoken greeting before the LLM is invoked. Keep it short — the LLM's
+# first reply is what the operator is actually trying to hear.
+# GREETING=Hi — what can I help you with today?
+
+# OpenAI LLM
+OPENAI_API_KEY=sk-your-openai-key
+# LLM_MODEL=gpt-4.1-mini
+
+# Deepgram STT
+DEEPGRAM_API_KEY=your-deepgram-key
+# STT_MODEL=nova-3   # or 'flux'
+
+# TTS provider — set ONE of these and the corresponding API key.
+# TTS_PROVIDER=elevenlabs   (default)
+ELEVENLABS_API_KEY=your-elevenlabs-key
+# ELEVENLABS_VOICE_ID=iP95p4xoKVk53GoZ742B
+
+# Or Cartesia:
+# TTS_PROVIDER=cartesia
+# CARTESIA_API_KEY=your-cartesia-key
+# CARTESIA_VOICE_ID=

--- a/examples/agents/livekit-prompt-test-agent/.gitignore
+++ b/examples/agents/livekit-prompt-test-agent/.gitignore
@@ -1,0 +1,8 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.coverage
+htmlcov/
+.cache/

--- a/examples/agents/livekit-prompt-test-agent/Dockerfile
+++ b/examples/agents/livekit-prompt-test-agent/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Download models at build time (avoids runtime download)
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/main.py", "start"]

--- a/examples/agents/livekit-prompt-test-agent/README.md
+++ b/examples/agents/livekit-prompt-test-agent/README.md
@@ -1,0 +1,151 @@
+# LiveKit Prompt-Test Agent
+
+A lean LiveKit voice agent that **fetches its system prompt from ModelGuide on every session**. Inspired by [voiceblox](https://github.com/voiceblox-ai/voiceblox): one prompt, no business logic, instant feedback loop.
+
+The point of this worker is the dashboard loop it unlocks:
+
+> **Compile prompt** → **click "Talk to agent"** → **hear the prompt you just compiled** — no worker redeploy needed.
+
+The existing [`livekit-agent/`](../livekit-agent/) (BuildPro Sam) bakes its prompt into the image. That's the right shape for production agents with custom tools and guardrails, but it makes prompt iteration painful — every tweak needs a deploy. This prototype trades the bakedness for liveness.
+
+## What's in the box
+
+| File | Job |
+|------|-----|
+| `src/prompt_loader.py` | Calls `GET /api/agents/me` with the worker's API key, returns the live `compiledInstructions`. Falls back to a verbose default if the API is unreachable or no prompt is compiled. |
+| `src/dynamic_agent.py` | Thin `livekit.agents.Agent` subclass — instructions arrive at construction time. No tools, no hooks. |
+| `src/mg_client.py` | REST client for session create/complete + transcript submission. |
+| `src/main.py` | Worker entrypoint: parse dispatch metadata → fetch prompt → run `AgentSession` → post transcript on close. |
+| `src/providers.py` | STT/TTS factories (Deepgram, ElevenLabs, Cartesia). |
+| `src/config.py` | Env-var loading + validation. |
+| `tests/` | Unit tests against `httpx.MockTransport` — no network, no LiveKit required. |
+
+## Stack
+
+| Component | Service |
+|-----------|---------|
+| Transport | LiveKit Cloud WebRTC |
+| VAD | Silero |
+| Turn detection | English EOU model |
+| STT | Deepgram Nova-3 |
+| LLM | OpenAI GPT-4.1-mini |
+| TTS | ElevenLabs Flash v2.5 (or Cartesia) |
+| Prompt | **Fetched live from `GET /api/agents/me`** |
+| Tools | None (yet — see "Adding tools" below) |
+
+## Prerequisites
+
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
+- API keys for OpenAI, Deepgram, and ElevenLabs
+- A running ModelGuide API with an active agent that has:
+  - A `mgk_*` API key (created with the agent)
+  - LiveKit configured (URL, API key/secret, **Agent Name = `modelguide-prompt-test`** — or whatever you set in `AGENT_NAME` below)
+  - A compiled prompt (Prompt → Compile in the dashboard)
+
+## Quick start (local)
+
+```bash
+cd examples/agents/livekit-prompt-test-agent
+uv venv && uv pip install -e .
+cp .env.example .env
+# Edit .env with your API keys + the agent's mgk_* key
+```
+
+Then in three terminals:
+
+```bash
+# Terminal 1 — local LiveKit server
+livekit-server --dev
+
+# Terminal 2 — the worker
+uv run python src/main.py dev
+
+# Terminal 3 — from the ModelGuide dashboard, open the agent detail page
+# and click "Talk to agent" in the Voice Test panel.
+```
+
+When the worker boots it logs:
+
+```
+agent | INFO | modelguide-prompt-test prompt-test agent v0.1.0 — entrypoint called
+agent | INFO | Participant joined: user-...
+prompt_loader | INFO | Loaded compiled prompt for agent <slug> (<id>, NNNN chars)
+```
+
+That last line is the proof the prompt came from ModelGuide — not from disk.
+
+### Text-only console mode (no WebRTC)
+
+```bash
+uv run python src/main.py console
+```
+
+Useful for sanity-checking the prompt fetch without an audio pipeline.
+
+## How the dashboard loop works
+
+1. **Operator** edits the SOP / prompt config in the dashboard.
+2. **Operator** clicks **Compile** in the Prompt section → `POST /api/agents/:id/compile` persists `compiledInstructions` on the agent row.
+3. **Operator** clicks **Talk to agent** in the Voice Test panel.
+4. **Dashboard** calls `POST /api/agents/:id/voice-test-token` — ModelGuide creates a session, dispatches a worker registered under the agent's configured `agentName`, and returns a short-lived LiveKit token.
+5. **Worker** boots, calls `GET /api/agents/me` with its own `mgk_*` API key, reads the *just-compiled* `compiledInstructions`, and passes them to the LLM.
+6. **Operator** hears the new prompt within ~2 seconds of the click.
+
+This works because (5) happens on **every session**, not at worker startup. There's no in-memory cache to invalidate, no deploy to wait for.
+
+## Configuration
+
+All env vars are documented in `.env.example`. The two non-obvious ones:
+
+- **`AGENT_NAME`** — the LiveKit worker registers itself under this name. The ModelGuide agent's "LiveKit → Agent Name" must match, or the voice-test dispatch will timeout silently (the room stays empty for 15 seconds, then the browser gives up).
+- **`MODELGUIDE_API_KEY`** — this is the `mgk_*` key shown when the ModelGuide agent was created. The worker authenticates as this agent for `GET /api/agents/me`. **One worker = one agent.** If you want one worker process to serve multiple ModelGuide agents (multi-profile), look at the buildpro example for the routing pattern.
+
+## Adding tools
+
+This prototype is prompt-only. To add MCP tools (`add_to_cart`, etc.), follow the buildpro pattern:
+
+1. Subclass `DynamicAgent` with `@function_tool` methods.
+2. Import an `MCPConnection` from a copy of `livekit-agent/src/mg_client.py` (the streamablehttp_client bits).
+3. Open the connection during entrypoint, pass it into your subclass, route each `@function_tool` to `mcp.call_tool(...)`.
+
+We deliberately left that out of the prototype so the diff stays small and the prompt-fetching story stays the headline.
+
+## Deployment
+
+LiveKit Cloud (one-time):
+
+```bash
+lk cloud auth login
+lk agent create   # writes livekit.toml — commit the project/agent IDs
+lk agent update-secrets \
+  OPENAI_API_KEY=sk-... \
+  DEEPGRAM_API_KEY=... \
+  ELEVENLABS_API_KEY=... \
+  MODELGUIDE_API_URL=https://your-mg.up.railway.app \
+  MODELGUIDE_API_KEY=mgk_your-agent-key \
+  AGENT_NAME=modelguide-prompt-test
+lk agent deploy
+```
+
+After that, every `lk agent deploy` ships the **worker** — your **prompt** lives in the database and updates the moment you hit Compile.
+
+## Tests
+
+```bash
+uv run pytest               # all tests (~0.1s)
+uv run pytest -k loader     # just the prompt-loader tests
+```
+
+The tests run without LiveKit installed (the agent module has a defensive import). They cover:
+
+- `prompt_loader.fetch_agent_profile` — request shape, success, 401/500/transport failures
+- `prompt_loader.load_prompt` — happy path + every fallback case
+- `dynamic_agent.DynamicAgent` — construction without I/O, transcript isolation
+
+Tool execution is not covered (no tools yet).
+
+## Related
+
+- [ADR-014](../../../docs/decisions/014-browser-voice-testing.md) — the voice-test dispatch endpoint this worker is dispatched into.
+- [ADR-015](../../../docs/decisions/015-dynamic-prompt-livekit-agent.md) — why this prototype exists and how it deviates from ADR-014's "no prompt injection" stance.
+- [`../livekit-agent/`](../livekit-agent/) — the production-shape BuildPro Sam example with MCP tools and baked prompts.

--- a/examples/agents/livekit-prompt-test-agent/livekit.toml
+++ b/examples/agents/livekit-prompt-test-agent/livekit.toml
@@ -1,0 +1,7 @@
+# LiveKit Cloud manifest. Populated by `lk agent create` — see
+# DEPLOY.md in this directory for the first-time setup.
+[project]
+  subdomain = ""
+
+[agent]
+  id = ""

--- a/examples/agents/livekit-prompt-test-agent/pyproject.toml
+++ b/examples/agents/livekit-prompt-test-agent/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "livekit-prompt-test-agent"
+version = "0.1.0"
+description = "LiveKit voice agent that fetches its system prompt from ModelGuide on every session — voiceblox-style, for the 'click compile → click talk' dashboard loop."
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "livekit-plugins-cartesia~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/examples/agents/livekit-prompt-test-agent/src/config.py
+++ b/examples/agents/livekit-prompt-test-agent/src/config.py
@@ -1,0 +1,107 @@
+"""Environment variable loading and validation.
+
+AGENT_NAME is read at import time (the LiveKit worker registers itself
+under that name before ``validate()`` runs). Everything else is set up
+by ``validate()`` so the worker process can boot far enough to log a
+useful error when env vars are missing — instead of crashing during
+module import with a stack trace nobody reads.
+"""
+
+import logging
+import os
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger("config")
+
+load_dotenv()
+
+REQUIRED_VARS = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+# Read at import time — the LiveKit worker needs this to register
+# itself. If unset, the worker will use the literal string below;
+# anything that dispatches to a different agent name simply won't reach
+# this worker.
+AGENT_NAME: str = os.getenv("AGENT_NAME", "modelguide-prompt-test")
+
+# Filled in by validate()
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+CARTESIA_API_KEY: str = ""
+LLM_MODEL: str = "gpt-4.1-mini"
+STT_MODEL: str = "nova-3"
+TTS_PROVIDER: str = "elevenlabs"
+ELEVENLABS_VOICE_ID: str = ""
+CARTESIA_VOICE_ID: str = ""
+
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+USER_EMAIL: str = ""
+
+GREETING: str = ""
+
+
+_validated = False
+
+
+def validate() -> None:
+    """Validate required env vars and populate module-level constants.
+
+    Safe to call multiple times — only runs once.
+    """
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    g = globals()
+    g.update({
+        "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+        "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+        "ELEVENLABS_API_KEY": os.getenv("ELEVENLABS_API_KEY", ""),
+        "CARTESIA_API_KEY": os.getenv("CARTESIA_API_KEY", ""),
+        "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4.1-mini"),
+        "STT_MODEL": os.getenv("STT_MODEL", "nova-3"),
+        "TTS_PROVIDER": os.getenv("TTS_PROVIDER", "elevenlabs"),
+        "ELEVENLABS_VOICE_ID": os.getenv(
+            "ELEVENLABS_VOICE_ID", "iP95p4xoKVk53GoZ742B"
+        ),
+        "CARTESIA_VOICE_ID": os.getenv(
+            "CARTESIA_VOICE_ID", "a167e0f3-df7e-4d52-a9c3-f949145571bd"
+        ),
+        "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+        "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+        "USER_EMAIL": os.getenv("USER_EMAIL", "voice-caller"),
+        "GREETING": os.getenv(
+            "GREETING",
+            "Hi — what can I help you with today?",
+        ),
+    })
+
+    tts = g["TTS_PROVIDER"]
+    if tts == "cartesia" and not g["CARTESIA_API_KEY"]:
+        raise ConfigError(
+            "TTS_PROVIDER=cartesia but CARTESIA_API_KEY is not set"
+        )
+    if tts == "elevenlabs" and not g["ELEVENLABS_API_KEY"]:
+        raise ConfigError(
+            "TTS_PROVIDER=elevenlabs but ELEVENLABS_API_KEY is not set"
+        )
+
+    _validated = True

--- a/examples/agents/livekit-prompt-test-agent/src/dynamic_agent.py
+++ b/examples/agents/livekit-prompt-test-agent/src/dynamic_agent.py
@@ -1,0 +1,51 @@
+"""Voice agent whose system prompt is loaded at runtime from ModelGuide.
+
+The class itself is intentionally a thin holder of
+``(session_id, instructions, transcript)``. The interesting work — fetch
+the compiled prompt, mint a session, run the audio loop — happens in
+``main.py``. Keeping this class tiny makes it easy to unit-test without
+spinning up a LiveKit session.
+
+For an agent that ALSO calls MCP tools (e.g. add_to_cart, get_order),
+add ``@function_tool`` methods on a subclass and route to MCP from there
+— the same pattern as the buildpro example's ``BuildProAgent``. For
+this prototype we focus only on the prompt loop so the diff is small.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from transcript import TranscriptCollector
+
+# Defensive import: the livekit-agents package isn't installed in the
+# bare unit-test environment (CI's pytest run has it, but a one-off
+# `python -m pytest tests/` on a freshly cloned repo doesn't need to
+# bring in the LiveKit runtime just to verify construction). Fall back
+# to a minimal stand-in that holds the same ``instructions`` attribute
+# the LiveKit Agent exposes.
+try:
+    from livekit.agents import Agent as _LiveKitAgent  # type: ignore
+except ImportError:  # pragma: no cover — exercised only in bare envs
+    class _LiveKitAgent:  # type: ignore[no-redef]
+        def __init__(self, *, instructions: str) -> None:
+            self.instructions = instructions
+
+
+class DynamicAgent(_LiveKitAgent):
+    """LiveKit ``Agent`` with a runtime-supplied system prompt.
+
+    The prompt comes from ``prompt_loader.load_prompt`` in the entrypoint
+    — by the time the agent is constructed, the string is already
+    finalized. This class doesn't do any I/O.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: Optional[str],
+        instructions: str,
+    ) -> None:
+        self.session_id = session_id
+        self.transcript = TranscriptCollector()
+        super().__init__(instructions=instructions)

--- a/examples/agents/livekit-prompt-test-agent/src/main.py
+++ b/examples/agents/livekit-prompt-test-agent/src/main.py
@@ -1,0 +1,206 @@
+"""LiveKit voice-agent entrypoint that fetches its prompt at runtime.
+
+Lifecycle per session:
+
+    1. Parse dispatch metadata (carries the ModelGuide session_id when
+       the voice-test endpoint pre-created one — see ADR-014).
+    2. Fetch the calling agent's compiled prompt via
+       ``GET /api/agents/me`` using the worker's mgk_* API key.
+    3. If MG didn't pre-create a session, create one now so the call
+       still shows up in the dashboard.
+    4. Run the LiveKit AgentSession (STT → LLM → TTS).
+    5. On disconnect, post the transcript and mark the session
+       completed/abandoned.
+
+The point of this worker is the prompt fetch in step 2: it makes
+"Compile → click Talk to agent" pick up the latest prompt without a
+worker redeploy.
+
+CLI:
+    python src/main.py console     (text-only, no WebRTC)
+    python src/main.py dev         (full WebRTC, local LiveKit)
+    python src/main.py start       (production worker)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from livekit import agents
+from livekit.agents import AgentSession
+from livekit.plugins import openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+import mg_client
+from dynamic_agent import DynamicAgent
+from prompt_loader import load_prompt
+from providers import create_stt, create_tts
+
+VERSION = "0.1.0"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(name)s | %(levelname)s | %(message)s",
+)
+logger = logging.getLogger("agent")
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    """LiveKit agent entrypoint — called once per room/job."""
+    config.validate()
+    logger.info(
+        "%s prompt-test agent v%s — entrypoint called",
+        config.AGENT_NAME,
+        VERSION,
+    )
+
+    # Voice-test dispatch metadata (from POST /agents/:id/voice-test-token)
+    # carries a pre-created session_id; for non-voice-test rooms we create
+    # one ourselves below.
+    dispatch_metadata: dict = {}
+    if ctx.job.metadata:
+        try:
+            dispatch_metadata = json.loads(ctx.job.metadata)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Invalid JSON in job metadata: %s", ctx.job.metadata[:100]
+            )
+
+    await ctx.connect()
+    participant = await ctx.wait_for_participant()
+    logger.info("Participant joined: %s", participant.identity)
+
+    # Fetch the live compiled prompt from ModelGuide. Falls back to
+    # FALLBACK_PROMPT on any failure (see prompt_loader.py) — never
+    # raises, because dead air on a live call is the worst outcome.
+    http = mg_client.get_http_client()
+    instructions = await load_prompt(
+        http,
+        api_url=config.MODELGUIDE_API_URL,
+        api_key=config.MODELGUIDE_API_KEY,
+    )
+
+    user_identifier = (
+        dispatch_metadata.get("user_identifier")
+        or dispatch_metadata.get("email")
+        or participant.identity
+        or config.USER_EMAIL
+    )
+
+    session_id = dispatch_metadata.get("session_id")
+    if not session_id:
+        try:
+            session_id = await mg_client.create_session(user_identifier)
+        except Exception:
+            logger.exception(
+                "Failed to create ModelGuide session — running without tracking"
+            )
+    logger.info(
+        "ModelGuide session: %s (user: %s)", session_id, user_identifier
+    )
+
+    agent = DynamicAgent(session_id=session_id, instructions=instructions)
+    stt = create_stt()
+    tts = create_tts()
+
+    session = AgentSession(
+        stt=stt,
+        llm=openai.LLM(
+            model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY
+        ),
+        tts=tts,
+        vad=silero.VAD.load(),
+        turn_detection="stt" if config.STT_MODEL == "flux" else EnglishModel(),
+        allow_interruptions=True,
+        min_interruption_duration=1.0,
+        min_endpointing_delay=0.5,
+    )
+
+    @session.on("user_input_transcribed")
+    def _on_user_speech(ev):
+        if ev.is_final:
+            agent.transcript.add_user_utterance(ev.transcript)
+
+    @session.on("conversation_item_added")
+    def _on_conversation_item(ev):
+        item = ev.item
+        if not (hasattr(item, "role") and item.role == "assistant"):
+            return
+        text = _extract_text(item)
+        if text:
+            agent.transcript.add_assistant_response(text)
+
+    session_done = asyncio.Event()
+
+    @session.on("close")
+    def _on_close():
+        logger.info("Session close event fired")
+        session_done.set()
+
+    @ctx.room.on("disconnected")
+    def _on_disconnect():
+        logger.info("Room disconnected event fired")
+        session_done.set()
+
+    await session.start(room=ctx.room, agent=agent)
+
+    # Opening line. Keep it short — the LLM's first reply is what the
+    # operator cares about hearing.
+    await session.say(config.GREETING)
+
+    try:
+        await session_done.wait()
+    finally:
+        logger.info(
+            "Running cleanup (messages: %d)",
+            len(agent.transcript.get_messages()),
+        )
+        await _cleanup(session_id, agent)
+
+
+def _extract_text(item) -> str:
+    """Extract text from a conversation item's content."""
+    if not hasattr(item, "content") or not item.content:
+        return ""
+    if isinstance(item.content, str):
+        return item.content.strip()
+    if isinstance(item.content, list):
+        return " ".join(
+            part if isinstance(part, str) else getattr(part, "text", "")
+            for part in item.content
+        ).strip()
+    return ""
+
+
+async def _cleanup(session_id: str | None, agent: DynamicAgent) -> None:
+    """Post transcript and complete the ModelGuide session."""
+    if not session_id:
+        await mg_client.close_http_client()
+        return
+    try:
+        messages = agent.transcript.get_messages()
+        status = "completed" if len(messages) > 1 else "abandoned"
+        if messages:
+            await mg_client.add_messages(session_id, messages)
+            logger.info(
+                "Posted %d messages to session %s", len(messages), session_id
+            )
+        await mg_client.complete_session(session_id, status=status)
+    except Exception:
+        logger.exception(
+            "Failed to post transcript / complete session %s", session_id
+        )
+    finally:
+        await mg_client.close_http_client()
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-prompt-test-agent/src/mg_client.py
+++ b/examples/agents/livekit-prompt-test-agent/src/mg_client.py
@@ -1,0 +1,104 @@
+"""Minimal ModelGuide REST client used by the prompt-test agent.
+
+Scope: session create/complete + post-call transcript submission. Tool
+execution is intentionally not handled here — this prototype targets
+the prompt-iteration loop, not full MCP-tool playback. Add an
+``MCPConnection`` (see the buildpro example) if you want tool calls.
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+import config
+
+logger = logging.getLogger("mg_client")
+
+
+# A shared client gives us one TCP connection pool per worker process.
+_http_client: Optional[httpx.AsyncClient] = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Lazy-init a shared httpx.AsyncClient for REST calls."""
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(
+            base_url=config.MODELGUIDE_API_URL,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {config.MODELGUIDE_API_KEY}",
+            },
+            timeout=30.0,
+        )
+    return _http_client
+
+
+async def close_http_client() -> None:
+    """Close the shared HTTP client. Call during shutdown."""
+    global _http_client
+    if _http_client and not _http_client.is_closed:
+        await _http_client.aclose()
+        _http_client = None
+
+
+async def create_session(user_identifier: Optional[str] = None) -> str:
+    """Create a new ModelGuide session. Returns the session ID."""
+    client = get_http_client()
+    res = await client.post(
+        "/api/sessions",
+        json={
+            "channelType": "voice",
+            "userIdentifier": user_identifier or "voice-caller",
+        },
+    )
+    res.raise_for_status()
+    data = res.json()
+    session_id = data["id"]
+    logger.info("Session created: %s", session_id)
+    return session_id
+
+
+async def add_messages(session_id: str, messages: list[dict]) -> None:
+    """Post messages to a session. Errors are logged, not raised — the
+    voice call is already over by the time this runs."""
+    client = get_http_client()
+    for msg in messages:
+        try:
+            res = await client.post(
+                f"/api/sessions/{session_id}/messages", json=msg
+            )
+            if not res.is_success:
+                logger.warning(
+                    "Failed to post message (status %s): %s",
+                    res.status_code,
+                    res.text,
+                )
+        except Exception:
+            logger.exception("Error posting message to session %s", session_id)
+
+
+async def complete_session(
+    session_id: str,
+    status: str = "completed",
+    metadata: Optional[dict] = None,
+) -> None:
+    """Mark session as completed or abandoned."""
+    client = get_http_client()
+    body: dict = {"status": status}
+    if metadata:
+        body["metadata"] = metadata
+    try:
+        res = await client.patch(f"/api/sessions/{session_id}", json=body)
+        if res.is_success:
+            logger.info("Session %s completed", session_id)
+        else:
+            logger.warning(
+                "Failed to complete session %s (status %s): %s",
+                session_id,
+                res.status_code,
+                res.text,
+            )
+    except Exception:
+        logger.exception("Error completing session %s", session_id)

--- a/examples/agents/livekit-prompt-test-agent/src/prompt_loader.py
+++ b/examples/agents/livekit-prompt-test-agent/src/prompt_loader.py
@@ -1,0 +1,144 @@
+"""Fetches the agent's compiled system prompt from ModelGuide at session start.
+
+Why this exists
+---------------
+The buildpro example bakes its system prompt into the worker image
+(``src/prompts/``). That means an admin who edits a SOP and clicks
+"Compile" in the dashboard can't actually hear the difference until the
+worker is redeployed — defeating the whole point of having a one-click
+"Talk to agent" loop.
+
+This module flips that: every time a session starts, we ``GET
+/api/agents/me`` with the worker's own API key, read the live
+``compiledInstructions``, and use that string as the LLM's system
+prompt. Click compile → click "Talk to agent" → hear the change.
+
+Failure handling
+----------------
+A voice call is already in flight in the operator's browser by the time
+this runs. Crashing here means dead air. So:
+
+- API down → ``load_prompt`` returns ``FALLBACK_PROMPT`` and logs loudly
+- Compiled prompt missing → same fallback (the operator can still talk
+  to the agent and hear that "no prompt is configured")
+- ``fetch_agent_profile`` still raises ``PromptLoadError`` for callers
+  that need to know — ``load_prompt`` is the consumer-friendly wrapper.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("prompt_loader")
+
+
+# Spoken-aloud fallback. Deliberately verbose: the operator should hear
+# WHY they got the fallback instead of silently getting some generic
+# default that looks like the real prompt.
+FALLBACK_PROMPT = (
+    "You are a voice assistant for a ModelGuide-powered agent. "
+    "No compiled prompt was returned by the ModelGuide API for this agent. "
+    "Tell the caller: 'I'm running on the fallback prompt because I couldn't "
+    "load my instructions. Please compile a prompt in the dashboard and try "
+    "again.' Be brief and stay in this fallback mode."
+)
+
+
+class PromptLoadError(RuntimeError):
+    """Raised when the agent profile cannot be fetched from ModelGuide."""
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """Just enough of the ``/api/agents/me`` payload for the worker to run.
+
+    We intentionally don't model the whole response — keeping the surface
+    small means a new optional field on the API side doesn't break this
+    client.
+    """
+
+    id: str
+    slug: str
+    name: str
+    compiled_prompt: Optional[str]
+    is_active: bool
+
+
+async def fetch_agent_profile(
+    client: httpx.AsyncClient,
+    *,
+    api_url: str,
+    api_key: str,
+) -> AgentProfile:
+    """Fetch the calling agent's profile via ``GET /api/agents/me``.
+
+    Raises ``PromptLoadError`` on any non-2xx response or transport
+    failure. Caller decides whether to recover (use ``load_prompt`` for
+    the recover-and-fall-back behavior).
+    """
+    url = f"{api_url.rstrip('/')}/api/agents/me"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        response = await client.get(url, headers=headers, timeout=10.0)
+    except httpx.HTTPError as e:
+        raise PromptLoadError(f"transport error calling {url}: {e}") from e
+
+    if response.status_code != 200:
+        raise PromptLoadError(
+            f"GET {url} returned {response.status_code}: {response.text[:200]}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as e:
+        raise PromptLoadError(f"invalid JSON from {url}: {e}") from e
+
+    return AgentProfile(
+        id=body["id"],
+        slug=body["slug"],
+        name=body["name"],
+        compiled_prompt=body.get("compiledInstructions"),
+        is_active=body.get("isActive", False),
+    )
+
+
+async def load_prompt(
+    client: httpx.AsyncClient,
+    *,
+    api_url: str,
+    api_key: str,
+) -> str:
+    """Return the system prompt the LLM should use for this session.
+
+    Never raises. Returns ``FALLBACK_PROMPT`` when anything goes wrong so
+    the operator hears a clear message instead of dead air.
+    """
+    try:
+        profile = await fetch_agent_profile(
+            client, api_url=api_url, api_key=api_key
+        )
+    except PromptLoadError as e:
+        logger.error("Failed to load compiled prompt — using fallback: %s", e)
+        return FALLBACK_PROMPT
+
+    compiled = (profile.compiled_prompt or "").strip()
+    if not compiled:
+        logger.warning(
+            "Agent %s (%s) has no compiled prompt — using fallback",
+            profile.slug,
+            profile.id,
+        )
+        return FALLBACK_PROMPT
+
+    logger.info(
+        "Loaded compiled prompt for agent %s (%s, %d chars)",
+        profile.slug,
+        profile.id,
+        len(compiled),
+    )
+    return compiled

--- a/examples/agents/livekit-prompt-test-agent/src/providers.py
+++ b/examples/agents/livekit-prompt-test-agent/src/providers.py
@@ -1,0 +1,72 @@
+"""STT and TTS provider factories.
+
+Controlled by STT_MODEL and TTS_PROVIDER env vars in config. Mirrors
+the buildpro example so a deployment switching between the two workers
+only has to re-point its env vars, not relearn the provider knobs.
+"""
+
+import logging
+
+import config
+
+logger = logging.getLogger("providers")
+
+
+def create_stt():
+    """Create STT instance based on config.STT_MODEL."""
+    from livekit.plugins import deepgram
+
+    model = config.STT_MODEL
+    logger.info("STT model: %s", model)
+
+    if model == "flux":
+        return deepgram.STTv2(
+            model="flux-general-en",
+            api_key=config.DEEPGRAM_API_KEY,
+            eager_eot_threshold=0.5,
+            eot_threshold=0.7,
+        )
+
+    return deepgram.STT(
+        model="nova-3",
+        api_key=config.DEEPGRAM_API_KEY,
+        interim_results=True,
+        endpointing_ms=300,
+    )
+
+
+def create_tts():
+    """Create TTS instance based on config.TTS_PROVIDER."""
+    provider = config.TTS_PROVIDER
+    logger.info("TTS provider: %s", provider)
+
+    if provider == "cartesia":
+        from livekit.plugins import cartesia
+        from livekit.agents import tokenize as _tokenize
+
+        return cartesia.TTS(
+            voice=config.CARTESIA_VOICE_ID,
+            model="sonic-3",
+            speed=1.05,
+            emotion=["Conversational", "Friendly"],
+            api_key=config.CARTESIA_API_KEY,
+            tokenizer=_tokenize.blingfire.SentenceTokenizer(
+                min_sentence_len=8,
+                stream_context_len=5,
+            ),
+        )
+
+    # Default: ElevenLabs
+    from livekit.plugins import elevenlabs
+    from livekit.agents import tokenize
+
+    return elevenlabs.TTS(
+        voice_id=config.ELEVENLABS_VOICE_ID,
+        model="eleven_flash_v2_5",
+        api_key=config.ELEVENLABS_API_KEY,
+        inactivity_timeout=30,
+        word_tokenizer=tokenize.blingfire.SentenceTokenizer(
+            min_sentence_len=8,
+            stream_context_len=5,
+        ),
+    )

--- a/examples/agents/livekit-prompt-test-agent/src/transcript.py
+++ b/examples/agents/livekit-prompt-test-agent/src/transcript.py
@@ -1,0 +1,45 @@
+"""In-memory transcript collector for post-call submission to ModelGuide.
+
+Mirrors the implementation used by the buildpro example so transcripts
+posted by both workers have an identical shape on the ModelGuide side.
+"""
+
+from datetime import datetime, timezone
+
+
+class TranscriptCollector:
+    """Collects user utterances, assistant responses, and tool calls during a
+    voice conversation, then formats them for the ModelGuide messages API."""
+
+    def __init__(self) -> None:
+        self._messages: list[dict] = []
+
+    def add_user_utterance(self, text: str) -> None:
+        if not text.strip():
+            return
+        # Merge consecutive user utterances (STT sends fragments)
+        if self._messages and self._messages[-1].get("role") == "user":
+            self._messages[-1]["content"] += " " + text.strip()
+        else:
+            self._messages.append({
+                "role": "user",
+                "content": text.strip(),
+                "occurredAt": _now_iso(),
+            })
+
+    def add_assistant_response(self, text: str) -> None:
+        if not text.strip():
+            return
+        self._messages.append({
+            "role": "assistant",
+            "content": text.strip(),
+            "occurredAt": _now_iso(),
+        })
+
+    def get_messages(self) -> list[dict]:
+        """Return all collected messages."""
+        return list(self._messages)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/examples/agents/livekit-prompt-test-agent/tests/conftest.py
+++ b/examples/agents/livekit-prompt-test-agent/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures and sys.path setup for the prompt-test agent tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Set dummy env vars BEFORE importing the worker modules (config validates
+# on validate() but some module-level reads happen at import time).
+_TEST_ENV = {
+    "OPENAI_API_KEY": "test_openai_key",
+    "DEEPGRAM_API_KEY": "test_deepgram_key",
+    "ELEVENLABS_API_KEY": "test_elevenlabs_key",
+    "MODELGUIDE_API_URL": "http://localhost:3000",
+    "MODELGUIDE_API_KEY": "mgk_test_key",
+    "AGENT_NAME": "modelguide-prompt-test",
+}
+
+for k, v in _TEST_ENV.items():
+    os.environ.setdefault(k, v)
+
+# Add src/ to sys.path so tests can import modules directly
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/examples/agents/livekit-prompt-test-agent/tests/test_dynamic_agent.py
+++ b/examples/agents/livekit-prompt-test-agent/tests/test_dynamic_agent.py
@@ -1,0 +1,63 @@
+"""Tests for the DynamicAgent class.
+
+DynamicAgent's job is small: it's an ``Agent`` subclass whose
+``instructions`` are passed in at construction time (the entrypoint
+fetches them from ModelGuide right before, see ``main.py``). The class
+itself should:
+
+- accept any string as instructions (don't gate on length, format, etc.)
+- expose the bound session_id so the cleanup hook can find it
+- own a TranscriptCollector for post-call submission
+
+We don't unit-test the LiveKit session loop itself — that's the
+framework's responsibility — but we do guarantee the agent is
+constructible without touching the network, which matters because the
+worker boot path needs to fail fast on config errors *before* any
+remote call happens.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamic_agent import DynamicAgent
+from transcript import TranscriptCollector
+
+
+class TestDynamicAgentConstruction:
+    def test_uses_provided_instructions_verbatim(self):
+        instructions = "You are an assistant. Be brief."
+        agent = DynamicAgent(
+            session_id="sess_x", instructions=instructions
+        )
+        assert agent.instructions == instructions
+
+    def test_accepts_long_instructions(self):
+        instructions = "x" * 50_000
+        agent = DynamicAgent(
+            session_id="sess_x", instructions=instructions
+        )
+        assert agent.instructions == instructions
+
+    def test_stores_session_id(self):
+        agent = DynamicAgent(
+            session_id="sess_abc", instructions="prompt"
+        )
+        assert agent.session_id == "sess_abc"
+
+    def test_allows_null_session_id(self):
+        """Session creation can fail upstream — agent still runs without it."""
+        agent = DynamicAgent(session_id=None, instructions="prompt")
+        assert agent.session_id is None
+
+    def test_provides_fresh_transcript_collector(self):
+        agent = DynamicAgent(session_id="s", instructions="prompt")
+        assert isinstance(agent.transcript, TranscriptCollector)
+        assert agent.transcript.get_messages() == []
+
+    def test_each_instance_has_its_own_transcript(self):
+        a1 = DynamicAgent(session_id="s1", instructions="p")
+        a2 = DynamicAgent(session_id="s2", instructions="p")
+        a1.transcript.add_user_utterance("hi")
+        assert a1.transcript.get_messages() != a2.transcript.get_messages()
+        assert a2.transcript.get_messages() == []

--- a/examples/agents/livekit-prompt-test-agent/tests/test_prompt_loader.py
+++ b/examples/agents/livekit-prompt-test-agent/tests/test_prompt_loader.py
@@ -1,0 +1,322 @@
+"""Tests for the dynamic prompt loader.
+
+The loader is the single thing that makes this agent different from the
+baked-prompt buildpro example: it fetches `compiledInstructions` from
+ModelGuide's `GET /api/agents/me` endpoint on every session, so a fresh
+compile in the dashboard is picked up by the very next "Talk to agent"
+click without redeploying the worker.
+
+These tests are deliberately blocking on the loader's contract:
+- it must call the right URL with the agent API key
+- it must return the compiled prompt verbatim
+- it must fall back gracefully when the prompt is missing or the API is
+  down, because "no prompt" is recoverable (use a default) but a hard
+  crash on a single-call API blip would silently fail every voice test.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from prompt_loader import (
+    FALLBACK_PROMPT,
+    AgentProfile,
+    PromptLoadError,
+    fetch_agent_profile,
+    load_prompt,
+)
+
+
+def _httpx_mock_transport(handler) -> httpx.AsyncClient:
+    """Build an httpx.AsyncClient backed by a MockTransport handler."""
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(transport=transport, base_url="http://mg.test")
+
+
+# ----------------------------------------------------------------------
+# fetch_agent_profile — the raw API call
+# ----------------------------------------------------------------------
+
+
+class TestFetchAgentProfile:
+    @pytest.mark.asyncio
+    async def test_calls_agents_me_with_bearer_token(self):
+        """Loader must hit GET /api/agents/me with the API key as Bearer."""
+        seen_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_requests.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_abc",
+                    "name": "Voice Agent",
+                    "slug": "voice-agent",
+                    "compiledInstructions": "You are a helpful assistant.",
+                    "compiledAt": "2025-01-01T00:00:00Z",
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            await fetch_agent_profile(
+                client, api_url="http://mg.test", api_key="mgk_secret"
+            )
+        finally:
+            await client.aclose()
+
+        assert len(seen_requests) == 1
+        req = seen_requests[0]
+        assert req.method == "GET"
+        assert req.url.path == "/api/agents/me"
+        assert req.headers["authorization"] == "Bearer mgk_secret"
+
+    @pytest.mark.asyncio
+    async def test_returns_parsed_profile_with_compiled_prompt(self):
+        compiled = "You are Sam, a helpful contractor supply assistant."
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_sam",
+                    "name": "Sam",
+                    "slug": "buildpro-sam",
+                    "compiledInstructions": compiled,
+                    "compiledAt": "2025-01-01T00:00:00Z",
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            profile = await fetch_agent_profile(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert isinstance(profile, AgentProfile)
+        assert profile.id == "agt_sam"
+        assert profile.slug == "buildpro-sam"
+        assert profile.compiled_prompt == compiled
+        assert profile.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_returns_profile_with_null_compiled_prompt(self):
+        """Fresh agent — no prompt compiled yet. Profile loads, prompt is None."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_fresh",
+                    "name": "Fresh",
+                    "slug": "fresh-agent",
+                    "compiledInstructions": None,
+                    "compiledAt": None,
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            profile = await fetch_agent_profile(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert profile.compiled_prompt is None
+
+    @pytest.mark.asyncio
+    async def test_raises_prompt_load_error_on_401(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"code": "UNAUTHORIZED"})
+
+        client = _httpx_mock_transport(handler)
+        try:
+            with pytest.raises(PromptLoadError):
+                await fetch_agent_profile(
+                    client, api_url="http://mg.test", api_key="mgk_bad"
+                )
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_raises_prompt_load_error_on_500(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"code": "INTERNAL"})
+
+        client = _httpx_mock_transport(handler)
+        try:
+            with pytest.raises(PromptLoadError):
+                await fetch_agent_profile(
+                    client, api_url="http://mg.test", api_key="mgk_x"
+                )
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_raises_prompt_load_error_on_transport_failure(self):
+        """Network failure / DNS error / connection refused."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        client = _httpx_mock_transport(handler)
+        try:
+            with pytest.raises(PromptLoadError):
+                await fetch_agent_profile(
+                    client, api_url="http://mg.test", api_key="mgk_x"
+                )
+        finally:
+            await client.aclose()
+
+
+# ----------------------------------------------------------------------
+# load_prompt — the top-level helper used by the agent entrypoint.
+#
+# Returns the *string* that the LLM will see as its system prompt:
+#   1. If the API returns a non-empty compiledInstructions → use that.
+#   2. If the API returns null/empty → use FALLBACK_PROMPT (configurable,
+#      keeps the call alive so the operator can hear the fallback rather
+#      than getting silence).
+#   3. If the API call fails → use FALLBACK_PROMPT and log loudly. We
+#      explicitly do NOT crash the worker because the voice call has
+#      already started in the browser by the time the fetch fires.
+# ----------------------------------------------------------------------
+
+
+class TestLoadPrompt:
+    @pytest.mark.asyncio
+    async def test_returns_compiled_prompt_when_present(self):
+        compiled = "Be brief. Be helpful. Be honest."
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_x",
+                    "name": "X",
+                    "slug": "x",
+                    "compiledInstructions": compiled,
+                    "compiledAt": "2025-01-01T00:00:00Z",
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            prompt = await load_prompt(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert prompt == compiled
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_compiled_prompt_missing(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_fresh",
+                    "name": "Fresh",
+                    "slug": "fresh",
+                    "compiledInstructions": None,
+                    "compiledAt": None,
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            prompt = await load_prompt(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert prompt == FALLBACK_PROMPT
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_empty_string_prompt(self):
+        """Treat empty/whitespace prompts the same as null."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "agt_x",
+                    "name": "X",
+                    "slug": "x",
+                    "compiledInstructions": "   ",
+                    "compiledAt": None,
+                    "compiledFrom": None,
+                    "agentPlatform": "livekit",
+                    "modality": "voice",
+                    "isActive": True,
+                },
+            )
+
+        client = _httpx_mock_transport(handler)
+        try:
+            prompt = await load_prompt(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert prompt == FALLBACK_PROMPT
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_api_failure(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, json={"code": "UNAVAILABLE"})
+
+        client = _httpx_mock_transport(handler)
+        try:
+            prompt = await load_prompt(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert prompt == FALLBACK_PROMPT
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_transport_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("no route to host")
+
+        client = _httpx_mock_transport(handler)
+        try:
+            prompt = await load_prompt(
+                client, api_url="http://mg.test", api_key="mgk_x"
+            )
+        finally:
+            await client.aclose()
+
+        assert prompt == FALLBACK_PROMPT

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -586,6 +588,43 @@ router.openapi(createPlatformAgentRoute, async (c) => {
   }
 
   throw Errors.invalidInput(`Unsupported platform: ${platform}`);
+});
+
+// ============================================================================
+// GET /me — self-lookup for API-key callers (LiveKit workers, etc.)
+//
+// Registered before `/:id` so the static segment wins over the UUID
+// parameter and a worker's `GET /api/agents/me` doesn't fall through to
+// the UUID-typed handler (which would 422). Returns the same shape as
+// `GET /:id` so a single client schema covers both routes.
+// ============================================================================
+
+router.get("/me", requireAgent(), requireOrganization());
+
+const getCurrentAgentRoute = createRoute({
+  method: "get",
+  path: "/me",
+  tags: ["Agents"],
+  summary: "Get the calling agent's own profile",
+  description:
+    "Returns the profile of the agent identified by the API key in the Authorization header — including the latest `compiledInstructions`. Intended for voice/text workers that need to fetch their own configuration at session start (e.g. the LiveKit prompt-test agent). Requires `mgk_*` API key auth; user JWTs are rejected.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Agent detail for the calling agent",
+      content: {
+        "application/json": { schema: agentResponseSchema },
+      },
+    },
+    401: errorResponse("Missing or invalid API key"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(getCurrentAgentRoute, async (c) => {
+  const auth = getCurrentAgent(c);
+  const agent = await getAgentById(auth.organizationId, auth.id);
+  return c.json(formatAgent(agent), 200);
 });
 
 // GET /:id

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,12 +8,19 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
 let orgASupportHeaders: Record<string, string>;
 let orgBAdminHeaders: Record<string, string>;
+let orgAAgentHeaders: Record<string, string>;
+let orgBAgentHeaders: Record<string, string>;
 
 /** IDs of agents created during tests (for cleanup) */
 const createdAgentIds: string[] = [];
@@ -27,6 +34,8 @@ beforeAll(async () => {
   orgAAdminHeaders = await authHeadersFor(s.orgAAdmin);
   orgASupportHeaders = await authHeadersFor(s.orgASupport);
   orgBAdminHeaders = await authHeadersFor(s.orgBAdmin);
+  orgAAgentHeaders = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+  orgBAgentHeaders = await agentHeadersFor(s.orgBAgentId, s.orgB.id);
 });
 
 afterAll(async () => {
@@ -1058,5 +1067,90 @@ describe("Agent slug uniqueness", () => {
     expect(res2.status).toBe(409);
     const body = await res2.json();
     expect(body.code).toBe("ALREADY_EXISTS");
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me - Self-lookup for API-key callers (LiveKit workers etc.)
+// ============================================================================
+//
+// Lets a voice agent (running with its own mgk_* API key) fetch its current
+// profile — including the compiled prompt — at session start. This is the
+// hook that makes "Compile prompt → click Talk to agent → hear the latest
+// prompt" work without baking the prompt into the worker image.
+// ============================================================================
+
+describe("GET /api/agents/me", () => {
+  test("returns the calling agent's profile (200)", async () => {
+    const response = await request("/api/agents/me", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.name).toBeDefined();
+    expect(body.slug).toBeDefined();
+    expect(body.modality).toBeDefined();
+    expect(body.agentPlatform).toBeDefined();
+    // Compiled-prompt fields are always present in the response shape — null
+    // when the agent has not been compiled yet.
+    expect(body).toHaveProperty("compiledInstructions");
+    expect(body).toHaveProperty("compiledAt");
+    expect(body).toHaveProperty("compiledFrom");
+  });
+
+  test("returns the up-to-date compiled prompt after a write (200)", async () => {
+    // Regression guard for the "stale prompt" failure mode: if the route
+    // ever cached or memoized the agent record, recompiling wouldn't be
+    // visible to the worker on the next session.
+    const updatedPrompt = `Updated prompt at ${Date.now()}`;
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          compiledInstructions: updatedPrompt,
+          compiledAt: new Date(),
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const response = await request("/api/agents/me", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.compiledInstructions).toBe(updatedPrompt);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me");
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects user JWT — agent API key required (401)", async () => {
+    // Admin JWT must not be able to call /me. This is "self-lookup for the
+    // calling agent", not "list my agents for the org".
+    const response = await request("/api/agents/me", {
+      headers: orgAAdminHeaders,
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test("two different agents see two different identities (cross-org)", async () => {
+    const [respA, respB] = await Promise.all([
+      request("/api/agents/me", { headers: orgAAgentHeaders }),
+      request("/api/agents/me", { headers: orgBAgentHeaders }),
+    ]);
+
+    expect(respA.status).toBe(200);
+    expect(respB.status).toBe(200);
+    const [bodyA, bodyB] = await Promise.all([respA.json(), respB.json()]);
+
+    expect(bodyA.id).toBe(s.orgAAgentId);
+    expect(bodyB.id).toBe(s.orgBAgentId);
+    expect(bodyA.id).not.toBe(bodyB.id);
   });
 });


### PR DESCRIPTION
## Summary

Closes the gap left by [ADR-014](../blob/main/docs/decisions/014-browser-voice-testing.md): the dashboard has a one-click "Talk to agent" button, but the worker bakes its prompt at deploy time — so compiling a fresh prompt in the dashboard doesn't actually change what the operator hears. This PR adds a voiceblox-inspired prototype that **fetches its system prompt from ModelGuide on every session**, making the loop:

> **Compile prompt** → **click Talk to agent** → **hear the prompt you just compiled** — no worker redeploy.

## Changes

### API (`modelguide-api`)

- **`GET /api/agents/me`** — returns the calling agent's profile (incl. live `compiledInstructions`), authenticated by the agent's own `mgk_*` API key. Reuses `formatAgent()` so the response shape matches `GET /:id` exactly. User JWTs are rejected — this endpoint is for workers, not the dashboard.
- Route is registered before `/:id` so the static `/me` segment wins over the UUID parameter.
- **4 new integration tests** (`tests/integration/agents.test.ts`):
  - happy path returns profile fields
  - a fresh DB write to `compiledInstructions` is visible on the next read (freshness guarantee)
  - missing auth → 401
  - user JWT → 401 (no privilege confusion)

### Worker (`examples/agents/livekit-prompt-test-agent/`)

A separate Python LiveKit example, parallel to the existing buildpro `livekit-agent/`. ~250 LoC across:

- **`src/prompt_loader.py`** — `fetch_agent_profile` calls `GET /api/agents/me` with the API key; `load_prompt` wraps it and falls back to `FALLBACK_PROMPT` on any error so a live call never gets dead air.
- **`src/dynamic_agent.py`** — a thin `livekit.agents.Agent` subclass that takes its instructions at construction time. Uses a defensive `try/except ImportError` for the LiveKit base class so tests can run in a bare environment.
- **`src/main.py`** — worker entrypoint: parse dispatch metadata → fetch prompt → spin up `AgentSession` → post transcript on close.
- **`src/mg_client.py`** / **`providers.py`** / **`config.py`** / **`transcript.py`** — session lifecycle, STT/TTS factories, env-var handling. Parallel to buildpro so the diff between the two is legible.
- **`Dockerfile`** / **`livekit.toml`** / **`.env.example`** — ready for `lk agent deploy`.

### Tests (TDD red→green)

- **17 pytest cases** against `httpx.MockTransport` — no network, no LiveKit runtime required.
- Loader tests existed and failed (`ModuleNotFoundError`) before any `src/` file was written; agent tests likewise.

```
tests/test_prompt_loader.py::TestFetchAgentProfile      6 passed
tests/test_prompt_loader.py::TestLoadPrompt             5 passed
tests/test_dynamic_agent.py::TestDynamicAgentConstruction  6 passed
============================== 17 passed in 0.05s ==============================
```

### Docs

- **`examples/agents/livekit-prompt-test-agent/README.md`** — quick start, dashboard loop walkthrough, deployment, how to add tools.
- **`docs/decisions/015-dynamic-prompt-livekit-agent.md`** — design rationale and how it relates to ADR-014's deliberate "no prompt injection via dispatch metadata" stance (it doesn't — prompts come from a dedicated REST call, not metadata).
- ADR index updated.

## Verification

- [x] `bun run lint:check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test:unit` — 896 pass, 0 fail
- [x] `pytest examples/agents/livekit-prompt-test-agent/tests/` — 17 pass
- [ ] `bun run test:integration` — requires Docker, not available in this sandbox. New tests will run on CI.

## Out of scope

- **Tools.** The prototype is prompt-only. Adding `@function_tool` methods + an `MCPConnection` is a copy/paste from the buildpro example.
- **Multi-profile routing.** One worker = one ModelGuide agent (one `mgk_*` key). Multi-profile pattern lives in the buildpro example.
- **UI changes.** The existing `VoiceTestPanel` already drives the dispatch flow; once an org points their LiveKit "Agent Name" at a deployed `modelguide-prompt-test` worker, "Talk to agent" works end-to-end with no UI changes.

## Test plan

- [ ] Deploy this worker to a LiveKit Cloud project against a staging ModelGuide API
- [ ] In the dashboard: configure an agent's LiveKit `agentName` = `modelguide-prompt-test`
- [ ] Compile a prompt with a distinctive phrase ("I am the freshly compiled prompt")
- [ ] Click "Talk to agent" — the agent should greet using that phrase
- [ ] Edit the SOP, recompile with a different distinctive phrase
- [ ] Click "Talk to agent" again — the *new* phrase should come back without redeploying the worker

---
_Generated by [Claude Code](https://claude.ai/code/session_015XLErczAbx931HgZh3gXHe)_