### PR TITLE
Wevn Phase 2: Mode B signal emission against MockLoreVaultClient

### DIFF
--- a/modelguide-api/src/features/connectors/catalog/hubspot/client.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/client.ts
@@ -1,0 +1,168 @@
+/**
+ * HubSpot API client.
+ *
+ * Wraps the HubSpot v3 surface (CRM, Conversations, CMS Knowledge Base)
+ * behind a single ConnectorFetcher. Adds HubSpot-specific 429 handling:
+ * respects `Retry-After` when present, otherwise backs off when
+ * `X-HubSpot-RateLimit-Remaining` is low.
+ */
+
+import { getLogger } from "@lib/logger";
+import {
+  ConnectorApiError,
+  type ConnectorFetchOptions,
+  type ConnectorFetcher,
+} from "../lib/http-client";
+
+export type { ConnectorFetcher as HubSpotFetcher };
+
+const HUBSPOT_BASE_URL = "https://api.hubapi.com";
+const MAX_RETRIES = 4;
+const MAX_RETRY_DELAY_MS = 30_000;
+const RATE_LIMIT_LOW_WATERMARK = 2;
+
+interface CreateFetcherOptions {
+  timeoutMs?: number;
+  /** Override clock for tests. Returns milliseconds since epoch. */
+  now?: () => number;
+  /** Override sleeper for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export function createHubSpotFetcher(
+  config: Record<string, string>,
+  options: CreateFetcherOptions = {},
+): ConnectorFetcher {
+  const { accessToken } = config;
+  if (!accessToken) {
+    throw new Error("HubSpot accessToken is required");
+  }
+
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  return async function hubspotFetch<T = unknown>(
+    path: string,
+    fetchOptions?: ConnectorFetchOptions,
+  ): Promise<T> {
+    const { method = "GET", body, params } = fetchOptions ?? {};
+
+    let url = `${HUBSPOT_BASE_URL}${path}`;
+    if (params) {
+      const entries = Object.entries(params).filter(([, v]) => v !== undefined);
+      if (entries.length > 0) {
+        const qs = new URLSearchParams(entries.map(([k, v]) => [k, String(v)]));
+        url += `?${qs}`;
+      }
+    }
+
+    const log = getLogger();
+    const callCtx = { connector: "HubSpot", method, path };
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const start = performance.now();
+      let response: Response;
+
+      try {
+        response = await fetch(url, {
+          method,
+          headers: { ...headers },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+      } catch (err) {
+        const duration = Math.round(performance.now() - start);
+        log.error({ ...callCtx, duration, err }, "connector call error");
+        throw err;
+      }
+
+      const duration = Math.round(performance.now() - start);
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const delayMs = resolveRetryDelay(response.headers, attempt);
+        log.warn(
+          { ...callCtx, attempt, delayMs, status: 429 },
+          "HubSpot rate limit hit; retrying",
+        );
+        await response.body?.cancel();
+        await sleep(delayMs);
+        continue;
+      }
+
+      if (!response.ok) {
+        const raw = await response.text();
+        const text = raw.length > 512 ? `${raw.slice(0, 512)}…` : raw;
+        log.warn(
+          { ...callCtx, status: response.status, duration },
+          "connector call failed",
+        );
+        throw new ConnectorApiError("HubSpot", response.status, text);
+      }
+
+      log.info(
+        { ...callCtx, status: response.status, duration },
+        "connector call completed",
+      );
+
+      // Proactive backoff: if HubSpot says we're near the per-second limit,
+      // pause briefly before returning so the *next* call doesn't 429.
+      const remaining = parseRemaining(response.headers);
+      if (remaining !== null && remaining <= RATE_LIMIT_LOW_WATERMARK) {
+        await sleep(jitter(250));
+      }
+
+      if (response.status === 204) {
+        return {} as T;
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        return (await response.text()) as unknown as T;
+      }
+
+      return (await response.json()) as T;
+    }
+
+    throw new ConnectorApiError(
+      "HubSpot",
+      429,
+      `Exceeded ${MAX_RETRIES} retries on rate-limited request to ${path}`,
+    );
+  };
+}
+
+function resolveRetryDelay(headers: Headers, attempt: number): number {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.min(seconds * 1_000, MAX_RETRY_DELAY_MS);
+    }
+  }
+  const exponential = Math.min(
+    1_000 * 2 ** attempt + jitter(250),
+    MAX_RETRY_DELAY_MS,
+  );
+  return exponential;
+}
+
+function parseRemaining(headers: Headers): number | null {
+  const raw = headers.get("x-hubspot-ratelimit-remaining");
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function jitter(maxMs: number): number {
+  return Math.floor(Math.random() * maxMs);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/handlers.ts
@@ -19,6 +19,7 @@ import { withConnector } from "../lib/http-client";
 import { runHealthCheck } from "../lib/run-health-check";
 import type { HealthCheckResult, ToolExecutionResult } from "../types";
 import { type HubSpotFetcher, createHubSpotFetcher } from "./client";
+import { withSignalEmission } from "./ingest/mode-b/emit";
 
 // ---------------------------------------------------------------------------
 // Property allowlists (spec §6)
@@ -219,7 +220,7 @@ export const searchContacts = withHubSpot(async (fetcher, ctx) => {
   return { success: true, data };
 });
 
-export const createContact = withHubSpot(async (fetcher, ctx) => {
+const createContactImpl = withHubSpot(async (fetcher, ctx) => {
   const { properties } = ctx.input as { properties: Record<string, unknown> };
   if (!properties || typeof properties !== "object") {
     return { success: false, error: "properties object is required" };
@@ -235,7 +236,7 @@ export const createContact = withHubSpot(async (fetcher, ctx) => {
   );
 });
 
-export const updateContact = withHubSpot(async (fetcher, ctx) => {
+const updateContactImpl = withHubSpot(async (fetcher, ctx) => {
   const { contactId, properties } = ctx.input as {
     contactId: string;
     properties: Record<string, unknown>;
@@ -348,7 +349,7 @@ export const listDealsForContact = withHubSpot(async (fetcher, ctx) => {
   return { success: true, data };
 });
 
-export const createDeal = withHubSpot(async (fetcher, ctx) => {
+const createDealImpl = withHubSpot(async (fetcher, ctx) => {
   const input = ctx.input as {
     properties: Record<string, unknown>;
     associations?: HubSpotAssociation[];
@@ -376,7 +377,7 @@ export const createDeal = withHubSpot(async (fetcher, ctx) => {
   );
 });
 
-export const updateDealStage = withHubSpot(async (fetcher, ctx) => {
+const updateDealStageImpl = withHubSpot(async (fetcher, ctx) => {
   const { dealId, stage } = ctx.input as {
     dealId: string;
     stage: string;
@@ -485,7 +486,7 @@ export const searchTickets = withHubSpot(async (fetcher, ctx) => {
   return { success: true, data };
 });
 
-export const createTicket = withHubSpot(async (fetcher, ctx) => {
+const createTicketImpl = withHubSpot(async (fetcher, ctx) => {
   const input = ctx.input as {
     properties: Record<string, unknown>;
     associations?: HubSpotAssociation[];
@@ -513,7 +514,7 @@ export const createTicket = withHubSpot(async (fetcher, ctx) => {
   );
 });
 
-export const updateTicket = withHubSpot(async (fetcher, ctx) => {
+const updateTicketImpl = withHubSpot(async (fetcher, ctx) => {
   const { ticketId, properties } = ctx.input as {
     ticketId: string;
     properties: Record<string, unknown>;
@@ -570,7 +571,7 @@ export const updateTicket = withHubSpot(async (fetcher, ctx) => {
   );
 });
 
-export const closeTicket = withHubSpot(async (fetcher, ctx) => {
+const closeTicketImpl = withHubSpot(async (fetcher, ctx) => {
   const { ticketId, closeNote } = ctx.input as {
     ticketId: string;
     closeNote?: string;
@@ -688,7 +689,7 @@ async function getPrimaryTicketThread(
   return { thread: sorted[0] };
 }
 
-export const addReplyToTicket = withHubSpot(async (fetcher, ctx) => {
+const addReplyToTicketImpl = withHubSpot(async (fetcher, ctx) => {
   const { ticketId, text, richText, internal } = ctx.input as {
     ticketId: string;
     text?: string;
@@ -751,7 +752,7 @@ export const addReplyToTicket = withHubSpot(async (fetcher, ctx) => {
 // Engagements (2)
 // ---------------------------------------------------------------------------
 
-export const logCallEngagement = withHubSpot(async (fetcher, ctx) => {
+const logCallEngagementImpl = withHubSpot(async (fetcher, ctx) => {
   const input = ctx.input as {
     properties: Record<string, unknown>;
     associations?: HubSpotAssociation[];
@@ -769,7 +770,7 @@ export const logCallEngagement = withHubSpot(async (fetcher, ctx) => {
   return { success: true, data };
 });
 
-export const createNote = withHubSpot(async (fetcher, ctx) => {
+const createNoteImpl = withHubSpot(async (fetcher, ctx) => {
   const input = ctx.input as {
     properties: Record<string, unknown>;
     associations?: HubSpotAssociation[];
@@ -786,6 +787,44 @@ export const createNote = withHubSpot(async (fetcher, ctx) => {
   });
   return { success: true, data };
 });
+
+// ---------------------------------------------------------------------------
+// Mode B re-exports — 10 emitting tools per spec §5 are wrapped so each
+// success path also enqueues a signal envelope. Read-only tools are
+// re-exported as-is below.
+// ---------------------------------------------------------------------------
+
+export const createContact = withSignalEmission(
+  "Create Contact",
+  createContactImpl,
+);
+export const updateContact = withSignalEmission(
+  "Update Contact",
+  updateContactImpl,
+);
+export const createDeal = withSignalEmission("Create Deal", createDealImpl);
+export const updateDealStage = withSignalEmission(
+  "Update Deal Stage",
+  updateDealStageImpl,
+);
+export const createTicket = withSignalEmission(
+  "Create Ticket",
+  createTicketImpl,
+);
+export const updateTicket = withSignalEmission(
+  "Update Ticket",
+  updateTicketImpl,
+);
+export const closeTicket = withSignalEmission("Close Ticket", closeTicketImpl);
+export const addReplyToTicket = withSignalEmission(
+  "Add Reply To Ticket",
+  addReplyToTicketImpl,
+);
+export const logCallEngagement = withSignalEmission(
+  "Log Call Engagement",
+  logCallEngagementImpl,
+);
+export const createNote = withSignalEmission("Create Note", createNoteImpl);
 
 // ---------------------------------------------------------------------------
 // Internal-only KB ingest operations — NOT MCP-registered (spec §5).

--- a/modelguide-api/src/features/connectors/catalog/hubspot/handlers.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/handlers.ts
@@ -1,0 +1,952 @@
+/**
+ * HubSpot connector handlers.
+ *
+ * 19 MCP-exposed tools grouped by entity:
+ *   Contacts (5), Companies (2), Deals (3), Tickets (7), Engagements (2)
+ *
+ * Plus 2 internal-only KB ingest operations (NOT MCP-registered):
+ *   listKnowledgeArticles, getKnowledgeArticle
+ *
+ * Governance rules enforced here (per spec §6):
+ *   - Property allowlist on Update Contact and Update Ticket.
+ *   - Close Ticket resolves the per-pipeline CLOSED stage at handler entry.
+ *   - Update Ticket rejects any pipeline-stage that resolves to a closed stage.
+ *   - Add Reply To Ticket writes via Conversations API, channel inferred from
+ *     the existing thread; errors clearly when no thread exists.
+ */
+
+import { withConnector } from "../lib/http-client";
+import { runHealthCheck } from "../lib/run-health-check";
+import type { HealthCheckResult, ToolExecutionResult } from "../types";
+import { type HubSpotFetcher, createHubSpotFetcher } from "./client";
+
+// ---------------------------------------------------------------------------
+// Property allowlists (spec §6)
+// ---------------------------------------------------------------------------
+
+export const UPDATE_CONTACT_ALLOWED_PROPERTIES: ReadonlySet<string> = new Set([
+  "firstname",
+  "lastname",
+  "email",
+  "phone",
+  "mobilephone",
+  "company",
+  "jobtitle",
+  "lifecyclestage",
+  "hs_lead_status",
+  "address",
+  "city",
+  "state",
+  "zip",
+  "country",
+  "website",
+]);
+
+export const UPDATE_TICKET_ALLOWED_PROPERTIES: ReadonlySet<string> = new Set([
+  "subject",
+  "content",
+  "hs_ticket_priority",
+  "hs_ticket_category",
+  "hubspot_owner_id",
+  "hs_pipeline",
+  "hs_pipeline_stage",
+]);
+
+function rejectNonAllowlisted(
+  properties: Record<string, unknown>,
+  allowlist: ReadonlySet<string>,
+  toolName: string,
+): { error: string } | null {
+  const offending = Object.keys(properties).filter((k) => !allowlist.has(k));
+  if (offending.length === 0) return null;
+  return {
+    error: `${toolName} rejected non-allowlisted properties: ${offending.join(
+      ", ",
+    )}. Allowed: ${[...allowlist].sort().join(", ")}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline / stage helpers
+// ---------------------------------------------------------------------------
+
+interface PipelineStage {
+  id: string;
+  label: string;
+  metadata?: { ticketState?: string };
+}
+
+interface Pipeline {
+  id: string;
+  label: string;
+  stages: PipelineStage[];
+}
+
+async function fetchTicketPipeline(
+  fetcher: HubSpotFetcher,
+  pipelineId: string,
+): Promise<Pipeline> {
+  return await fetcher<Pipeline>(
+    `/crm/v3/pipelines/tickets/${encodeURIComponent(pipelineId)}`,
+  );
+}
+
+function isClosedStage(stage: PipelineStage): boolean {
+  return stage.metadata?.ticketState === "CLOSED";
+}
+
+async function resolveClosedStageId(
+  fetcher: HubSpotFetcher,
+  pipelineId: string,
+): Promise<{ stageId: string } | { error: string }> {
+  const pipeline = await fetchTicketPipeline(fetcher, pipelineId);
+  const closed = pipeline.stages.find(isClosedStage);
+  if (!closed) {
+    return {
+      error: `Pipeline ${pipelineId} (${pipeline.label}) has no stage with metadata.ticketState === "CLOSED". Configure a closed stage in HubSpot, then retry.`,
+    };
+  }
+  return { stageId: closed.id };
+}
+
+// ---------------------------------------------------------------------------
+// Deep-link helper
+// ---------------------------------------------------------------------------
+
+function objectUrl(
+  config: Record<string, string>,
+  objectPath: string,
+  id: string,
+): string | undefined {
+  const portalId = config.portalId?.trim();
+  if (!portalId) return undefined;
+  return `https://app.hubspot.com/${objectPath}/${portalId}/${encodeURIComponent(
+    id,
+  )}`;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP wrapper bound to HubSpot config
+// ---------------------------------------------------------------------------
+
+const withHubSpot = withConnector((config) => createHubSpotFetcher(config));
+
+// ---------------------------------------------------------------------------
+// Contacts (5)
+// ---------------------------------------------------------------------------
+
+export const getContactByEmail = withHubSpot(async (fetcher, ctx) => {
+  const { email, properties } = ctx.input as {
+    email: string;
+    properties?: string[];
+  };
+  if (!email) return { success: false, error: "email is required" };
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/contacts/${encodeURIComponent(email)}`,
+    {
+      params: {
+        idProperty: "email",
+        properties: properties?.join(","),
+      },
+    },
+  );
+  const id = (data as { id?: string }).id;
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "contacts", id ?? email),
+  );
+});
+
+export const getContactByPhone = withHubSpot(async (fetcher, ctx) => {
+  const { phone, properties } = ctx.input as {
+    phone: string;
+    properties?: string[];
+  };
+  if (!phone) return { success: false, error: "phone is required" };
+
+  const data = await fetcher<{ results?: { id: string }[] }>(
+    "/crm/v3/objects/contacts/search",
+    {
+      method: "POST",
+      body: {
+        filterGroups: [
+          {
+            filters: [{ propertyName: "phone", operator: "EQ", value: phone }],
+          },
+          {
+            filters: [
+              { propertyName: "mobilephone", operator: "EQ", value: phone },
+            ],
+          },
+        ],
+        properties: properties ?? defaultContactProperties(),
+        limit: 5,
+      },
+    },
+  );
+
+  const first = data.results?.[0];
+  return withMaybeUrl(
+    { success: true, data: data as Record<string, unknown> },
+    first ? objectUrl(ctx.config, "contacts", first.id) : undefined,
+  );
+});
+
+export const searchContacts = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    query?: string;
+    filters?: HubSpotSearchFilter[];
+    properties?: string[];
+    limit?: number;
+    after?: string;
+  };
+
+  const body: Record<string, unknown> = {
+    properties: input.properties ?? defaultContactProperties(),
+    limit: Math.min(input.limit ?? 25, 100),
+  };
+  if (input.query) body.query = input.query;
+  if (input.filters?.length) {
+    body.filterGroups = [{ filters: input.filters }];
+  }
+  if (input.after) body.after = input.after;
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/contacts/search",
+    { method: "POST", body },
+  );
+  return { success: true, data };
+});
+
+export const createContact = withHubSpot(async (fetcher, ctx) => {
+  const { properties } = ctx.input as { properties: Record<string, unknown> };
+  if (!properties || typeof properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/contacts",
+    { method: "POST", body: { properties } },
+  );
+  const id = (data as { id?: string }).id;
+  return withMaybeUrl(
+    { success: true, data },
+    id ? objectUrl(ctx.config, "contacts", id) : undefined,
+  );
+});
+
+export const updateContact = withHubSpot(async (fetcher, ctx) => {
+  const { contactId, properties } = ctx.input as {
+    contactId: string;
+    properties: Record<string, unknown>;
+  };
+  if (!contactId) return { success: false, error: "contactId is required" };
+  if (!properties || typeof properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+
+  const rejected = rejectNonAllowlisted(
+    properties,
+    UPDATE_CONTACT_ALLOWED_PROPERTIES,
+    "Update Contact",
+  );
+  if (rejected) return { success: false, error: rejected.error };
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/contacts/${encodeURIComponent(contactId)}`,
+    { method: "PATCH", body: { properties } },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "contacts", contactId),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Companies (2)
+// ---------------------------------------------------------------------------
+
+export const getCompany = withHubSpot(async (fetcher, ctx) => {
+  const { companyId, properties } = ctx.input as {
+    companyId: string;
+    properties?: string[];
+  };
+  if (!companyId) return { success: false, error: "companyId is required" };
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/companies/${encodeURIComponent(companyId)}`,
+    { params: { properties: properties?.join(",") } },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "company", companyId),
+  );
+});
+
+export const listCompaniesForContact = withHubSpot(async (fetcher, ctx) => {
+  const { contactId } = ctx.input as { contactId: string };
+  if (!contactId) return { success: false, error: "contactId is required" };
+
+  const assoc = await fetcher<{
+    results?: { toObjectId: string | number; id?: string }[];
+  }>(
+    `/crm/v3/objects/contacts/${encodeURIComponent(
+      contactId,
+    )}/associations/companies`,
+  );
+  const ids = (assoc.results ?? []).map((r) =>
+    String((r as { toObjectId?: string | number }).toObjectId ?? r.id ?? ""),
+  );
+  if (ids.length === 0) {
+    return { success: true, data: { results: [], total: 0 } };
+  }
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/companies/batch/read",
+    {
+      method: "POST",
+      body: {
+        properties: defaultCompanyProperties(),
+        inputs: ids.map((id) => ({ id })),
+      },
+    },
+  );
+  return { success: true, data };
+});
+
+// ---------------------------------------------------------------------------
+// Deals (3)
+// ---------------------------------------------------------------------------
+
+export const listDealsForContact = withHubSpot(async (fetcher, ctx) => {
+  const { contactId } = ctx.input as { contactId: string };
+  if (!contactId) return { success: false, error: "contactId is required" };
+
+  const assoc = await fetcher<{
+    results?: { toObjectId: string | number; id?: string }[];
+  }>(
+    `/crm/v3/objects/contacts/${encodeURIComponent(
+      contactId,
+    )}/associations/deals`,
+  );
+  const ids = (assoc.results ?? []).map((r) =>
+    String((r as { toObjectId?: string | number }).toObjectId ?? r.id ?? ""),
+  );
+  if (ids.length === 0) {
+    return { success: true, data: { results: [], total: 0 } };
+  }
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/deals/batch/read",
+    {
+      method: "POST",
+      body: {
+        properties: defaultDealProperties(),
+        inputs: ids.map((id) => ({ id })),
+      },
+    },
+  );
+  return { success: true, data };
+});
+
+export const createDeal = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    properties: Record<string, unknown>;
+    associations?: HubSpotAssociation[];
+  };
+  if (!input.properties || typeof input.properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+
+  const properties = { ...input.properties };
+  if (!properties.pipeline && ctx.config.defaultPipelineId) {
+    properties.pipeline = ctx.config.defaultPipelineId;
+  }
+
+  const body: Record<string, unknown> = { properties };
+  if (input.associations?.length) body.associations = input.associations;
+
+  const data = await fetcher<Record<string, unknown>>("/crm/v3/objects/deals", {
+    method: "POST",
+    body,
+  });
+  const id = (data as { id?: string }).id;
+  return withMaybeUrl(
+    { success: true, data },
+    id ? objectUrl(ctx.config, "deal", id) : undefined,
+  );
+});
+
+export const updateDealStage = withHubSpot(async (fetcher, ctx) => {
+  const { dealId, stage } = ctx.input as {
+    dealId: string;
+    stage: string;
+  };
+  if (!dealId) return { success: false, error: "dealId is required" };
+  if (!stage) return { success: false, error: "stage is required" };
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/deals/${encodeURIComponent(dealId)}`,
+    { method: "PATCH", body: { properties: { dealstage: stage } } },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "deal", dealId),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Tickets (7)
+// ---------------------------------------------------------------------------
+
+export const getTicket = withHubSpot(async (fetcher, ctx) => {
+  const { ticketId, properties } = ctx.input as {
+    ticketId: string;
+    properties?: string[];
+  };
+  if (!ticketId) return { success: false, error: "ticketId is required" };
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/tickets/${encodeURIComponent(ticketId)}`,
+    {
+      params: {
+        properties: (properties ?? defaultTicketProperties()).join(","),
+      },
+    },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "tickets", ticketId),
+  );
+});
+
+export const listTicketsForContact = withHubSpot(async (fetcher, ctx) => {
+  const { contactId } = ctx.input as { contactId: string };
+  if (!contactId) return { success: false, error: "contactId is required" };
+
+  const assoc = await fetcher<{
+    results?: { toObjectId: string | number; id?: string }[];
+  }>(
+    `/crm/v3/objects/contacts/${encodeURIComponent(
+      contactId,
+    )}/associations/tickets`,
+  );
+  const ids = (assoc.results ?? []).map((r) =>
+    String((r as { toObjectId?: string | number }).toObjectId ?? r.id ?? ""),
+  );
+  if (ids.length === 0) {
+    return { success: true, data: { results: [], total: 0 } };
+  }
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/tickets/batch/read",
+    {
+      method: "POST",
+      body: {
+        properties: defaultTicketProperties(),
+        inputs: ids.map((id) => ({ id })),
+      },
+    },
+  );
+  return { success: true, data };
+});
+
+export const searchTickets = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    query?: string;
+    filters?: HubSpotSearchFilter[];
+    properties?: string[];
+    limit?: number;
+    after?: string;
+    sortBy?: string;
+    sortDirection?: "ASCENDING" | "DESCENDING";
+  };
+
+  const body: Record<string, unknown> = {
+    properties: input.properties ?? defaultTicketProperties(),
+    limit: Math.min(input.limit ?? 25, 100),
+  };
+  if (input.query) body.query = input.query;
+  if (input.filters?.length) {
+    body.filterGroups = [{ filters: input.filters }];
+  }
+  if (input.after) body.after = input.after;
+  if (input.sortBy) {
+    body.sorts = [
+      {
+        propertyName: input.sortBy,
+        direction: input.sortDirection ?? "DESCENDING",
+      },
+    ];
+  }
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/tickets/search",
+    { method: "POST", body },
+  );
+  return { success: true, data };
+});
+
+export const createTicket = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    properties: Record<string, unknown>;
+    associations?: HubSpotAssociation[];
+  };
+  if (!input.properties || typeof input.properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+
+  const properties = { ...input.properties };
+  if (!properties.hs_pipeline && ctx.config.defaultTicketPipelineId) {
+    properties.hs_pipeline = ctx.config.defaultTicketPipelineId;
+  }
+
+  const body: Record<string, unknown> = { properties };
+  if (input.associations?.length) body.associations = input.associations;
+
+  const data = await fetcher<Record<string, unknown>>(
+    "/crm/v3/objects/tickets",
+    { method: "POST", body },
+  );
+  const id = (data as { id?: string }).id;
+  return withMaybeUrl(
+    { success: true, data },
+    id ? objectUrl(ctx.config, "tickets", id) : undefined,
+  );
+});
+
+export const updateTicket = withHubSpot(async (fetcher, ctx) => {
+  const { ticketId, properties } = ctx.input as {
+    ticketId: string;
+    properties: Record<string, unknown>;
+  };
+  if (!ticketId) return { success: false, error: "ticketId is required" };
+  if (!properties || typeof properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+
+  const rejected = rejectNonAllowlisted(
+    properties,
+    UPDATE_TICKET_ALLOWED_PROPERTIES,
+    "Update Ticket",
+  );
+  if (rejected) return { success: false, error: rejected.error };
+
+  // Reject any pipeline-stage that resolves to a closed stage (spec §6).
+  const proposedStage = properties.hs_pipeline_stage;
+  if (typeof proposedStage === "string" && proposedStage.length > 0) {
+    const pipelineId =
+      typeof properties.hs_pipeline === "string" && properties.hs_pipeline
+        ? properties.hs_pipeline
+        : await resolveTicketPipelineId(fetcher, ticketId);
+    if (!pipelineId) {
+      return {
+        success: false,
+        error:
+          "Update Ticket cannot validate hs_pipeline_stage: ticket has no resolvable pipeline. Include hs_pipeline in the update, or use Close Ticket.",
+      };
+    }
+    const pipeline = await fetchTicketPipeline(fetcher, pipelineId);
+    const stage = pipeline.stages.find((s) => s.id === proposedStage);
+    if (!stage) {
+      return {
+        success: false,
+        error: `Update Ticket: hs_pipeline_stage "${proposedStage}" is not a valid stage of pipeline ${pipelineId}.`,
+      };
+    }
+    if (isClosedStage(stage)) {
+      return {
+        success: false,
+        error: `Update Ticket cannot move a ticket to closed stage "${stage.label}" (${stage.id}). Use Close Ticket instead.`,
+      };
+    }
+  }
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/tickets/${encodeURIComponent(ticketId)}`,
+    { method: "PATCH", body: { properties } },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "tickets", ticketId),
+  );
+});
+
+export const closeTicket = withHubSpot(async (fetcher, ctx) => {
+  const { ticketId, closeNote } = ctx.input as {
+    ticketId: string;
+    closeNote?: string;
+  };
+  if (!ticketId) return { success: false, error: "ticketId is required" };
+
+  const pipelineId = await resolveTicketPipelineId(fetcher, ticketId);
+  if (!pipelineId) {
+    return {
+      success: false,
+      error: `Close Ticket cannot resolve pipeline for ticket ${ticketId}. Verify the ticket exists and has hs_pipeline set.`,
+    };
+  }
+  const resolved = await resolveClosedStageId(fetcher, pipelineId);
+  if ("error" in resolved) return { success: false, error: resolved.error };
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/crm/v3/objects/tickets/${encodeURIComponent(ticketId)}`,
+    {
+      method: "PATCH",
+      body: {
+        properties: {
+          hs_pipeline: pipelineId,
+          hs_pipeline_stage: resolved.stageId,
+          ...(closeNote ? { closed_note: closeNote } : {}),
+        },
+      },
+    },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "tickets", ticketId),
+  );
+});
+
+interface ConversationThread {
+  id: string;
+  latestMessageReceivedTimestamp?: string;
+  channelId?: string;
+  channelAccountId?: string;
+  associatedContactId?: string;
+  inboxId?: string;
+  status?: string;
+}
+
+interface ConversationMessage {
+  id: string;
+  type: string;
+  channelId?: string;
+  channelAccountId?: string;
+  recipients?: Array<Record<string, unknown>>;
+  senders?: Array<Record<string, unknown>>;
+  subject?: string;
+  direction?: string;
+  text?: string;
+  richText?: string;
+}
+
+async function getPrimaryTicketThread(
+  fetcher: HubSpotFetcher,
+  ticketId: string,
+): Promise<{ thread: ConversationThread } | { error: string }> {
+  // Preferred path: read the ticket's hs_thread_ids property (semicolon-separated).
+  const ticket = await fetcher<{
+    properties?: { hs_thread_ids?: string };
+  }>(`/crm/v3/objects/tickets/${encodeURIComponent(ticketId)}`, {
+    params: { properties: "hs_thread_ids" },
+  });
+
+  const raw = ticket.properties?.hs_thread_ids?.trim();
+  let threadIds: string[] = [];
+  if (raw) {
+    threadIds = raw.split(/[;,\s]+/).filter(Boolean);
+  } else {
+    // Fallback: associations API.
+    const assoc = await fetcher<{
+      results?: { toObjectId?: string | number; id?: string }[];
+    }>(
+      `/crm/v3/objects/tickets/${encodeURIComponent(
+        ticketId,
+      )}/associations/conversation`,
+    );
+    threadIds = (assoc.results ?? [])
+      .map((r) => String(r.toObjectId ?? r.id ?? ""))
+      .filter(Boolean);
+  }
+
+  if (threadIds.length === 0) {
+    return {
+      error: `Add Reply To Ticket: ticket ${ticketId} has no associated conversation thread. Replies require an existing thread (the ticket must have been opened via a conversations channel: email, chat, etc.).`,
+    };
+  }
+
+  // Pick the most recent thread by latestMessageReceivedTimestamp.
+  const threads = await Promise.all(
+    threadIds.map((id) =>
+      fetcher<ConversationThread>(
+        `/conversations/v3/conversations/threads/${encodeURIComponent(id)}`,
+      ),
+    ),
+  );
+  const sorted = threads
+    .filter((t) => !!t.id)
+    .sort((a, b) =>
+      (b.latestMessageReceivedTimestamp ?? "").localeCompare(
+        a.latestMessageReceivedTimestamp ?? "",
+      ),
+    );
+
+  if (sorted.length === 0) {
+    return {
+      error: `Add Reply To Ticket: ticket ${ticketId} references thread IDs but none resolved via the Conversations API.`,
+    };
+  }
+  return { thread: sorted[0] };
+}
+
+export const addReplyToTicket = withHubSpot(async (fetcher, ctx) => {
+  const { ticketId, text, richText, internal } = ctx.input as {
+    ticketId: string;
+    text?: string;
+    richText?: string;
+    internal?: boolean;
+  };
+  if (!ticketId) return { success: false, error: "ticketId is required" };
+  if (!text && !richText) {
+    return { success: false, error: "Either text or richText is required" };
+  }
+
+  const resolved = await getPrimaryTicketThread(fetcher, ticketId);
+  if ("error" in resolved) return { success: false, error: resolved.error };
+  const { thread } = resolved;
+
+  // Inspect the most recent inbound message to mirror its channel + recipients.
+  const history = await fetcher<{ results?: ConversationMessage[] }>(
+    `/conversations/v3/conversations/threads/${encodeURIComponent(
+      thread.id,
+    )}/messages`,
+    { params: { limit: 25 } },
+  );
+  const latestInbound = (history.results ?? [])
+    .filter((m) => m.type === "MESSAGE" && m.direction === "INCOMING")
+    .pop();
+
+  const channelId = latestInbound?.channelId ?? thread.channelId;
+  const channelAccountId =
+    latestInbound?.channelAccountId ?? thread.channelAccountId;
+  if (!channelId || !channelAccountId) {
+    return {
+      success: false,
+      error: `Add Reply To Ticket: could not infer channel/channelAccount from thread ${thread.id}. The thread is missing both inbound message history and channel metadata.`,
+    };
+  }
+
+  const messageBody: Record<string, unknown> = {
+    type: internal ? "COMMENT" : "MESSAGE",
+    channelId,
+    channelAccountId,
+    recipients: latestInbound?.senders ?? latestInbound?.recipients ?? [],
+    subject: latestInbound?.subject,
+    text,
+    richText: richText ?? text,
+  };
+
+  const data = await fetcher<Record<string, unknown>>(
+    `/conversations/v3/conversations/threads/${encodeURIComponent(
+      thread.id,
+    )}/messages`,
+    { method: "POST", body: messageBody },
+  );
+  return withMaybeUrl(
+    { success: true, data },
+    objectUrl(ctx.config, "tickets", ticketId),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Engagements (2)
+// ---------------------------------------------------------------------------
+
+export const logCallEngagement = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    properties: Record<string, unknown>;
+    associations?: HubSpotAssociation[];
+  };
+  if (!input.properties || typeof input.properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+  const body: Record<string, unknown> = { properties: input.properties };
+  if (input.associations?.length) body.associations = input.associations;
+
+  const data = await fetcher<Record<string, unknown>>("/crm/v3/objects/calls", {
+    method: "POST",
+    body,
+  });
+  return { success: true, data };
+});
+
+export const createNote = withHubSpot(async (fetcher, ctx) => {
+  const input = ctx.input as {
+    properties: Record<string, unknown>;
+    associations?: HubSpotAssociation[];
+  };
+  if (!input.properties || typeof input.properties !== "object") {
+    return { success: false, error: "properties object is required" };
+  }
+  const body: Record<string, unknown> = { properties: input.properties };
+  if (input.associations?.length) body.associations = input.associations;
+
+  const data = await fetcher<Record<string, unknown>>("/crm/v3/objects/notes", {
+    method: "POST",
+    body,
+  });
+  return { success: true, data };
+});
+
+// ---------------------------------------------------------------------------
+// Internal-only KB ingest operations — NOT MCP-registered (spec §5).
+// ---------------------------------------------------------------------------
+
+export interface ListKnowledgeArticlesParams {
+  limit?: number;
+  after?: string;
+  state?: "DRAFT" | "PUBLISHED" | "SCHEDULED";
+  updatedAfter?: string;
+}
+
+export interface HubSpotKnowledgeArticle {
+  id: string;
+  name?: string;
+  htmlTitle?: string;
+  language?: string;
+  url?: string;
+  archived?: boolean;
+  state?: string;
+  publishDate?: string;
+  updatedAt?: string;
+  createdAt?: string;
+  htmlBody?: string;
+  [key: string]: unknown;
+}
+
+export interface HubSpotKnowledgeArticleListResponse {
+  results: HubSpotKnowledgeArticle[];
+  paging?: { next?: { after?: string } };
+  total?: number;
+}
+
+export async function listKnowledgeArticles(
+  config: Record<string, string>,
+  params: ListKnowledgeArticlesParams = {},
+): Promise<HubSpotKnowledgeArticleListResponse> {
+  const fetcher = createHubSpotFetcher(config);
+  return await fetcher<HubSpotKnowledgeArticleListResponse>(
+    "/cms/v3/knowledge-base/articles",
+    {
+      params: {
+        limit: params.limit ?? 100,
+        after: params.after,
+        state: params.state,
+        updatedAfter: params.updatedAfter,
+      },
+    },
+  );
+}
+
+export async function getKnowledgeArticle(
+  config: Record<string, string>,
+  articleId: string,
+): Promise<HubSpotKnowledgeArticle> {
+  const fetcher = createHubSpotFetcher(config);
+  return await fetcher<HubSpotKnowledgeArticle>(
+    `/cms/v3/knowledge-base/articles/${encodeURIComponent(articleId)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+export function healthCheck(
+  config: Record<string, string>,
+): Promise<HealthCheckResult> {
+  return runHealthCheck(async () => {
+    const fetcher = createHubSpotFetcher(config, { timeoutMs: 5_000 });
+    await fetcher("/crm/v3/objects/contacts", { params: { limit: "1" } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared types and helpers
+// ---------------------------------------------------------------------------
+
+export interface HubSpotSearchFilter {
+  propertyName: string;
+  operator: string;
+  value?: string | number | boolean;
+  values?: Array<string | number>;
+  highValue?: string | number;
+}
+
+export interface HubSpotAssociation {
+  to: { id: string };
+  types: Array<{ associationCategory: string; associationTypeId: number }>;
+}
+
+function withMaybeUrl(
+  result: ToolExecutionResult,
+  url: string | undefined,
+): ToolExecutionResult {
+  return url ? { ...result, url } : result;
+}
+
+async function resolveTicketPipelineId(
+  fetcher: HubSpotFetcher,
+  ticketId: string,
+): Promise<string | undefined> {
+  const ticket = await fetcher<{
+    properties?: { hs_pipeline?: string };
+  }>(`/crm/v3/objects/tickets/${encodeURIComponent(ticketId)}`, {
+    params: { properties: "hs_pipeline" },
+  });
+  return ticket.properties?.hs_pipeline;
+}
+
+function defaultContactProperties(): string[] {
+  return [
+    "firstname",
+    "lastname",
+    "email",
+    "phone",
+    "company",
+    "lifecyclestage",
+    "hs_lead_status",
+    "createdate",
+    "lastmodifieddate",
+  ];
+}
+
+function defaultCompanyProperties(): string[] {
+  return [
+    "name",
+    "domain",
+    "industry",
+    "lifecyclestage",
+    "city",
+    "state",
+    "country",
+    "annualrevenue",
+    "numberofemployees",
+  ];
+}
+
+function defaultDealProperties(): string[] {
+  return [
+    "dealname",
+    "amount",
+    "dealstage",
+    "pipeline",
+    "closedate",
+    "hubspot_owner_id",
+    "createdate",
+  ];
+}
+
+function defaultTicketProperties(): string[] {
+  return [
+    "subject",
+    "content",
+    "hs_pipeline",
+    "hs_pipeline_stage",
+    "hs_ticket_priority",
+    "hs_ticket_category",
+    "hubspot_owner_id",
+    "createdate",
+    "hs_lastmodifieddate",
+    "hs_thread_ids",
+  ];
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/index.ts
@@ -629,6 +629,25 @@ const hubspotManifest: ConnectorManifest = {
       description:
         "Default ticket pipeline ID. Used by Create Ticket when the agent does not specify one.",
     },
+    lorevaultKnowledgeSpaceId: {
+      type: "string",
+      required: false,
+      description:
+        "LoreVault Knowledge Space ID for Mode B signal emission. When unset (alongside lorevaultVaultId), Mode B is disabled.",
+    },
+    lorevaultVaultId: {
+      type: "string",
+      required: false,
+      description:
+        "LoreVault Vault ID. Becomes tenant_id in the canonical_object_identity envelope per Phase 0 §1.1.",
+    },
+    signalEmissionEnabled: {
+      type: "boolean",
+      required: false,
+      default: true,
+      description:
+        "Mode B toggle. When false, state-changing tool calls do not emit signals. Useful for staging environments.",
+    },
   },
   tools,
   healthCheck,

--- a/modelguide-api/src/features/connectors/catalog/hubspot/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/index.ts
@@ -1,0 +1,637 @@
+/**
+ * HubSpot connector module.
+ *
+ * Surfaces 19 MCP tools (Contacts 5, Companies 2, Deals 3, Tickets 7,
+ * Engagements 2) plus 2 internal-only KB ingest operations (not MCP-exposed —
+ * used by the Mode C corpus walker in `./ingest`).
+ *
+ * Spec: ../../../../../../HubSpot Connector Spec.md (§3, §5, §6).
+ */
+
+import type { ConnectorManifest, ConnectorToolDefinition } from "../types";
+import {
+  addReplyToTicket,
+  closeTicket,
+  createContact,
+  createDeal,
+  createNote,
+  createTicket,
+  getCompany,
+  getContactByEmail,
+  getContactByPhone,
+  getTicket,
+  healthCheck,
+  listCompaniesForContact,
+  listDealsForContact,
+  listTicketsForContact,
+  logCallEngagement,
+  searchContacts,
+  searchTickets,
+  updateContact,
+  updateDealStage,
+  updateTicket,
+} from "./handlers";
+import {
+  COMPANY,
+  CONTACT,
+  CONVERSATION_MESSAGE,
+  DEAL,
+  ENGAGEMENT,
+  TICKET,
+} from "./response-shapes";
+
+const FILTER_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    propertyName: { type: "string" },
+    operator: {
+      type: "string",
+      description:
+        "HubSpot search operator (EQ, NEQ, GT, GTE, LT, LTE, BETWEEN, IN, NOT_IN, HAS_PROPERTY, NOT_HAS_PROPERTY, CONTAINS_TOKEN, NOT_CONTAINS_TOKEN)",
+    },
+    value: {},
+    values: { type: "array" },
+    highValue: {},
+  },
+  required: ["propertyName", "operator"],
+} as const;
+
+const ASSOCIATION_ITEM_SCHEMA = {
+  type: "object",
+  description:
+    "HubSpot association — links the new record to another CRM object",
+  properties: {
+    to: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+    },
+    types: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          associationCategory: {
+            type: "string",
+            description: "HUBSPOT_DEFINED or USER_DEFINED",
+          },
+          associationTypeId: { type: "integer" },
+        },
+        required: ["associationCategory", "associationTypeId"],
+      },
+    },
+  },
+  required: ["to", "types"],
+} as const;
+
+const tools: ConnectorToolDefinition[] = [
+  // -------------------------------------------------------------------------
+  // Contacts (5)
+  // -------------------------------------------------------------------------
+  {
+    catalog: {
+      name: "Get Contact By Email",
+      description:
+        "Look up a HubSpot contact by their email address. Returns id, properties, and timestamps.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          email: { type: "string", description: "Contact email address" },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Specific HubSpot contact properties to include",
+          },
+        },
+        required: ["email"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: getContactByEmail,
+    responseShape: CONTACT,
+  },
+  {
+    catalog: {
+      name: "Get Contact By Phone",
+      description:
+        "Look up a HubSpot contact by phone or mobile number. Returns up to five matches (HubSpot does not enforce phone uniqueness).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          phone: {
+            type: "string",
+            description: "E.164-formatted phone number",
+          },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Specific HubSpot contact properties to include",
+          },
+        },
+        required: ["phone"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: getContactByPhone,
+    responseShape: { results: CONTACT, total: true, paging: true },
+  },
+  {
+    catalog: {
+      name: "Search Contacts",
+      description:
+        "Search HubSpot contacts using a free-text query and/or structured filters (HubSpot search API).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Free-text query — searches name, email, and company",
+          },
+          filters: {
+            type: "array",
+            items: FILTER_ITEM_SCHEMA,
+            description: "Structured property filters",
+          },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Properties to return on each match",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            description: "Max results (default 25, max 100)",
+          },
+          after: { type: "string", description: "Cursor for pagination" },
+        },
+        required: [],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 20,
+    },
+    handler: searchContacts,
+    responseShape: { results: CONTACT, total: true, paging: true },
+  },
+  {
+    catalog: {
+      name: "Create Contact",
+      description:
+        "Create a new HubSpot contact. Pass HubSpot-defined contact properties (e.g. firstname, lastname, email, phone).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          properties: {
+            type: "object",
+            description: "HubSpot contact properties keyed by property name",
+            additionalProperties: true,
+          },
+          associations: {
+            type: "array",
+            items: ASSOCIATION_ITEM_SCHEMA,
+            description: "Optional associations to companies, deals, etc.",
+          },
+        },
+        required: ["properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: createContact,
+    responseShape: CONTACT,
+  },
+  {
+    catalog: {
+      name: "Update Contact",
+      description:
+        "Update a HubSpot contact. Only allowlisted properties may be written: firstname, lastname, email, phone, mobilephone, company, jobtitle, lifecyclestage, hs_lead_status, address, city, state, zip, country, website.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          contactId: { type: "string", description: "HubSpot contact ID" },
+          properties: {
+            type: "object",
+            description: "Allowlisted contact properties to update",
+            additionalProperties: true,
+          },
+        },
+        required: ["contactId", "properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: updateContact,
+    responseShape: CONTACT,
+  },
+
+  // -------------------------------------------------------------------------
+  // Companies (2)
+  // -------------------------------------------------------------------------
+  {
+    catalog: {
+      name: "Get Company",
+      description: "Get a HubSpot company by its ID.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          companyId: { type: "string", description: "HubSpot company ID" },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Specific HubSpot company properties to include",
+          },
+        },
+        required: ["companyId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: getCompany,
+    responseShape: COMPANY,
+  },
+  {
+    catalog: {
+      name: "List Companies For Contact",
+      description:
+        "List all companies associated with a HubSpot contact (via the associations API + batch read).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          contactId: { type: "string", description: "HubSpot contact ID" },
+        },
+        required: ["contactId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: listCompaniesForContact,
+    responseShape: { results: COMPANY, total: true },
+  },
+
+  // -------------------------------------------------------------------------
+  // Deals (3)
+  // -------------------------------------------------------------------------
+  {
+    catalog: {
+      name: "List Deals For Contact",
+      description:
+        "List all deals associated with a HubSpot contact (via the associations API + batch read).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          contactId: { type: "string", description: "HubSpot contact ID" },
+        },
+        required: ["contactId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: listDealsForContact,
+    responseShape: { results: DEAL, total: true },
+  },
+  {
+    catalog: {
+      name: "Create Deal",
+      description:
+        "Create a new HubSpot deal. Requires confirmation. If no pipeline is provided, the connector falls back to the connector's `defaultPipelineId` config.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          properties: {
+            type: "object",
+            description:
+              "HubSpot deal properties (dealname, amount, dealstage, pipeline, closedate, hubspot_owner_id, etc.)",
+            additionalProperties: true,
+          },
+          associations: {
+            type: "array",
+            items: ASSOCIATION_ITEM_SCHEMA,
+            description: "Optional associations to contacts, companies, etc.",
+          },
+        },
+        required: ["properties"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 20,
+    },
+    handler: createDeal,
+    responseShape: DEAL,
+  },
+  {
+    catalog: {
+      name: "Update Deal Stage",
+      description:
+        "Move a HubSpot deal to a new dealstage. Requires confirmation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          dealId: { type: "string", description: "HubSpot deal ID" },
+          stage: {
+            type: "string",
+            description: "Target dealstage ID (pipeline-defined)",
+          },
+        },
+        required: ["dealId", "stage"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: updateDealStage,
+    responseShape: DEAL,
+  },
+
+  // -------------------------------------------------------------------------
+  // Tickets (7)
+  // -------------------------------------------------------------------------
+  {
+    catalog: {
+      name: "Get Ticket",
+      description: "Get a HubSpot ticket by ID with its key properties.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ticketId: { type: "string", description: "HubSpot ticket ID" },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Specific HubSpot ticket properties to include",
+          },
+        },
+        required: ["ticketId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: getTicket,
+    responseShape: TICKET,
+  },
+  {
+    catalog: {
+      name: "List Tickets For Contact",
+      description:
+        "List all tickets associated with a HubSpot contact (associations API + batch read).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          contactId: { type: "string", description: "HubSpot contact ID" },
+        },
+        required: ["contactId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: listTicketsForContact,
+    responseShape: { results: TICKET, total: true },
+  },
+  {
+    catalog: {
+      name: "Search Tickets",
+      description:
+        "Search HubSpot tickets using a free-text query and/or structured filters.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Free-text query" },
+          filters: {
+            type: "array",
+            items: FILTER_ITEM_SCHEMA,
+            description: "Structured property filters",
+          },
+          properties: {
+            type: "array",
+            items: { type: "string" },
+            description: "Properties to return on each match",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            description: "Max results (default 25, max 100)",
+          },
+          after: { type: "string", description: "Cursor for pagination" },
+          sortBy: {
+            type: "string",
+            description: "Property name to sort by (e.g. hs_lastmodifieddate)",
+          },
+          sortDirection: {
+            type: "string",
+            enum: ["ASCENDING", "DESCENDING"],
+            description: "Sort direction (default DESCENDING)",
+          },
+        },
+        required: [],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 20,
+    },
+    handler: searchTickets,
+    responseShape: { results: TICKET, total: true, paging: true },
+  },
+  {
+    catalog: {
+      name: "Create Ticket",
+      description:
+        "Create a new HubSpot ticket. If no pipeline is provided, falls back to the connector's `defaultTicketPipelineId`.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          properties: {
+            type: "object",
+            description:
+              "HubSpot ticket properties (subject, content, hs_pipeline, hs_pipeline_stage, hs_ticket_priority, hs_ticket_category, hubspot_owner_id)",
+            additionalProperties: true,
+          },
+          associations: {
+            type: "array",
+            items: ASSOCIATION_ITEM_SCHEMA,
+            description: "Optional associations to contacts, companies, deals",
+          },
+        },
+        required: ["properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: createTicket,
+    responseShape: TICKET,
+  },
+  {
+    catalog: {
+      name: "Update Ticket",
+      description:
+        "Update a HubSpot ticket. Only allowlisted properties may be written: subject, content, hs_ticket_priority, hs_ticket_category, hubspot_owner_id, hs_pipeline, hs_pipeline_stage. Any hs_pipeline_stage that resolves to a CLOSED stage is rejected — use Close Ticket instead.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ticketId: { type: "string", description: "HubSpot ticket ID" },
+          properties: {
+            type: "object",
+            description: "Allowlisted ticket properties to update",
+            additionalProperties: true,
+          },
+        },
+        required: ["ticketId", "properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: updateTicket,
+    responseShape: TICKET,
+  },
+  {
+    catalog: {
+      name: "Close Ticket",
+      description:
+        "Close a HubSpot ticket. Requires confirmation. The connector resolves the per-pipeline CLOSED stage at runtime (metadata.ticketState === 'CLOSED'); no stage ID is hardcoded.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ticketId: { type: "string", description: "HubSpot ticket ID" },
+          closeNote: {
+            type: "string",
+            description: "Optional resolution note recorded on the ticket",
+          },
+        },
+        required: ["ticketId"],
+      },
+      defaultRequiresConfirmation: true,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: closeTicket,
+    responseShape: TICKET,
+  },
+  {
+    catalog: {
+      name: "Add Reply To Ticket",
+      description:
+        "Post a reply on the ticket's primary conversation thread via the Conversations API. Channel is inferred from the thread's most recent inbound message. Errors clearly if the ticket has no associated thread.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ticketId: { type: "string", description: "HubSpot ticket ID" },
+          text: {
+            type: "string",
+            description: "Plain-text body of the reply",
+          },
+          richText: {
+            type: "string",
+            description:
+              "Rich-text (HTML) body of the reply. If omitted, defaults to text.",
+          },
+          internal: {
+            type: "boolean",
+            description:
+              "Post as an internal comment instead of a customer-facing message (default false)",
+          },
+        },
+        required: ["ticketId"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 20,
+    },
+    handler: addReplyToTicket,
+    responseShape: CONVERSATION_MESSAGE,
+  },
+
+  // -------------------------------------------------------------------------
+  // Engagements (2)
+  // -------------------------------------------------------------------------
+  {
+    catalog: {
+      name: "Log Call Engagement",
+      description:
+        "Log a call engagement against contacts, companies, deals, or tickets.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          properties: {
+            type: "object",
+            description:
+              "HubSpot call engagement properties (hs_call_title, hs_call_body, hs_call_duration, hs_call_status, hs_call_direction, hs_timestamp, hubspot_owner_id)",
+            additionalProperties: true,
+          },
+          associations: {
+            type: "array",
+            items: ASSOCIATION_ITEM_SCHEMA,
+            description: "Associations to the entities the call relates to",
+          },
+        },
+        required: ["properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: logCallEngagement,
+    responseShape: ENGAGEMENT,
+  },
+  {
+    catalog: {
+      name: "Create Note",
+      description:
+        "Create an internal HubSpot note (e.g. HITL handoff context). Associates to specified entities.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          properties: {
+            type: "object",
+            description:
+              "HubSpot note properties (hs_note_body, hs_timestamp, hubspot_owner_id)",
+            additionalProperties: true,
+          },
+          associations: {
+            type: "array",
+            items: ASSOCIATION_ITEM_SCHEMA,
+            description: "Associations to the entities the note relates to",
+          },
+        },
+        required: ["properties"],
+      },
+      defaultRequiresConfirmation: false,
+      defaultTimeoutSeconds: 15,
+    },
+    handler: createNote,
+    responseShape: ENGAGEMENT,
+  },
+];
+
+const hubspotManifest: ConnectorManifest = {
+  name: "HubSpot",
+  slug: "hubspot",
+  description:
+    "HubSpot CRM + Service Hub connector. Provides AI-agent tool access to contacts, companies, deals, tickets, and conversations. KB articles are ingested into LoreVault as corpus (internal-only — not agent-callable).",
+  connectorType: "api",
+  authMethods: ["api_key"],
+  iconUrl: "/logos/hubspot.svg",
+  configSchema: {
+    accessToken: {
+      type: "secret",
+      required: true,
+      description:
+        "HubSpot Private App access token. Required scopes documented in the HubSpot Connector Spec §4.",
+    },
+    portalId: {
+      type: "string",
+      required: false,
+      description:
+        "HubSpot portal (hub) ID. Used for deep-link URLs and as source_instance on emitted signals.",
+    },
+    defaultPipelineId: {
+      type: "string",
+      required: false,
+      description:
+        "Default deal pipeline ID. Used by Create Deal when the agent does not specify one.",
+    },
+    defaultTicketPipelineId: {
+      type: "string",
+      required: false,
+      description:
+        "Default ticket pipeline ID. Used by Create Ticket when the agent does not specify one.",
+    },
+  },
+  tools,
+  healthCheck,
+};
+
+export default hubspotManifest;

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/canonical-identity.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/canonical-identity.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonical identity derivation per Phase 0 Integration Contract §1.2.
+ *
+ *   source_id = `{tenant_id}:hubspot:{object_type}:{object_id}`
+ *
+ * `tenant_id` is the LoreVault vault_id. Same canonical identity → same
+ * document, idempotent upsert.
+ */
+
+export type HubSpotObjectType =
+  | "contact"
+  | "company"
+  | "deal"
+  | "ticket"
+  | "engagement"
+  | "knowledge_article";
+
+export const HUBSPOT_SOURCE_SYSTEM = "hubspot" as const;
+
+export interface CanonicalIdentityInput {
+  tenantId: string;
+  objectType: HubSpotObjectType;
+  objectId: string;
+}
+
+export function deriveSourceId(input: CanonicalIdentityInput): string {
+  const { tenantId, objectType, objectId } = input;
+  if (!tenantId) throw new Error("tenantId is required");
+  if (!objectType) throw new Error("objectType is required");
+  if (!objectId) throw new Error("objectId is required");
+  return `${tenantId}:${HUBSPOT_SOURCE_SYSTEM}:${objectType}:${objectId}`;
+}
+
+export const DATASET_IDS: Record<HubSpotObjectType, string> = {
+  contact: "hubspot-contacts",
+  company: "hubspot-companies",
+  deal: "hubspot-deals",
+  ticket: "hubspot-tickets",
+  engagement: "hubspot-engagements",
+  knowledge_article: "hubspot-kb",
+};

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/canonical-identity.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/canonical-identity.ts
@@ -13,6 +13,7 @@ export type HubSpotObjectType =
   | "deal"
   | "ticket"
   | "engagement"
+  | "note"
   | "knowledge_article";
 
 export const HUBSPOT_SOURCE_SYSTEM = "hubspot" as const;
@@ -37,5 +38,10 @@ export const DATASET_IDS: Record<HubSpotObjectType, string> = {
   deal: "hubspot-deals",
   ticket: "hubspot-tickets",
   engagement: "hubspot-engagements",
+  // `note` is an entity type for canonical identity (Mode B emits
+  // note.created) but notes are not a separate Mode C corpus surface —
+  // they ride along inside ticket/contact documents. Keep the dataset
+  // identifier so the source_system→dataset_id mapping is total.
+  note: "hubspot-notes",
   knowledge_article: "hubspot-kb",
 };

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/index.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/index.ts
@@ -1,0 +1,330 @@
+/**
+ * HubSpot Mode C corpus ingest skeleton.
+ *
+ * Walks ticket / KB-article / contact corpora, renders each entity to
+ * markdown, and pushes batches into LoreVault via the thin-adapter
+ * `LoreVaultIntegrationClient` interface.
+ *
+ * Idempotency: documents are keyed by canonical `source_id` (Phase 0 §1.2).
+ * Re-running with the same source on the same LoreVault state produces no
+ * duplicate documents — the mock client upserts on `source_id`, and the
+ * real HTTP client is contractually required to do the same.
+ *
+ * Out of scope for Phase 1 (stubbed):
+ *   - Mode B (signal emission) — `enqueueSignal()` returns without doing
+ *     anything; wave-2 work wires it to the queue + retry path.
+ *   - Mode D (HubSpot webhooks) — not until post-POC.
+ */
+
+import { getLogger } from "@lib/logger";
+import type {
+  IngestDocument,
+  IngestionJobAcceptResponse,
+  LoreVaultIntegrationClient,
+  SignalEvent,
+} from "../../../../lorevault/client";
+import type { HubSpotKnowledgeArticle } from "../handlers";
+import { DATASET_IDS, type HubSpotObjectType } from "./canonical-identity";
+import {
+  type HubSpotContactWithContext,
+  type HubSpotObject,
+  type HubSpotTicketWithThread,
+  renderContactAsMarkdown,
+  renderKnowledgeArticleAsMarkdown,
+  renderTicketAsMarkdown,
+} from "./renderers";
+
+// ---------------------------------------------------------------------------
+// Source provider — pluggable HubSpot access surface.
+// ---------------------------------------------------------------------------
+
+export interface HubSpotIngestSource {
+  listTickets(params: PaginationParams): Promise<Page<HubSpotTicketWithThread>>;
+  listKnowledgeArticles(
+    params: PaginationParams,
+  ): Promise<Page<HubSpotKnowledgeArticle>>;
+  listContacts(
+    params: PaginationParams,
+  ): Promise<Page<HubSpotContactWithContext>>;
+}
+
+export interface PaginationParams {
+  after?: string;
+  /** ISO-8601 watermark for incremental sync. Implementations filter on
+   * lastModified ≥ watermark when present. */
+  updatedSince?: string;
+  limit: number;
+}
+
+export interface Page<T> {
+  items: T[];
+  next?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Watermark tracking
+// ---------------------------------------------------------------------------
+
+export interface WatermarkStore {
+  read(objectType: HubSpotObjectType): Promise<string | undefined>;
+  write(objectType: HubSpotObjectType, watermark: string): Promise<void>;
+}
+
+/** In-memory watermark store. Production wires a Drizzle-backed store. */
+export class InMemoryWatermarkStore implements WatermarkStore {
+  private readonly map = new Map<HubSpotObjectType, string>();
+
+  async read(objectType: HubSpotObjectType): Promise<string | undefined> {
+    return this.map.get(objectType);
+  }
+
+  async write(objectType: HubSpotObjectType, watermark: string): Promise<void> {
+    this.map.set(objectType, watermark);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runner config + result
+// ---------------------------------------------------------------------------
+
+export interface CorpusIngestConfig {
+  knowledgeSpaceId: string;
+  /** Vault ID that doubles as `tenant_id` for canonical-identity derivation
+   * (Phase 0 §1.1: `tenant_id = vault_id`). */
+  vaultId: string;
+  /** HubSpot portal ID. Becomes `source_instance` on emitted documents. */
+  sourceInstance: string;
+  /** Page size for HubSpot list calls. Default 100. */
+  pageSize?: number;
+  /** Batch size for LoreVault `ingestDocuments` calls. Default 25. */
+  batchSize?: number;
+  /** Entity types to ingest. Default: all three (ticket, knowledge_article, contact). */
+  entityTypes?: Array<"ticket" | "knowledge_article" | "contact">;
+}
+
+export interface CorpusIngestResult {
+  totals: Record<
+    "ticket" | "knowledge_article" | "contact",
+    {
+      documents: number;
+      jobs: string[];
+    }
+  >;
+  watermarks: Partial<Record<HubSpotObjectType, string>>;
+}
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_BATCH_SIZE = 25;
+
+// ---------------------------------------------------------------------------
+// Main entry — full walk + incremental sync share the same code path,
+// differentiated by whether the caller passes a `watermarkStore`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a full corpus walk. Equivalent to `runIncrementalSync` with an empty
+ * watermark store — every entity is rendered and upserted by canonical
+ * source_id. Re-runs are idempotent.
+ */
+export async function runInitialBackfill(
+  source: HubSpotIngestSource,
+  client: LoreVaultIntegrationClient,
+  config: CorpusIngestConfig,
+): Promise<CorpusIngestResult> {
+  return runIngest(source, client, config, new InMemoryWatermarkStore());
+}
+
+/**
+ * Run an incremental sync. Reads per-object watermarks from `watermarkStore`,
+ * filters the HubSpot walk with `updatedSince`, and writes new watermarks at
+ * the end of each entity's loop.
+ */
+export async function runIncrementalSync(
+  source: HubSpotIngestSource,
+  client: LoreVaultIntegrationClient,
+  config: CorpusIngestConfig,
+  watermarkStore: WatermarkStore,
+): Promise<CorpusIngestResult> {
+  return runIngest(source, client, config, watermarkStore);
+}
+
+async function runIngest(
+  source: HubSpotIngestSource,
+  client: LoreVaultIntegrationClient,
+  config: CorpusIngestConfig,
+  watermarkStore: WatermarkStore,
+): Promise<CorpusIngestResult> {
+  const log = getLogger();
+  const pageSize = config.pageSize ?? DEFAULT_PAGE_SIZE;
+  const batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+  const entityTypes =
+    config.entityTypes ?? (["ticket", "knowledge_article", "contact"] as const);
+
+  const result: CorpusIngestResult = {
+    totals: {
+      ticket: { documents: 0, jobs: [] },
+      knowledge_article: { documents: 0, jobs: [] },
+      contact: { documents: 0, jobs: [] },
+    },
+    watermarks: {},
+  };
+
+  for (const type of entityTypes) {
+    const watermark = await watermarkStore.read(type);
+    log.info(
+      { connector: "HubSpot", type, watermark },
+      "Mode C ingest: walk start",
+    );
+
+    let nextWatermark = watermark ?? "";
+    let cursor: string | undefined;
+    do {
+      const page = await fetchPage(source, type, {
+        after: cursor,
+        updatedSince: watermark,
+        limit: pageSize,
+      });
+
+      for (let i = 0; i < page.items.length; i += batchSize) {
+        const slice = page.items.slice(i, i + batchSize);
+        const documents = slice.map((entity) =>
+          renderEntity(type, entity, config),
+        );
+        if (documents.length === 0) continue;
+
+        const job = await client.ingestDocuments({
+          knowledge_space_id: config.knowledgeSpaceId,
+          dataset_id: DATASET_IDS[entityToHubSpotObject(type)],
+          documents,
+        });
+        recordJob(result, type, job);
+
+        const sliceWatermark = pickHighestWatermark(slice);
+        if (sliceWatermark && sliceWatermark > nextWatermark) {
+          nextWatermark = sliceWatermark;
+        }
+      }
+
+      cursor = page.next;
+    } while (cursor);
+
+    if (nextWatermark && nextWatermark !== (watermark ?? "")) {
+      await watermarkStore.write(type, nextWatermark);
+      result.watermarks[entityToHubSpotObject(type)] = nextWatermark;
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Mode B stub (per spec §10 / dispatch scope)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mode B signal emission entry point. Phase 1 is a no-op — the call is wired
+ * so handlers can route signals here today without behavior changes when
+ * Wave 2 lights up the queue + retry path.
+ */
+export async function enqueueSignal(
+  _client: LoreVaultIntegrationClient,
+  _event: SignalEvent,
+): Promise<void> {
+  // Intentional no-op: Mode B is out of scope for Phase 1.
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type EntityKey = "ticket" | "knowledge_article" | "contact";
+
+function entityToHubSpotObject(type: EntityKey): HubSpotObjectType {
+  return type;
+}
+
+async function fetchPage(
+  source: HubSpotIngestSource,
+  type: EntityKey,
+  params: PaginationParams,
+): Promise<
+  Page<
+    | HubSpotTicketWithThread
+    | HubSpotKnowledgeArticle
+    | HubSpotContactWithContext
+  >
+> {
+  switch (type) {
+    case "ticket":
+      return source.listTickets(params);
+    case "knowledge_article":
+      return source.listKnowledgeArticles(params);
+    case "contact":
+      return source.listContacts(params);
+  }
+}
+
+function renderEntity(
+  type: EntityKey,
+  entity:
+    | HubSpotTicketWithThread
+    | HubSpotKnowledgeArticle
+    | HubSpotContactWithContext,
+  config: CorpusIngestConfig,
+): IngestDocument {
+  const ctx = {
+    tenantId: config.vaultId,
+    sourceInstance: config.sourceInstance,
+  };
+  switch (type) {
+    case "ticket":
+      return renderTicketAsMarkdown(entity as HubSpotTicketWithThread, ctx);
+    case "knowledge_article":
+      return renderKnowledgeArticleAsMarkdown(
+        entity as HubSpotKnowledgeArticle,
+        ctx,
+      );
+    case "contact":
+      return renderContactAsMarkdown(entity as HubSpotContactWithContext, ctx);
+  }
+}
+
+function recordJob(
+  result: CorpusIngestResult,
+  type: EntityKey,
+  job: IngestionJobAcceptResponse,
+): void {
+  result.totals[type].documents += job.accepted_count;
+  result.totals[type].jobs.push(job.ingestion_job_id);
+}
+
+function pickHighestWatermark(
+  items: Array<HubSpotObject | HubSpotKnowledgeArticle>,
+): string {
+  let highest = "";
+  for (const item of items) {
+    const candidate = pickItemTimestamp(item);
+    if (candidate && candidate > highest) highest = candidate;
+  }
+  return highest;
+}
+
+function pickItemTimestamp(
+  item: HubSpotObject | HubSpotKnowledgeArticle,
+): string | undefined {
+  if ("updatedAt" in item && typeof item.updatedAt === "string") {
+    return item.updatedAt;
+  }
+  if ("properties" in item) {
+    const props = (item.properties ?? {}) as Record<string, unknown>;
+    const candidates = [
+      props.hs_lastmodifieddate,
+      props.lastmodifieddate,
+      props.updatedAt,
+    ];
+    for (const c of candidates) {
+      if (typeof c === "string" && c) return c;
+    }
+  }
+  return undefined;
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/mode-b/emit.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/mode-b/emit.ts
@@ -1,0 +1,156 @@
+/**
+ * Mode B glue: a HOC that wraps a tool handler with non-blocking signal
+ * emission and a registry that connects a HubSpot connector instance to
+ * its `SignalEmissionQueue`.
+ *
+ * Tool handlers stay focused on the HubSpot call. After the inner handler
+ * returns success, `withSignalEmission` builds the envelope and enqueues
+ * it. The response to the agent never waits on emission.
+ *
+ * Per-connector queue lookup: each HubSpot connector instance gets its
+ * own queue (separate KS / vault / Mode B toggle). The registry below
+ * caches by `connectorId` so a single connector reuses the same queue
+ * across tool invocations.
+ */
+
+import { getLogger } from "@lib/logger";
+import { createLoreVaultClient } from "../../../../../lorevault/binding";
+import { SignalEmissionQueue } from "../../../../../lorevault/emission";
+import type { ToolExecutionContext, ToolExecutionResult } from "../../../types";
+import {
+  type EmissionConfig,
+  type EmittingToolName,
+  buildEnvelopeForTool,
+} from "./envelopes";
+
+// ---------------------------------------------------------------------------
+// Per-connector queue registry
+// ---------------------------------------------------------------------------
+
+interface QueueEntry {
+  queue: SignalEmissionQueue;
+  started: Promise<{ allowed: boolean }>;
+}
+
+const queues = new Map<string, QueueEntry>();
+
+/**
+ * Replace the queue factory for tests. Returning `null` disables Mode B
+ * for the test (handlers behave as if `signalEmissionEnabled = false`).
+ */
+let queueFactory: (ctx: ToolExecutionContext) => SignalEmissionQueue | null =
+  defaultQueueFactory;
+
+export function setQueueFactoryForTesting(
+  fn: ((ctx: ToolExecutionContext) => SignalEmissionQueue | null) | null,
+): void {
+  queueFactory = fn ?? defaultQueueFactory;
+  queues.clear();
+}
+
+export function getQueueForConnector(
+  ctx: ToolExecutionContext,
+): SignalEmissionQueue | null {
+  if (!modeBEnabled(ctx)) return null;
+
+  const existing = queues.get(ctx.connectorId);
+  if (existing) return existing.queue;
+
+  const queue = queueFactory(ctx);
+  if (!queue) return null;
+
+  const started = queue
+    .start()
+    .then((verdict) => ({ allowed: verdict.allowed }));
+  queues.set(ctx.connectorId, { queue, started });
+  return queue;
+}
+
+function defaultQueueFactory(
+  ctx: ToolExecutionContext,
+): SignalEmissionQueue | null {
+  const client = createLoreVaultClient({
+    knowledgeSpaceId: ctx.config.lorevaultKnowledgeSpaceId,
+  });
+  return new SignalEmissionQueue({ client });
+}
+
+function modeBEnabled(ctx: ToolExecutionContext): boolean {
+  const flag = ctx.config.signalEmissionEnabled;
+  // Default to enabled when KS + Vault are both configured.
+  const haveScope =
+    !!ctx.config.lorevaultKnowledgeSpaceId && !!ctx.config.lorevaultVaultId;
+  if (flag === undefined) return haveScope;
+  if (typeof flag === "string") {
+    return haveScope && flag.toLowerCase() === "true";
+  }
+  return haveScope && !!flag;
+}
+
+function emissionConfig(ctx: ToolExecutionContext): EmissionConfig | null {
+  const knowledgeSpaceId = ctx.config.lorevaultKnowledgeSpaceId;
+  const vaultId = ctx.config.lorevaultVaultId;
+  if (!knowledgeSpaceId || !vaultId) return null;
+  return {
+    knowledgeSpaceId,
+    vaultId,
+    sourceInstance: ctx.config.portalId ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HOC: wrap an emitting tool handler
+// ---------------------------------------------------------------------------
+
+export function withSignalEmission(
+  toolName: EmittingToolName,
+  inner: (ctx: ToolExecutionContext) => Promise<ToolExecutionResult>,
+): (ctx: ToolExecutionContext) => Promise<ToolExecutionResult> {
+  return async (ctx) => {
+    const result = await inner(ctx);
+    if (!result.success) return result;
+    try {
+      emitForTool(toolName, ctx, result);
+    } catch (err) {
+      // Emission is best-effort. We log but never fail the tool response.
+      getLogger().warn(
+        { err, toolName, connectorId: ctx.connectorId },
+        "Mode B emission threw synchronously; tool response unaffected",
+      );
+    }
+    return result;
+  };
+}
+
+function emitForTool(
+  toolName: EmittingToolName,
+  ctx: ToolExecutionContext,
+  result: ToolExecutionResult,
+): void {
+  const config = emissionConfig(ctx);
+  if (!config) return;
+  const queue = getQueueForConnector(ctx);
+  if (!queue) return;
+
+  const envelope = buildEnvelopeForTool(toolName, {
+    ctx,
+    result: result.data,
+    config,
+  });
+  if (!envelope) {
+    getLogger().warn(
+      { toolName, connectorId: ctx.connectorId },
+      "Mode B envelope builder produced no envelope; skipping",
+    );
+    return;
+  }
+  queue.enqueue(envelope);
+}
+
+/**
+ * Test/admin helper — clears the per-connector queue registry so the next
+ * tool call rebuilds (or skips) a queue with current config.
+ */
+export function resetQueuesForTesting(): void {
+  queues.clear();
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/mode-b/envelopes.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/mode-b/envelopes.ts
@@ -1,0 +1,338 @@
+/**
+ * Signal envelope builders for the HubSpot connector's signal-emitting tools.
+ *
+ * Spec mapping (HubSpot Connector Spec §5):
+ *
+ *   tool                  | event_type         | entity.type | declared_lens_hints
+ *   --------------------- | ------------------ | ----------- | -----------------------------------------------
+ *   Create Contact        | contact.created    | contact     | customer_interaction
+ *   Update Contact        | contact.updated    | contact     | customer_interaction (+ revenue_intelligence
+ *                                                              when properties_changed includes lifecyclestage)
+ *   Create Deal           | deal.created       | deal        | revenue_intelligence
+ *   Update Deal Stage     | deal.stage_changed | deal        | revenue_intelligence, operational_workflow
+ *   Create Ticket         | ticket.created     | ticket      | customer_interaction, operational_workflow
+ *   Update Ticket         | ticket.updated     | ticket      | operational_workflow
+ *   Close Ticket          | ticket.closed      | ticket      | operational_workflow, customer_interaction
+ *   Add Reply To Ticket   | ticket.reply_sent  | ticket      | customer_interaction, knowledge_integrity
+ *   Log Call Engagement   | call.logged        | engagement  | customer_interaction, operational_workflow
+ *   Create Note           | note.created       | note        | knowledge_integrity, operational_workflow
+ *
+ * (Spec §5's summary line says "12 signal-emitting" but the per-row table
+ * enumerates exactly 10. We implement what the row-level table specifies —
+ * the source of truth for behavior — and surface the count discrepancy in
+ * the Phase 2 PR description.)
+ *
+ * Envelope shape: Phase 0 Integration Contract §1.1. canonical_object_identity
+ * is derived deterministically from `deriveSourceId`.
+ */
+
+import type {
+  LensId,
+  SignalEvent,
+  SignalPayload,
+} from "../../../../../lorevault/client";
+import type { ToolExecutionContext } from "../../../types";
+import { type HubSpotObjectType, deriveSourceId } from "../canonical-identity";
+
+// ---------------------------------------------------------------------------
+// Tool name → event type lookup. Names match the manifest `catalog.name`.
+// ---------------------------------------------------------------------------
+
+export const EMITTING_TOOL_EVENT_TYPES = {
+  "Create Contact": "contact.created",
+  "Update Contact": "contact.updated",
+  "Create Deal": "deal.created",
+  "Update Deal Stage": "deal.stage_changed",
+  "Create Ticket": "ticket.created",
+  "Update Ticket": "ticket.updated",
+  "Close Ticket": "ticket.closed",
+  "Add Reply To Ticket": "ticket.reply_sent",
+  "Log Call Engagement": "call.logged",
+  "Create Note": "note.created",
+} as const;
+
+export type EmittingToolName = keyof typeof EMITTING_TOOL_EVENT_TYPES;
+export type SignalEventType =
+  (typeof EMITTING_TOOL_EVENT_TYPES)[EmittingToolName];
+
+// ---------------------------------------------------------------------------
+// Builder input
+// ---------------------------------------------------------------------------
+
+export interface EmissionConfig {
+  knowledgeSpaceId: string;
+  vaultId: string;
+  sourceInstance: string;
+}
+
+export interface EnvelopeBuildInput {
+  ctx: ToolExecutionContext;
+  /** HubSpot envelope returned by the tool handler. */
+  result: Record<string, unknown> | undefined;
+  config: EmissionConfig;
+  /** Injectable for tests; defaults to crypto.randomUUID() + Date.now(). */
+  signalId?: string;
+  emittedAt?: string;
+}
+
+interface InternalEntity {
+  type: HubSpotObjectType;
+  id: string;
+  portalUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool builders
+// ---------------------------------------------------------------------------
+
+type Builder = (input: EnvelopeBuildInput) => SignalEvent | null;
+
+const builders: Record<EmittingToolName, Builder> = {
+  "Create Contact": (i) =>
+    buildEnvelope(i, {
+      eventType: "contact.created",
+      entityFrom: { type: "contact", source: "result" },
+      lensHints: ["customer_interaction"],
+      payload: (i) => ({ snapshot: extractProperties(i.result) }),
+    }),
+
+  "Update Contact": (i) => {
+    const inputProps = readInputProperties(i.ctx);
+    const propertiesChanged = Object.keys(inputProps);
+    const lensHints: LensId[] = ["customer_interaction"];
+    if ("lifecyclestage" in inputProps) lensHints.push("revenue_intelligence");
+    return buildEnvelope(i, {
+      eventType: "contact.updated",
+      entityFrom: { type: "contact", source: "input", inputField: "contactId" },
+      lensHints,
+      payload: () => ({
+        after: extractProperties(i.result),
+        properties_changed: propertiesChanged,
+      }),
+    });
+  },
+
+  "Create Deal": (i) =>
+    buildEnvelope(i, {
+      eventType: "deal.created",
+      entityFrom: { type: "deal", source: "result" },
+      lensHints: ["revenue_intelligence"],
+      payload: () => ({ snapshot: extractProperties(i.result) }),
+    }),
+
+  "Update Deal Stage": (i) => {
+    const stage = readInputField(i.ctx, "stage") as string | undefined;
+    return buildEnvelope(i, {
+      eventType: "deal.stage_changed",
+      entityFrom: { type: "deal", source: "input", inputField: "dealId" },
+      lensHints: ["revenue_intelligence", "operational_workflow"],
+      payload: () => ({
+        after: { dealstage: stage },
+        properties_changed: ["dealstage"],
+      }),
+    });
+  },
+
+  "Create Ticket": (i) =>
+    buildEnvelope(i, {
+      eventType: "ticket.created",
+      entityFrom: { type: "ticket", source: "result" },
+      lensHints: ["customer_interaction", "operational_workflow"],
+      payload: () => ({ snapshot: extractProperties(i.result) }),
+    }),
+
+  "Update Ticket": (i) => {
+    const inputProps = readInputProperties(i.ctx);
+    return buildEnvelope(i, {
+      eventType: "ticket.updated",
+      entityFrom: { type: "ticket", source: "input", inputField: "ticketId" },
+      lensHints: ["operational_workflow"],
+      payload: () => ({
+        after: extractProperties(i.result),
+        properties_changed: Object.keys(inputProps),
+      }),
+    });
+  },
+
+  "Close Ticket": (i) =>
+    buildEnvelope(i, {
+      eventType: "ticket.closed",
+      entityFrom: { type: "ticket", source: "input", inputField: "ticketId" },
+      lensHints: ["operational_workflow", "customer_interaction"],
+      payload: () => ({
+        after: extractProperties(i.result),
+        properties_changed: ["hs_pipeline_stage"],
+      }),
+    }),
+
+  "Add Reply To Ticket": (i) => {
+    const text =
+      (readInputField(i.ctx, "text") as string | undefined) ??
+      (readInputField(i.ctx, "richText") as string | undefined);
+    return buildEnvelope(i, {
+      eventType: "ticket.reply_sent",
+      entityFrom: { type: "ticket", source: "input", inputField: "ticketId" },
+      lensHints: ["customer_interaction", "knowledge_integrity"],
+      payload: () => ({ text }),
+    });
+  },
+
+  "Log Call Engagement": (i) =>
+    buildEnvelope(i, {
+      eventType: "call.logged",
+      entityFrom: { type: "engagement", source: "result" },
+      lensHints: ["customer_interaction", "operational_workflow"],
+      payload: () => ({ snapshot: extractProperties(i.result) }),
+    }),
+
+  "Create Note": (i) =>
+    buildEnvelope(i, {
+      eventType: "note.created",
+      entityFrom: { type: "note", source: "result" },
+      lensHints: ["knowledge_integrity", "operational_workflow"],
+      payload: () => ({ snapshot: extractProperties(i.result) }),
+    }),
+};
+
+export function buildEnvelopeForTool(
+  toolName: EmittingToolName,
+  input: EnvelopeBuildInput,
+): SignalEvent | null {
+  const fn = builders[toolName];
+  return fn ? fn(input) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface BuildSpec {
+  eventType: SignalEventType;
+  entityFrom:
+    | { type: HubSpotObjectType; source: "result" }
+    | { type: HubSpotObjectType; source: "input"; inputField: string };
+  lensHints: LensId[];
+  payload: (input: EnvelopeBuildInput) => SignalPayload;
+}
+
+function buildEnvelope(
+  input: EnvelopeBuildInput,
+  spec: BuildSpec,
+): SignalEvent | null {
+  const entity = resolveEntity(input, spec.entityFrom);
+  if (!entity) return null;
+
+  const portalUrl =
+    entity.portalUrl ?? buildPortalUrl(input.ctx, entity.type, entity.id);
+
+  return {
+    signal_id: input.signalId ?? crypto.randomUUID(),
+    signal_version: "1",
+    emitted_at: input.emittedAt ?? new Date().toISOString(),
+    source_system: "hubspot",
+    source_instance: input.config.sourceInstance,
+    knowledge_space_id: input.config.knowledgeSpaceId,
+    vault_id: input.config.vaultId,
+    event_type: spec.eventType,
+    entity: {
+      type: entity.type,
+      id: entity.id,
+      ...(portalUrl ? { portal_url: portalUrl } : {}),
+    },
+    actor: resolveActor(input.ctx),
+    declared_lens_hints: spec.lensHints,
+    canonical_object_identity: {
+      tenant_id: input.config.vaultId,
+      source_system: "hubspot",
+      object_type: entity.type,
+      object_id: entity.id,
+    },
+    payload: spec.payload(input),
+  };
+}
+
+function resolveEntity(
+  input: EnvelopeBuildInput,
+  spec: BuildSpec["entityFrom"],
+): InternalEntity | null {
+  if (spec.source === "result") {
+    const id =
+      typeof input.result?.id === "string"
+        ? input.result.id
+        : input.result?.id != null
+          ? String(input.result.id)
+          : undefined;
+    if (!id) return null;
+    return { type: spec.type, id };
+  }
+  const id = readInputField(input.ctx, spec.inputField) as string | undefined;
+  if (!id) return null;
+  return { type: spec.type, id };
+}
+
+function resolveActor(ctx: ToolExecutionContext): SignalEvent["actor"] {
+  // Mode B fires only on agent-originated tool calls (spec §2).
+  // We have no per-call agent identity in the current context, so we
+  // attribute to the connector instance. The agentic-layer dispatch (Phase 3)
+  // can thread the real agent_id through here without changing the envelope.
+  return {
+    type: "ai_agent",
+    id: ctx.connectorId,
+    name: ctx.organizationId,
+  };
+}
+
+function buildPortalUrl(
+  ctx: ToolExecutionContext,
+  objectType: HubSpotObjectType,
+  id: string,
+): string | undefined {
+  const portalId = ctx.config.portalId?.trim();
+  if (!portalId) return undefined;
+  const path = OBJECT_TYPE_TO_URL_PATH[objectType];
+  if (!path) return undefined;
+  return `https://app.hubspot.com/${path}/${portalId}/${encodeURIComponent(id)}`;
+}
+
+const OBJECT_TYPE_TO_URL_PATH: Partial<Record<HubSpotObjectType, string>> = {
+  contact: "contacts",
+  company: "company",
+  deal: "deal",
+  ticket: "tickets",
+};
+
+function readInputProperties(
+  ctx: ToolExecutionContext,
+): Record<string, unknown> {
+  const props = (ctx.input as { properties?: unknown }).properties;
+  if (!props || typeof props !== "object") return {};
+  return props as Record<string, unknown>;
+}
+
+function readInputField(ctx: ToolExecutionContext, field: string): unknown {
+  return (ctx.input as Record<string, unknown>)[field];
+}
+
+function extractProperties(
+  result: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!result) return undefined;
+  const props = (result as { properties?: unknown }).properties;
+  if (props && typeof props === "object")
+    return props as Record<string, unknown>;
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Re-export the canonical identity helper to make the envelope→source_id
+// mapping obvious at the call site (audit + dashboard cross-link).
+// ---------------------------------------------------------------------------
+
+export function deriveSignalSourceId(envelope: SignalEvent): string {
+  return deriveSourceId({
+    tenantId: envelope.canonical_object_identity.tenant_id,
+    objectType: envelope.canonical_object_identity
+      .object_type as HubSpotObjectType,
+    objectId: envelope.canonical_object_identity.object_id,
+  });
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/ingest/renderers.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/ingest/renderers.ts
@@ -1,0 +1,344 @@
+/**
+ * HubSpot → markdown renderers for Mode C corpus ingest.
+ *
+ *  - `renderTicketAsMarkdown`   one document per ticket, thread inline, properties header
+ *  - `renderKnowledgeArticleAsMarkdown`   KB article → markdown
+ *  - `renderContactAsMarkdown`   denormalized: contact + company + recent tickets
+ *
+ * Output shape lines up with `IngestDocument` from the LoreVault contract
+ * (Phase 0 §1.2): `{ source_id, title, content, metadata }`.
+ */
+
+import type { IngestDocument } from "../../../../lorevault/client";
+import type { HubSpotKnowledgeArticle } from "../handlers";
+import {
+  type CanonicalIdentityInput,
+  deriveSourceId,
+} from "./canonical-identity";
+
+// ---------------------------------------------------------------------------
+// Shared HubSpot CRM object shapes for ingest. Intentionally permissive —
+// we render whatever properties HubSpot returns, header-summarized.
+// ---------------------------------------------------------------------------
+
+export interface HubSpotObject {
+  id: string;
+  properties?: Record<string, string | number | boolean | null | undefined>;
+  createdAt?: string;
+  updatedAt?: string;
+  archived?: boolean;
+}
+
+export interface HubSpotConversationMessage {
+  id: string;
+  type: string;
+  direction?: string;
+  createdAt?: string;
+  senders?: Array<{ name?: string; deliveryIdentifier?: { value?: string } }>;
+  recipients?: Array<{
+    name?: string;
+    deliveryIdentifier?: { value?: string };
+  }>;
+  text?: string;
+  richText?: string;
+}
+
+export interface HubSpotTicketWithThread extends HubSpotObject {
+  thread?: HubSpotConversationMessage[];
+}
+
+export interface HubSpotContactWithContext extends HubSpotObject {
+  primaryCompany?: HubSpotObject;
+  recentTickets?: HubSpotObject[];
+}
+
+interface RenderContext {
+  tenantId: string;
+  sourceInstance: string;
+}
+
+// ---------------------------------------------------------------------------
+// Ticket
+// ---------------------------------------------------------------------------
+
+export function renderTicketAsMarkdown(
+  ticket: HubSpotTicketWithThread,
+  ctx: RenderContext,
+): IngestDocument {
+  const props = ticket.properties ?? {};
+  const title = stringify(props.subject) || `HubSpot Ticket #${ticket.id}`;
+
+  const header = renderPropertiesHeader({
+    Subject: props.subject,
+    Status: props.hs_pipeline_stage,
+    Pipeline: props.hs_pipeline,
+    Priority: props.hs_ticket_priority,
+    Category: props.hs_ticket_category,
+    Owner: props.hubspot_owner_id,
+    Created: ticket.createdAt ?? props.createdate,
+    Updated: ticket.updatedAt ?? props.hs_lastmodifieddate,
+    "Source instance": ctx.sourceInstance,
+    "Ticket ID": ticket.id,
+  });
+
+  const description = stringify(props.content);
+  const thread = renderThread(ticket.thread ?? []);
+
+  const content = [
+    `# Ticket #${ticket.id} — ${title}`,
+    "",
+    "## Properties",
+    header,
+    description ? `\n## Description\n\n${description}` : "",
+    thread ? `\n## Conversation thread\n\n${thread}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+  return buildDocument(
+    {
+      tenantId: ctx.tenantId,
+      objectType: "ticket",
+      objectId: ticket.id,
+    },
+    {
+      title,
+      content,
+      sourceInstance: ctx.sourceInstance,
+      entityType: "ticket",
+      entityId: ticket.id,
+      createdAt: stringify(ticket.createdAt) || stringify(props.createdate),
+      lastModifiedAt:
+        stringify(ticket.updatedAt) || stringify(props.hs_lastmodifieddate),
+    },
+  );
+}
+
+function renderThread(messages: HubSpotConversationMessage[]): string {
+  if (messages.length === 0) return "";
+  const ordered = [...messages].sort((a, b) =>
+    (a.createdAt ?? "").localeCompare(b.createdAt ?? ""),
+  );
+  return ordered
+    .map((m) => {
+      const who = describeParticipant(m);
+      const when = m.createdAt ?? "";
+      const body = (m.text ?? stripHtml(m.richText ?? "")).trim();
+      return `### ${who} — ${when}\n\n${body || "_(no body)_"}`;
+    })
+    .join("\n\n");
+}
+
+function describeParticipant(m: HubSpotConversationMessage): string {
+  const sender = m.senders?.[0];
+  const name = sender?.name ?? sender?.deliveryIdentifier?.value ?? "unknown";
+  const direction = m.direction ? ` (${m.direction.toLowerCase()})` : "";
+  return `${name}${direction}`;
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge base article
+// ---------------------------------------------------------------------------
+
+export function renderKnowledgeArticleAsMarkdown(
+  article: HubSpotKnowledgeArticle,
+  ctx: RenderContext,
+): IngestDocument {
+  const title =
+    stringify(article.name) ||
+    stringify(article.htmlTitle) ||
+    `HubSpot KB Article #${article.id}`;
+  const body = stripHtml(stringify(article.htmlBody) ?? "");
+
+  const header = renderPropertiesHeader({
+    Title: title,
+    Language: article.language,
+    State: article.state,
+    "Published at": article.publishDate,
+    "Last updated": article.updatedAt,
+    URL: article.url,
+    "Source instance": ctx.sourceInstance,
+    "Article ID": article.id,
+  });
+
+  const content = [
+    `# ${title}`,
+    "",
+    "## Metadata",
+    header,
+    body ? `\n## Body\n\n${body}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+  return buildDocument(
+    {
+      tenantId: ctx.tenantId,
+      objectType: "knowledge_article",
+      objectId: article.id,
+    },
+    {
+      title,
+      content,
+      sourceInstance: ctx.sourceInstance,
+      entityType: "knowledge_article",
+      entityId: article.id,
+      createdAt: stringify(article.createdAt),
+      lastModifiedAt: stringify(article.updatedAt),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Contact (denormalized: company + recent tickets)
+// ---------------------------------------------------------------------------
+
+export function renderContactAsMarkdown(
+  contact: HubSpotContactWithContext,
+  ctx: RenderContext,
+): IngestDocument {
+  const props = contact.properties ?? {};
+  const fullName =
+    [stringify(props.firstname), stringify(props.lastname)]
+      .filter(Boolean)
+      .join(" ")
+      .trim() ||
+    stringify(props.email) ||
+    `Contact #${contact.id}`;
+
+  const header = renderPropertiesHeader({
+    Name: fullName,
+    Email: props.email,
+    Phone: props.phone,
+    Company: props.company,
+    "Lifecycle stage": props.lifecyclestage,
+    "Lead status": props.hs_lead_status,
+    Owner: props.hubspot_owner_id,
+    Created: contact.createdAt ?? props.createdate,
+    Updated: contact.updatedAt ?? props.lastmodifieddate,
+    "Source instance": ctx.sourceInstance,
+    "Contact ID": contact.id,
+  });
+
+  const sections: string[] = [`# ${fullName}`, "", "## Profile", header];
+
+  if (contact.primaryCompany) {
+    const cp = contact.primaryCompany.properties ?? {};
+    sections.push(
+      "\n## Primary company",
+      renderPropertiesHeader({
+        Name: cp.name,
+        Domain: cp.domain,
+        Industry: cp.industry,
+        City: cp.city,
+        State: cp.state,
+        Country: cp.country,
+        "Annual revenue": cp.annualrevenue,
+        Employees: cp.numberofemployees,
+        "Company ID": contact.primaryCompany.id,
+      }),
+    );
+  }
+
+  if (contact.recentTickets?.length) {
+    sections.push("\n## Recent tickets");
+    for (const t of contact.recentTickets) {
+      const tp = t.properties ?? {};
+      sections.push(
+        `- **${stringify(tp.subject) || `Ticket #${t.id}`}** — ${
+          stringify(tp.hs_pipeline_stage) || "stage unknown"
+        }, priority ${stringify(tp.hs_ticket_priority) || "unspecified"} (#${
+          t.id
+        }, updated ${t.updatedAt ?? tp.hs_lastmodifieddate ?? "unknown"})`,
+      );
+    }
+  }
+
+  const content = sections.join("\n").trim();
+
+  return buildDocument(
+    {
+      tenantId: ctx.tenantId,
+      objectType: "contact",
+      objectId: contact.id,
+    },
+    {
+      title: fullName,
+      content,
+      sourceInstance: ctx.sourceInstance,
+      entityType: "contact",
+      entityId: contact.id,
+      createdAt: stringify(contact.createdAt) || stringify(props.createdate),
+      lastModifiedAt:
+        stringify(contact.updatedAt) || stringify(props.lastmodifieddate),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+interface DocumentFields {
+  title: string;
+  content: string;
+  sourceInstance: string;
+  entityType: string;
+  entityId: string;
+  createdAt?: string;
+  lastModifiedAt?: string;
+}
+
+function buildDocument(
+  identity: CanonicalIdentityInput,
+  fields: DocumentFields,
+): IngestDocument {
+  return {
+    source_id: deriveSourceId(identity),
+    title: fields.title,
+    content: fields.content,
+    metadata: {
+      source_system: "hubspot",
+      source_instance: fields.sourceInstance,
+      entity_type: fields.entityType,
+      entity_id: fields.entityId,
+      created_at: fields.createdAt ?? "",
+      last_modified_at: fields.lastModifiedAt ?? "",
+    },
+  };
+}
+
+function renderPropertiesHeader(
+  fields: Record<string, string | number | boolean | null | undefined>,
+): string {
+  const rows = Object.entries(fields)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `- **${k}:** ${stringify(v)}`);
+  return rows.join("\n");
+}
+
+function stringify(
+  value: string | number | boolean | null | undefined,
+): string {
+  if (value === undefined || value === null) return "";
+  return String(value);
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<br\s*\/?>(\s*)/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/modelguide-api/src/features/connectors/catalog/hubspot/response-shapes.ts
+++ b/modelguide-api/src/features/connectors/catalog/hubspot/response-shapes.ts
@@ -1,0 +1,80 @@
+/**
+ * HubSpot response shapes — allowlists of fields to keep per entity.
+ *
+ * Applied automatically by the connector dispatcher via `trimToShape()`,
+ * so handlers can return the raw HubSpot envelope without leaking noise.
+ *
+ * Reference: HubSpot Connector Spec §6.
+ */
+
+import type { ResponseShape } from "../lib/response-trimmer";
+
+// ---------------------------------------------------------------------------
+// Common HubSpot object envelope
+// ---------------------------------------------------------------------------
+
+const HUBSPOT_OBJECT_BASE: ResponseShape = {
+  id: true,
+  properties: true,
+  createdAt: true,
+  updatedAt: true,
+  archived: true,
+};
+
+// ---------------------------------------------------------------------------
+// Contact / Company / Deal / Ticket / Engagement
+// ---------------------------------------------------------------------------
+
+export const CONTACT: ResponseShape = { ...HUBSPOT_OBJECT_BASE };
+export const COMPANY: ResponseShape = { ...HUBSPOT_OBJECT_BASE };
+export const DEAL: ResponseShape = { ...HUBSPOT_OBJECT_BASE };
+export const TICKET: ResponseShape = { ...HUBSPOT_OBJECT_BASE };
+export const ENGAGEMENT: ResponseShape = { ...HUBSPOT_OBJECT_BASE };
+
+// ---------------------------------------------------------------------------
+// Conversation thread message (reply)
+// ---------------------------------------------------------------------------
+
+export const CONVERSATION_MESSAGE: ResponseShape = {
+  id: true,
+  type: true,
+  channelId: true,
+  channelAccountId: true,
+  createdAt: true,
+  createdBy: true,
+  status: true,
+  direction: true,
+  recipients: true,
+  senders: true,
+  subject: true,
+  text: true,
+  richText: true,
+};
+
+// ---------------------------------------------------------------------------
+// Search/list envelopes — keep totals + array slot
+// ---------------------------------------------------------------------------
+
+export const CONTACT_LIST: ResponseShape = {
+  results: CONTACT,
+  total: true,
+  paging: true,
+};
+
+export const COMPANY_LIST: ResponseShape = {
+  results: COMPANY,
+  total: true,
+  paging: true,
+};
+
+export const DEAL_LIST: ResponseShape = {
+  results: DEAL,
+  total: true,
+  paging: true,
+};
+
+export const TICKET_LIST: ResponseShape = {
+  results: TICKET,
+  total: true,
+  paging: true,
+};

--- a/modelguide-api/src/features/connectors/catalog/registry.ts
+++ b/modelguide-api/src/features/connectors/catalog/registry.ts
@@ -24,6 +24,7 @@ export async function loadAllManifests(): Promise<ConnectorManifest[]> {
   const modules = await Promise.all([
     import("./medusa/index"),
     import("./zendesk/index"),
+    import("./hubspot/index"),
   ]);
 
   for (const mod of modules) {

--- a/modelguide-api/src/features/lorevault/binding.ts
+++ b/modelguide-api/src/features/lorevault/binding.ts
@@ -1,0 +1,32 @@
+/**
+ * Single binding point for the LoreVault integration client.
+ *
+ * Application code imports `createLoreVaultClient` from here and never
+ * names a concrete implementation. Swapping mock → HTTP after Wave 1
+ * ships is one line: change `MockLoreVaultClient` to `HttpLoreVaultClient`
+ * (constructor signature is compatible — both accept a config object that
+ * the mock ignores).
+ *
+ * Phase 0 Integration Contract §3 — thin-adapter pattern.
+ */
+
+import type { LoreVaultIntegrationClient } from "./client";
+import { MockLoreVaultClient } from "./mock-client";
+
+export interface LoreVaultClientConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  knowledgeSpaceId?: string;
+}
+
+export function createLoreVaultClient(
+  _config: LoreVaultClientConfig = {},
+): LoreVaultIntegrationClient {
+  // Wave 1 swap point — change this one line to:
+  //   return new HttpLoreVaultClient({
+  //     baseUrl: _config.baseUrl!,
+  //     apiKey: _config.apiKey!,
+  //     knowledgeSpaceId: _config.knowledgeSpaceId!,
+  //   });
+  return new MockLoreVaultClient();
+}

--- a/modelguide-api/src/features/lorevault/client.ts
+++ b/modelguide-api/src/features/lorevault/client.ts
@@ -1,0 +1,364 @@
+/**
+ * LoreVault integration client — the thin-adapter pattern from Phase 0
+ * Contract §3.
+ *
+ * Wevn binds *only* to this interface. Two implementations:
+ *   - `MockLoreVaultClient` — fixture-backed, used today.
+ *   - `HttpLoreVaultClient` — wraps the real /external/v1/... endpoints,
+ *      stubbed until Wave 1 ships.
+ *
+ * Switching implementations is a one-line change (see fixtures/binding).
+ *
+ * Source of truth for shapes: Phase 0 Integration Contract.md §1.
+ * Do NOT extend types beyond what the contract locks. If a field is
+ * unclear, surface it; do not guess.
+ */
+
+// ---------------------------------------------------------------------------
+// Locked enums (Phase 0 §1.5, §1.6, §1.8)
+// ---------------------------------------------------------------------------
+
+export type LensId =
+  | "customer_interaction"
+  | "operational_workflow"
+  | "knowledge_integrity"
+  | "revenue_intelligence"
+  | "risk_compliance"
+  | "narrative_intelligence";
+
+export type NarrativeLifecycleState =
+  | "emerging"
+  | "active"
+  | "deteriorating"
+  | "stabilized"
+  | "resolved"
+  | "monitoring";
+
+export type EvidenceResolutionState =
+  | "pending_resolution"
+  | "resolved"
+  | "permanently_unresolved"
+  | "orphaned_after_resolution";
+
+export type SignalPolarity = "concern" | "health";
+
+export type DefaultWeightSource = "lorevault_substrate" | "wevn_default";
+
+export type SubscriptionTier = "starter" | "pro" | "enterprise";
+
+// ---------------------------------------------------------------------------
+// Signal ingest envelope (Phase 0 §1.1)
+// ---------------------------------------------------------------------------
+
+export type ActorType = "ai_agent" | "human" | "system";
+
+export interface SignalActor {
+  type: ActorType;
+  id: string;
+  name?: string;
+}
+
+export interface SignalEntity {
+  type: string;
+  id: string;
+  portal_url?: string;
+}
+
+export interface CanonicalObjectIdentity {
+  tenant_id: string;
+  source_system: string;
+  object_type: string;
+  object_id: string;
+}
+
+export interface SignalEvidenceRef {
+  type: "document" | "chunk";
+  dataset_id: string;
+  id: string;
+  resolution_status?: EvidenceResolutionState;
+}
+
+export interface SignalPayload {
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+  snapshot?: Record<string, unknown>;
+  properties_changed?: string[];
+  text?: string;
+}
+
+export interface SignalEvent {
+  signal_id: string;
+  signal_version: "1";
+  emitted_at: string;
+  source_system: string;
+  source_instance: string;
+  knowledge_space_id: string;
+  vault_id: string;
+  event_type: string;
+  entity: SignalEntity;
+  actor: SignalActor;
+  declared_lens_hints: LensId[];
+  canonical_object_identity: CanonicalObjectIdentity;
+  payload: SignalPayload;
+  evidence_refs?: SignalEvidenceRef[];
+}
+
+export interface SignalAcceptResponse {
+  signal_id: string;
+  accepted: true;
+  was_idempotent: boolean;
+}
+
+export interface BatchAcceptResponse {
+  accepted: SignalAcceptResponse[];
+  rejected: Array<{ signal_id: string; reason: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Document ingest envelope (Phase 0 §1.2, §1.3)
+// ---------------------------------------------------------------------------
+
+export interface DocumentMetadata {
+  source_system: string;
+  source_instance: string;
+  entity_type: string;
+  entity_id: string;
+  created_at: string;
+  last_modified_at: string;
+  [extra: string]: unknown;
+}
+
+export interface IngestDocument {
+  /**
+   * Canonical upsert key: `{tenant_id}:{source_system}:{object_type}:{object_id}`.
+   * Same canonical identity → same document, idempotent.
+   */
+  source_id: string;
+  title: string;
+  content: string;
+  metadata: DocumentMetadata;
+}
+
+export interface DocumentIngestRequest {
+  knowledge_space_id: string;
+  dataset_id: string;
+  documents: IngestDocument[];
+}
+
+export interface IngestionJobAcceptResponse {
+  ingestion_job_id: string;
+  accepted_count: number;
+  rejected_count: number;
+  rejection_reasons: Array<{ source_id: string; reason: string }>;
+}
+
+export type IngestionJobState = "queued" | "running" | "complete" | "failed";
+
+export interface IngestionJobStatus {
+  ingestion_job_id: string;
+  state: IngestionJobState;
+  knowledge_space_id: string;
+  dataset_id: string;
+  bytes_requested: number;
+  bytes_processed: number;
+  document_count: number;
+  started_at: string;
+  completed_at?: string;
+  rejection_reasons?: Array<{ source_id: string; reason: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Query (Phase 0 §1.4)
+// ---------------------------------------------------------------------------
+
+export interface SignalAwareQuery {
+  knowledge_space_id: string;
+  match: {
+    lens?: LensId[];
+    signal?: string[];
+    score_min?: number;
+    score_max?: number;
+    entity?: { type: string; id: string };
+    time_window?: { since: string; until?: string };
+  };
+  return: {
+    evidence_chunks?: boolean;
+    group_by?: "signal" | "lens" | "entity";
+    include_contributing_documents?: boolean;
+    limit?: number;
+  };
+}
+
+export interface QueryEvidenceChunk {
+  chunk_id: string;
+  source_document_id: string;
+  source_uri?: string;
+  raw_text: string;
+  signal_id: string;
+  raw_score: number;
+  polarity: SignalPolarity;
+  lens: LensId;
+  extracted_at: string;
+}
+
+export interface QueryResponse {
+  knowledge_space_id: string;
+  evidence: QueryEvidenceChunk[];
+  group_by?: "signal" | "lens" | "entity";
+  groups?: Array<{ key: string; chunk_ids: string[] }>;
+  next_cursor?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Narratives (Phase 0 §1.5)
+// ---------------------------------------------------------------------------
+
+export interface NarrativeFilter {
+  knowledge_space_id: string;
+  lifecycle_state?: NarrativeLifecycleState[];
+  primary_lens?: LensId[];
+  active?: boolean;
+  limit?: number;
+  cursor?: string;
+  if_modified_since?: string;
+}
+
+export interface NarrativeSummary {
+  narrative_id: string;
+  title: string;
+  knowledge_space_id: string;
+  lifecycle_state: NarrativeLifecycleState;
+  active: boolean;
+  confidence: number;
+  priority: number;
+  primary_lens: LensId;
+  contributing_lenses: Array<{ lens: LensId; weight: number }>;
+  contributing_entities: Array<{ type: string; id: string }>;
+  evidence_count: number;
+  created_at: string;
+  last_transitioned_at: string;
+  investigation_prompts?: string[];
+}
+
+export interface NarrativeListResponse {
+  narratives: NarrativeSummary[];
+  total: number;
+  next_cursor?: string;
+}
+
+export interface NarrativeDetailResponse extends NarrativeSummary {
+  contributing_signal_ids: string[];
+}
+
+export interface EvidenceChainItem {
+  chunk_id: string;
+  source_document_id: string;
+  source_uri?: string;
+  raw_text: string;
+  signal_id: string;
+  signal_raw_score: number;
+  signal_polarity: SignalPolarity;
+  chunk_score: number;
+  status: "live" | "orphaned";
+  extracted_at: string;
+}
+
+export interface EvidenceChainResponse {
+  narrative_id: string;
+  evidence: EvidenceChainItem[];
+}
+
+export interface SignalEvidenceResponse {
+  signal_id: string;
+  evidence: EvidenceChainItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Pack catalog (Phase 0 §1.6)
+// ---------------------------------------------------------------------------
+
+export interface PackSignal {
+  signal_id: string;
+  polarity: SignalPolarity;
+  raw_score_range: { min: number; max: number };
+  default_weight: number;
+  default_weight_source: DefaultWeightSource;
+  operator_visible: boolean;
+  maturity_tier: "stable" | "experimental" | "deprecated";
+  registered_entity_types: string[];
+}
+
+export interface Pack {
+  pack_id: string;
+  name: string;
+  description: string;
+  ontology_version: string;
+  enabled: boolean;
+  signals_contributed: PackSignal[];
+}
+
+export interface PackCatalogResponse {
+  packs: Pack[];
+}
+
+// ---------------------------------------------------------------------------
+// Entitlements (Phase 0 §1.7)
+// ---------------------------------------------------------------------------
+
+export interface QuotaUsage {
+  limit: number;
+  used: number;
+}
+
+export interface EntitlementResponse {
+  vault_id: string;
+  knowledge_space_id: string;
+  tier: SubscriptionTier;
+  features: {
+    osi_enabled: boolean;
+    lssr_enabled: boolean;
+  };
+  quotas: {
+    monthly_signal_events: QuotaUsage;
+    monthly_ingest_mb: QuotaUsage;
+    monthly_query_count: QuotaUsage;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Health (Phase 0 §1, Wave 1)
+// ---------------------------------------------------------------------------
+
+export interface HealthResponse {
+  status: "ok" | "degraded" | "down";
+  version?: string;
+  checked_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Interface — the only surface Wevn binds to
+// ---------------------------------------------------------------------------
+
+export interface LoreVaultIntegrationClient {
+  // Signal ingest
+  emitSignal(event: SignalEvent): Promise<SignalAcceptResponse>;
+  emitSignalsBatch(events: SignalEvent[]): Promise<BatchAcceptResponse>;
+
+  // Document ingest
+  ingestDocuments(
+    payload: DocumentIngestRequest,
+  ): Promise<IngestionJobAcceptResponse>;
+  getIngestionJob(id: string): Promise<IngestionJobStatus>;
+
+  // Query + narratives
+  query(payload: SignalAwareQuery): Promise<QueryResponse>;
+  listNarratives(filter: NarrativeFilter): Promise<NarrativeListResponse>;
+  getNarrative(id: string): Promise<NarrativeDetailResponse>;
+  getNarrativeEvidence(id: string): Promise<EvidenceChainResponse>;
+  getSignalEvidence(id: string): Promise<SignalEvidenceResponse>;
+
+  // Catalog + tenant
+  getEntitlements(): Promise<EntitlementResponse>;
+  getPacks(): Promise<PackCatalogResponse>;
+  getHealth(): Promise<HealthResponse>;
+}

--- a/modelguide-api/src/features/lorevault/emission/admin.ts
+++ b/modelguide-api/src/features/lorevault/emission/admin.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin surface for the LoreVault signal emission subsystem.
+ *
+ * Internal — NOT exposed as an MCP tool. Fulfills the
+ * "Show Recent Signals admin view" acceptance criterion in HubSpot
+ * Connector Spec §11.
+ *
+ * Returns the most recent N (default 100) emitted signals with their
+ * delivery status: pending | in_flight | delivered (with was_idempotent)
+ * | retrying | dead_lettered | gated.
+ */
+
+import type { SignalEmissionQueue } from "./queue";
+import type { SignalHistoryEntry } from "./types";
+
+export interface RecentSignalsView {
+  signals: SignalHistoryEntry[];
+  stats: {
+    pending: number;
+    inFlight: number;
+    deadLettered: number;
+    entitlementAllowed: boolean;
+    running: boolean;
+  };
+}
+
+export function getRecentSignalsView(
+  queue: SignalEmissionQueue,
+  limit = 100,
+): RecentSignalsView {
+  return {
+    signals: queue.getRecentSignals(limit),
+    stats: queue.getStats(),
+  };
+}

--- a/modelguide-api/src/features/lorevault/emission/dead-letter.ts
+++ b/modelguide-api/src/features/lorevault/emission/dead-letter.ts
@@ -1,0 +1,30 @@
+/**
+ * In-memory dead-letter store for the LoreVault signal emission queue.
+ *
+ * Phase 2 scope. Production wires a Drizzle-backed table; do not build
+ * that here. The interface lets the queue swap implementations later
+ * without touching its retry logic.
+ */
+
+import type { DeadLetterEntry, DeadLetterStore } from "./types";
+
+export class InMemoryDeadLetterStore implements DeadLetterStore {
+  private readonly entries: DeadLetterEntry[] = [];
+
+  add(entry: DeadLetterEntry): void {
+    this.entries.push(entry);
+  }
+
+  list(limit?: number): DeadLetterEntry[] {
+    if (limit === undefined) return [...this.entries];
+    return this.entries.slice(-limit);
+  }
+
+  size(): number {
+    return this.entries.length;
+  }
+
+  clear(): void {
+    this.entries.length = 0;
+  }
+}

--- a/modelguide-api/src/features/lorevault/emission/entitlement-gate.ts
+++ b/modelguide-api/src/features/lorevault/emission/entitlement-gate.ts
@@ -1,0 +1,66 @@
+/**
+ * Entitlement fail-fast gate (Phase 0 Integration Contract §1.7 + spec §11).
+ *
+ * Before Mode B starts emitting, call `GET /external/v1/entitlements`
+ * once. If the response shows a Starter-tier vault or `osi_enabled: false`,
+ * the connector refuses to enable Mode B with a clear error. Mode A and
+ * Mode C remain unaffected.
+ *
+ * The gate caches the verdict for the lifetime of the queue so we don't
+ * re-check on every signal.
+ */
+
+import { getLogger } from "@lib/logger";
+import type {
+  EntitlementResponse,
+  LoreVaultIntegrationClient,
+} from "../client";
+
+export type EntitlementVerdict =
+  | { allowed: true; entitlements: EntitlementResponse }
+  | { allowed: false; reason: string };
+
+export async function checkEntitlement(
+  client: LoreVaultIntegrationClient,
+): Promise<EntitlementVerdict> {
+  let entitlements: EntitlementResponse;
+  try {
+    entitlements = await client.getEntitlements();
+  } catch (err) {
+    return {
+      allowed: false,
+      reason: `Mode B disabled: entitlement lookup failed (${(err as Error).message}).`,
+    };
+  }
+
+  if (entitlements.tier === "starter") {
+    return {
+      allowed: false,
+      reason:
+        "Mode B disabled: vault tier does not include OSI (Starter tier excluded per Phase 0 §1.7).",
+    };
+  }
+  if (!entitlements.features.osi_enabled) {
+    return {
+      allowed: false,
+      reason:
+        "Mode B disabled: vault tier does not include OSI (features.osi_enabled is false).",
+    };
+  }
+  return { allowed: true, entitlements };
+}
+
+export function logVerdict(
+  verdict: EntitlementVerdict,
+  ctx: Record<string, unknown> = {},
+): void {
+  const log = getLogger();
+  if (verdict.allowed) {
+    log.info(
+      { ...ctx, tier: verdict.entitlements.tier },
+      "Mode B enabled: entitlement check passed",
+    );
+  } else {
+    log.warn({ ...ctx, reason: verdict.reason }, verdict.reason);
+  }
+}

--- a/modelguide-api/src/features/lorevault/emission/history.ts
+++ b/modelguide-api/src/features/lorevault/emission/history.ts
@@ -1,0 +1,75 @@
+/**
+ * Bounded ring buffer that tracks the most recent N emitted signals plus
+ * their delivery status. Backs the admin "Show Recent Signals" view
+ * (HubSpot Connector Spec §11 acceptance criterion).
+ */
+
+import type { DeliveryStatus, SignalHistoryEntry } from "./types";
+
+export interface SignalHistoryOptions {
+  /** Maximum number of entries retained. Default 100 per spec §11. */
+  capacity?: number;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+export class SignalHistory {
+  private readonly capacity: number;
+  private readonly now: () => Date;
+  private readonly bySignalId = new Map<string, SignalHistoryEntry>();
+  private readonly order: string[] = [];
+
+  constructor(options: SignalHistoryOptions = {}) {
+    this.capacity = options.capacity ?? 100;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  record(initial: {
+    signal_id: string;
+    event_type: string;
+    emitted_at: string;
+    status: DeliveryStatus;
+  }): void {
+    if (this.bySignalId.has(initial.signal_id)) {
+      this.update(initial.signal_id, { status: initial.status });
+      return;
+    }
+    const entry: SignalHistoryEntry = {
+      ...initial,
+      attempts: 0,
+      updated_at: this.now().toISOString(),
+    };
+    this.bySignalId.set(initial.signal_id, entry);
+    this.order.push(initial.signal_id);
+    while (this.order.length > this.capacity) {
+      const evictId = this.order.shift();
+      if (evictId) this.bySignalId.delete(evictId);
+    }
+  }
+
+  update(
+    signalId: string,
+    patch: Partial<
+      Pick<
+        SignalHistoryEntry,
+        "status" | "attempts" | "was_idempotent" | "last_error"
+      >
+    >,
+  ): void {
+    const entry = this.bySignalId.get(signalId);
+    if (!entry) return;
+    Object.assign(entry, patch, { updated_at: this.now().toISOString() });
+  }
+
+  list(limit?: number): SignalHistoryEntry[] {
+    const all = this.order
+      .map((id) => this.bySignalId.get(id))
+      .filter((e): e is SignalHistoryEntry => !!e);
+    const newestFirst = all.slice().reverse();
+    return limit === undefined ? newestFirst : newestFirst.slice(0, limit);
+  }
+
+  size(): number {
+    return this.bySignalId.size;
+  }
+}

--- a/modelguide-api/src/features/lorevault/emission/index.ts
+++ b/modelguide-api/src/features/lorevault/emission/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Public surface for the LoreVault signal emission subsystem.
+ */
+
+export { getRecentSignalsView, type RecentSignalsView } from "./admin";
+export { InMemoryDeadLetterStore } from "./dead-letter";
+export {
+  checkEntitlement,
+  type EntitlementVerdict,
+} from "./entitlement-gate";
+export { SignalHistory } from "./history";
+export {
+  SignalEmissionQueue,
+  type SignalEmissionQueueOptions,
+} from "./queue";
+export {
+  defaultRetryPolicy,
+  fixedRetryPolicy,
+  DEFAULT_MAX_ATTEMPTS,
+} from "./retry";
+export type {
+  DeadLetterEntry,
+  DeadLetterStore,
+  DeliveryStatus,
+  RetryPolicy,
+  SignalHistoryEntry,
+} from "./types";

--- a/modelguide-api/src/features/lorevault/emission/queue.ts
+++ b/modelguide-api/src/features/lorevault/emission/queue.ts
@@ -1,0 +1,275 @@
+/**
+ * In-process signal emission queue (HubSpot Connector Spec §7.2).
+ *
+ *   - Tool handlers `enqueue()` envelopes and return immediately.
+ *   - A worker drains the queue and calls `LoreVaultIntegrationClient.emitSignal`.
+ *   - On failure the worker re-enqueues with exponential backoff up to
+ *     `RetryPolicy.maxAttempts`; exhausted envelopes land in the
+ *     `DeadLetterStore`.
+ *   - On startup, the queue calls `getEntitlements()` exactly once and
+ *     fail-closes if the vault is Starter-tier or has `osi_enabled: false`.
+ *     Subsequent enqueues are no-ops with a single log.
+ *
+ * Concurrency: at most one in-flight `emitSignal` call at a time per queue
+ * instance. This bounds backpressure inside one connector process; production
+ * can scale by running multiple queues per Org if needed.
+ */
+
+import { getLogger } from "@lib/logger";
+import type { LoreVaultIntegrationClient, SignalEvent } from "../client";
+import { InMemoryDeadLetterStore } from "./dead-letter";
+import {
+  type EntitlementVerdict,
+  checkEntitlement,
+  logVerdict,
+} from "./entitlement-gate";
+import { SignalHistory } from "./history";
+import { defaultRetryPolicy } from "./retry";
+import type { DeadLetterStore, RetryPolicy, SignalHistoryEntry } from "./types";
+
+export interface SignalEmissionQueueOptions {
+  client: LoreVaultIntegrationClient;
+  retryPolicy?: RetryPolicy;
+  deadLetterStore?: DeadLetterStore;
+  history?: SignalHistory;
+  /** Sleep override for tests. Defaults to setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Clock override for tests. */
+  now?: () => Date;
+}
+
+interface QueueItem {
+  envelope: SignalEvent;
+  attempts: number;
+}
+
+export class SignalEmissionQueue {
+  private readonly client: LoreVaultIntegrationClient;
+  private readonly retryPolicy: RetryPolicy;
+  private readonly deadLetterStore: DeadLetterStore;
+  private readonly history: SignalHistory;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => Date;
+
+  private readonly pending: QueueItem[] = [];
+  private inFlightCount = 0;
+  private running = false;
+  private workerPromise: Promise<void> | null = null;
+  private entitlementChecked = false;
+  private entitlementAllowed = false;
+  private entitlementReason: string | undefined;
+  private notifyEnqueue: (() => void) | null = null;
+
+  constructor(options: SignalEmissionQueueOptions) {
+    this.client = options.client;
+    this.retryPolicy = options.retryPolicy ?? defaultRetryPolicy;
+    this.deadLetterStore =
+      options.deadLetterStore ?? new InMemoryDeadLetterStore();
+    this.history = options.history ?? new SignalHistory();
+    this.sleep = options.sleep ?? defaultSleep;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /**
+   * Run the entitlement check and (if allowed) start the worker loop.
+   * Safe to call multiple times — only the first call has effect.
+   */
+  async start(): Promise<EntitlementVerdict> {
+    const verdict = await this.ensureEntitlementChecked();
+    logVerdict(verdict);
+    if (!verdict.allowed) return verdict;
+
+    if (!this.running) {
+      this.running = true;
+      this.workerPromise = this.worker();
+    }
+    return verdict;
+  }
+
+  /**
+   * Stop accepting new work and wait for in-flight + queued items to drain.
+   */
+  async stop(): Promise<void> {
+    this.running = false;
+    this.notifyEnqueue?.();
+    if (this.workerPromise) {
+      await this.workerPromise;
+      this.workerPromise = null;
+    }
+  }
+
+  /**
+   * Add an envelope to the queue. Never blocks the caller.
+   * If the entitlement gate has already denied Mode B, the envelope is
+   * silently dropped with one history entry tagged `gated` so the admin
+   * view shows why.
+   */
+  enqueue(envelope: SignalEvent): void {
+    if (this.entitlementChecked && !this.entitlementAllowed) {
+      this.history.record({
+        signal_id: envelope.signal_id,
+        event_type: envelope.event_type,
+        emitted_at: envelope.emitted_at,
+        status: "gated",
+      });
+      this.history.update(envelope.signal_id, {
+        last_error: this.entitlementReason,
+      });
+      return;
+    }
+    this.history.record({
+      signal_id: envelope.signal_id,
+      event_type: envelope.event_type,
+      emitted_at: envelope.emitted_at,
+      status: "pending",
+    });
+    this.pending.push({ envelope, attempts: 0 });
+    this.notifyEnqueue?.();
+  }
+
+  /**
+   * Snapshot of queue health for the admin endpoint and tests.
+   */
+  getStats(): {
+    pending: number;
+    inFlight: number;
+    deadLettered: number;
+    entitlementAllowed: boolean;
+    running: boolean;
+  } {
+    return {
+      pending: this.pending.length,
+      inFlight: this.inFlightCount,
+      deadLettered: this.deadLetterStore.size(),
+      entitlementAllowed: this.entitlementAllowed,
+      running: this.running,
+    };
+  }
+
+  /**
+   * Recent signal history (admin "Show Recent Signals" view, spec §11).
+   * Defaults to the last 100; newest first.
+   */
+  getRecentSignals(limit?: number): SignalHistoryEntry[] {
+    return this.history.list(limit);
+  }
+
+  getDeadLetterStore(): DeadLetterStore {
+    return this.deadLetterStore;
+  }
+
+  isEntitled(): boolean {
+    return this.entitlementChecked && this.entitlementAllowed;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async ensureEntitlementChecked(): Promise<EntitlementVerdict> {
+    if (this.entitlementChecked) {
+      return this.entitlementAllowed
+        ? { allowed: true, entitlements: undefined as never }
+        : { allowed: false, reason: this.entitlementReason ?? "" };
+    }
+    const verdict = await checkEntitlement(this.client);
+    this.entitlementChecked = true;
+    this.entitlementAllowed = verdict.allowed;
+    if (!verdict.allowed) this.entitlementReason = verdict.reason;
+    return verdict;
+  }
+
+  private async worker(): Promise<void> {
+    while (this.running || this.pending.length > 0 || this.inFlightCount > 0) {
+      const next = this.pending.shift();
+      if (!next) {
+        if (!this.running) return;
+        await this.waitForEnqueue();
+        continue;
+      }
+      this.inFlightCount += 1;
+      try {
+        await this.deliver(next);
+      } finally {
+        this.inFlightCount -= 1;
+      }
+    }
+  }
+
+  private async deliver(item: QueueItem): Promise<void> {
+    const log = getLogger();
+    item.attempts += 1;
+    this.history.update(item.envelope.signal_id, {
+      status: "in_flight",
+      attempts: item.attempts,
+    });
+
+    try {
+      const ack = await this.client.emitSignal(item.envelope);
+      this.history.update(item.envelope.signal_id, {
+        status: "delivered",
+        attempts: item.attempts,
+        was_idempotent: ack.was_idempotent,
+      });
+      if (ack.was_idempotent) {
+        log.info(
+          { signal_id: item.envelope.signal_id },
+          "signal delivery acked as idempotent replay; no retry scheduled",
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (item.attempts >= this.retryPolicy.maxAttempts) {
+        log.error(
+          { signal_id: item.envelope.signal_id, attempts: item.attempts, err },
+          "signal delivery exhausted retries; dead-lettering",
+        );
+        this.deadLetterStore.add({
+          envelope: item.envelope,
+          attempts: item.attempts,
+          last_error: message,
+          dead_lettered_at: this.now().toISOString(),
+        });
+        this.history.update(item.envelope.signal_id, {
+          status: "dead_lettered",
+          attempts: item.attempts,
+          last_error: message,
+        });
+        return;
+      }
+      // Schedule retry via the configured backoff.
+      const delay = this.retryPolicy.delayMs(item.attempts - 1);
+      this.history.update(item.envelope.signal_id, {
+        status: "retrying",
+        attempts: item.attempts,
+        last_error: message,
+      });
+      log.warn(
+        {
+          signal_id: item.envelope.signal_id,
+          attempts: item.attempts,
+          delay_ms: delay,
+          err,
+        },
+        "signal delivery failed; scheduling retry",
+      );
+      await this.sleep(delay);
+      // Re-queue at the head so retries don't starve behind fresh work.
+      this.pending.unshift(item);
+      this.notifyEnqueue?.();
+    }
+  }
+
+  private waitForEnqueue(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.notifyEnqueue = () => {
+        this.notifyEnqueue = null;
+        resolve();
+      };
+    });
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/modelguide-api/src/features/lorevault/emission/retry.ts
+++ b/modelguide-api/src/features/lorevault/emission/retry.ts
@@ -1,0 +1,38 @@
+/**
+ * Retry policy for the LoreVault signal emission queue.
+ *
+ * Spec §7.2: "exponential backoff, max 6 attempts over ~10 minutes".
+ * The default schedule below sums to ~620 seconds across 5 retries:
+ *   1s → 5s → 30s → 60s → 240s → 300s (capped)
+ */
+
+import type { RetryPolicy } from "./types";
+
+export const DEFAULT_MAX_ATTEMPTS = 6;
+
+const DEFAULT_DELAY_SCHEDULE_MS: number[] = [
+  1_000, 5_000, 30_000, 60_000, 240_000, 300_000,
+];
+
+export const defaultRetryPolicy: RetryPolicy = {
+  maxAttempts: DEFAULT_MAX_ATTEMPTS,
+  delayMs(attempt: number): number {
+    if (attempt < 0) return 0;
+    const index = Math.min(attempt, DEFAULT_DELAY_SCHEDULE_MS.length - 1);
+    return DEFAULT_DELAY_SCHEDULE_MS[index];
+  },
+};
+
+/**
+ * Test-friendly factory that returns a fixed delay per retry. The total
+ * elapsed time scales with `attemptDelayMs * (maxAttempts - 1)`.
+ */
+export function fixedRetryPolicy(
+  attemptDelayMs: number,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+): RetryPolicy {
+  return {
+    maxAttempts,
+    delayMs: () => attemptDelayMs,
+  };
+}

--- a/modelguide-api/src/features/lorevault/emission/types.ts
+++ b/modelguide-api/src/features/lorevault/emission/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared types for the LoreVault signal emission subsystem.
+ */
+
+import type { SignalEvent } from "../client";
+
+export type DeliveryStatus =
+  | "pending"
+  | "in_flight"
+  | "delivered"
+  | "retrying"
+  | "dead_lettered"
+  | "gated";
+
+export interface SignalHistoryEntry {
+  signal_id: string;
+  event_type: string;
+  emitted_at: string;
+  status: DeliveryStatus;
+  attempts: number;
+  /** Whether the delivery hit LoreVault idempotency (Phase 0 §1.9). */
+  was_idempotent?: boolean;
+  /** Last error captured during retry, if any. */
+  last_error?: string;
+  /** When the entry was last updated by the worker. */
+  updated_at: string;
+}
+
+export interface DeadLetterEntry {
+  envelope: SignalEvent;
+  attempts: number;
+  last_error: string;
+  dead_lettered_at: string;
+}
+
+export interface DeadLetterStore {
+  add(entry: DeadLetterEntry): void;
+  list(limit?: number): DeadLetterEntry[];
+  size(): number;
+}
+
+export interface RetryPolicy {
+  /** Maximum number of attempts including the first try. */
+  maxAttempts: number;
+  /**
+   * Returns the delay in milliseconds before the *next* attempt.
+   * `attempt` is zero-indexed (0 = right after the first failure).
+   */
+  delayMs(attempt: number): number;
+}

--- a/modelguide-api/src/features/lorevault/fixtures/index.ts
+++ b/modelguide-api/src/features/lorevault/fixtures/index.ts
@@ -1,0 +1,324 @@
+/**
+ * Deterministic fixture data for the MockLoreVaultClient.
+ *
+ * Shapes conform to Phase 0 Integration Contract §1. Polarity values use
+ * `default_weight_source: "wevn_default"` per the contract — LSSR-010-POLARITY
+ * is locked but not yet shipped; consumers compute normalization until then.
+ *
+ * No timestamps are computed at module-load time. All timestamps are static
+ * ISO strings so fixtures are stable across runs.
+ */
+
+import type {
+  EntitlementResponse,
+  EvidenceChainResponse,
+  HealthResponse,
+  NarrativeDetailResponse,
+  NarrativeListResponse,
+  Pack,
+  PackCatalogResponse,
+  QueryResponse,
+  SignalEvidenceResponse,
+} from "../client";
+
+const FIXTURE_KS_ID = "ks_fixture_aura_poc";
+const FIXTURE_VAULT_ID = "vault_fixture_aura";
+const FIXTURE_TIMESTAMP = "2026-05-28T00:00:00.000Z";
+
+export const FIXTURE_IDS = {
+  knowledgeSpaceId: FIXTURE_KS_ID,
+  vaultId: FIXTURE_VAULT_ID,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Packs
+// ---------------------------------------------------------------------------
+
+const CUSTOMER_INTERACTION_PACK: Pack = {
+  pack_id: "pack_customer_interaction_v1",
+  name: "Customer Interaction",
+  description:
+    "Signals capturing customer sentiment, retention risk, and trust erosion across support and engagement surfaces.",
+  ontology_version: "1.0.0",
+  enabled: true,
+  signals_contributed: [
+    {
+      signal_id: "retention_risk",
+      polarity: "concern",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.7,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "stable",
+      registered_entity_types: ["contact", "company", "ticket"],
+    },
+    {
+      signal_id: "trust_erosion",
+      polarity: "concern",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.6,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "stable",
+      registered_entity_types: ["contact", "ticket"],
+    },
+    {
+      signal_id: "positive_engagement",
+      polarity: "health",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.5,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "stable",
+      registered_entity_types: ["contact", "engagement"],
+    },
+  ],
+};
+
+const OPERATIONAL_WORKFLOW_PACK: Pack = {
+  pack_id: "pack_operational_workflow_v1",
+  name: "Operational Workflow",
+  description:
+    "Signals capturing operational throughput, queue health, and ticket lifecycle anomalies.",
+  ontology_version: "1.0.0",
+  enabled: true,
+  signals_contributed: [
+    {
+      signal_id: "queue_backlog",
+      polarity: "concern",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.5,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "stable",
+      registered_entity_types: ["ticket"],
+    },
+    {
+      signal_id: "first_response_breach",
+      polarity: "concern",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.8,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "stable",
+      registered_entity_types: ["ticket"],
+    },
+  ],
+};
+
+const REVENUE_INTELLIGENCE_PACK: Pack = {
+  pack_id: "pack_revenue_intelligence_v1",
+  name: "Revenue Intelligence",
+  description:
+    "Signals capturing pipeline progression, deal velocity, and stage-time-in-stage anomalies.",
+  ontology_version: "1.0.0",
+  enabled: true,
+  signals_contributed: [
+    {
+      signal_id: "deal_slippage",
+      polarity: "concern",
+      raw_score_range: { min: 0, max: 100 },
+      default_weight: 0.7,
+      default_weight_source: "wevn_default",
+      operator_visible: true,
+      maturity_tier: "experimental",
+      registered_entity_types: ["deal"],
+    },
+  ],
+};
+
+export const FIXTURE_PACKS: PackCatalogResponse = {
+  packs: [
+    CUSTOMER_INTERACTION_PACK,
+    OPERATIONAL_WORKFLOW_PACK,
+    REVENUE_INTELLIGENCE_PACK,
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Entitlements
+// ---------------------------------------------------------------------------
+
+export const FIXTURE_ENTITLEMENTS: EntitlementResponse = {
+  vault_id: FIXTURE_VAULT_ID,
+  knowledge_space_id: FIXTURE_KS_ID,
+  tier: "enterprise",
+  features: {
+    osi_enabled: true,
+    lssr_enabled: true,
+  },
+  quotas: {
+    monthly_signal_events: { limit: 1_000_000, used: 12_345 },
+    monthly_ingest_mb: { limit: 5_120, used: 412 },
+    monthly_query_count: { limit: 50_000, used: 187 },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Narratives + evidence
+// ---------------------------------------------------------------------------
+
+const NARRATIVE_A: NarrativeDetailResponse = {
+  narrative_id: "nar_aura_retention_001",
+  title: "Repeated login failures correlating with retention risk in cohort A",
+  knowledge_space_id: FIXTURE_KS_ID,
+  lifecycle_state: "active",
+  active: true,
+  confidence: 0.82,
+  priority: 3,
+  primary_lens: "customer_interaction",
+  contributing_lenses: [
+    { lens: "customer_interaction", weight: 0.6 },
+    { lens: "operational_workflow", weight: 0.4 },
+  ],
+  contributing_entities: [
+    { type: "ticket", id: "hubspot:ticket:1001" },
+    { type: "ticket", id: "hubspot:ticket:1002" },
+    { type: "contact", id: "hubspot:contact:5001" },
+  ],
+  evidence_count: 12,
+  created_at: FIXTURE_TIMESTAMP,
+  last_transitioned_at: FIXTURE_TIMESTAMP,
+  investigation_prompts: [
+    "Are these contacts on the same identity provider?",
+    "Have any of these tickets been routed to escalation?",
+  ],
+  contributing_signal_ids: [
+    "sig_fixture_retention_001",
+    "sig_fixture_first_response_breach_002",
+  ],
+};
+
+const NARRATIVE_B: NarrativeDetailResponse = {
+  narrative_id: "nar_aura_pipeline_002",
+  title: "Mid-funnel deal slippage in Q2 cohort",
+  knowledge_space_id: FIXTURE_KS_ID,
+  lifecycle_state: "emerging",
+  active: true,
+  confidence: 0.65,
+  priority: 2,
+  primary_lens: "revenue_intelligence",
+  contributing_lenses: [{ lens: "revenue_intelligence", weight: 1.0 }],
+  contributing_entities: [{ type: "deal", id: "hubspot:deal:7001" }],
+  evidence_count: 4,
+  created_at: FIXTURE_TIMESTAMP,
+  last_transitioned_at: FIXTURE_TIMESTAMP,
+  investigation_prompts: ["Was a stage gate misconfigured for this cohort?"],
+  contributing_signal_ids: ["sig_fixture_deal_slippage_003"],
+};
+
+export const FIXTURE_NARRATIVES: NarrativeDetailResponse[] = [
+  NARRATIVE_A,
+  NARRATIVE_B,
+];
+
+export const FIXTURE_NARRATIVE_LIST: NarrativeListResponse = {
+  narratives: FIXTURE_NARRATIVES.map(
+    ({ contributing_signal_ids: _, ...summary }) => summary,
+  ),
+  total: FIXTURE_NARRATIVES.length,
+};
+
+export const FIXTURE_NARRATIVE_EVIDENCE: Record<string, EvidenceChainResponse> =
+  {
+    [NARRATIVE_A.narrative_id]: {
+      narrative_id: NARRATIVE_A.narrative_id,
+      evidence: [
+        {
+          chunk_id: "chunk_fixture_001",
+          source_document_id: "doc_fixture_ticket_1001",
+          source_uri: "lorevault://documents/doc_fixture_ticket_1001#chunk_001",
+          raw_text:
+            "Customer reported repeated login failures on the Aura portal after the v3.4 release.",
+          signal_id: "sig_fixture_retention_001",
+          signal_raw_score: 72,
+          signal_polarity: "concern",
+          chunk_score: 0.84,
+          status: "live",
+          extracted_at: FIXTURE_TIMESTAMP,
+        },
+        {
+          chunk_id: "chunk_fixture_002",
+          source_document_id: "doc_fixture_ticket_1002",
+          raw_text:
+            "Second user on the same tenant hit the same MFA loop within 36 hours.",
+          signal_id: "sig_fixture_first_response_breach_002",
+          signal_raw_score: 58,
+          signal_polarity: "concern",
+          chunk_score: 0.71,
+          status: "live",
+          extracted_at: FIXTURE_TIMESTAMP,
+        },
+      ],
+    },
+    [NARRATIVE_B.narrative_id]: {
+      narrative_id: NARRATIVE_B.narrative_id,
+      evidence: [
+        {
+          chunk_id: "chunk_fixture_003",
+          source_document_id: "doc_fixture_deal_7001",
+          raw_text:
+            "Deal stalled in 'Decision-Maker Engaged' for 41 days; expected median is 12 days.",
+          signal_id: "sig_fixture_deal_slippage_003",
+          signal_raw_score: 64,
+          signal_polarity: "concern",
+          chunk_score: 0.77,
+          status: "live",
+          extracted_at: FIXTURE_TIMESTAMP,
+        },
+      ],
+    },
+  };
+
+export const FIXTURE_SIGNAL_EVIDENCE: Record<string, SignalEvidenceResponse> = {
+  sig_fixture_retention_001: {
+    signal_id: "sig_fixture_retention_001",
+    evidence: FIXTURE_NARRATIVE_EVIDENCE[
+      NARRATIVE_A.narrative_id
+    ].evidence.filter((e) => e.signal_id === "sig_fixture_retention_001"),
+  },
+  sig_fixture_deal_slippage_003: {
+    signal_id: "sig_fixture_deal_slippage_003",
+    evidence: FIXTURE_NARRATIVE_EVIDENCE[
+      NARRATIVE_B.narrative_id
+    ].evidence.filter((e) => e.signal_id === "sig_fixture_deal_slippage_003"),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Query (signal-aware retrieval)
+// ---------------------------------------------------------------------------
+
+export const FIXTURE_QUERY_RESPONSE: QueryResponse = {
+  knowledge_space_id: FIXTURE_KS_ID,
+  evidence: [
+    {
+      chunk_id: "chunk_fixture_001",
+      source_document_id: "doc_fixture_ticket_1001",
+      raw_text:
+        "Customer reported repeated login failures on the Aura portal after the v3.4 release.",
+      signal_id: "sig_fixture_retention_001",
+      raw_score: 72,
+      polarity: "concern",
+      lens: "customer_interaction",
+      extracted_at: FIXTURE_TIMESTAMP,
+    },
+  ],
+  group_by: "signal",
+  groups: [
+    {
+      key: "sig_fixture_retention_001",
+      chunk_ids: ["chunk_fixture_001"],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+export const FIXTURE_HEALTH: HealthResponse = {
+  status: "ok",
+  version: "phase0-mock",
+  checked_at: FIXTURE_TIMESTAMP,
+};

--- a/modelguide-api/src/features/lorevault/fixtures/index.ts
+++ b/modelguide-api/src/features/lorevault/fixtures/index.ts
@@ -154,6 +154,24 @@ export const FIXTURE_ENTITLEMENTS: EntitlementResponse = {
   },
 };
 
+// Starter-tier fixture — used by entitlement fail-fast tests (Phase 0 §1.7
+// + HubSpot Connector Spec §11). Starter excludes OSI, so Mode B must
+// refuse to start when this is the entitlement response.
+export const FIXTURE_ENTITLEMENTS_STARTER: EntitlementResponse = {
+  vault_id: FIXTURE_VAULT_ID,
+  knowledge_space_id: FIXTURE_KS_ID,
+  tier: "starter",
+  features: {
+    osi_enabled: false,
+    lssr_enabled: false,
+  },
+  quotas: {
+    monthly_signal_events: { limit: 0, used: 0 },
+    monthly_ingest_mb: { limit: 512, used: 0 },
+    monthly_query_count: { limit: 0, used: 0 },
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Narratives + evidence
 // ---------------------------------------------------------------------------

--- a/modelguide-api/src/features/lorevault/http-client.ts
+++ b/modelguide-api/src/features/lorevault/http-client.ts
@@ -1,0 +1,97 @@
+/**
+ * HttpLoreVaultClient — STUB. Establishes the binding symbol used by the
+ * adapter swap-test; throws on every call until Wave 1 ships.
+ *
+ * Wave 1 endpoint surface (per Phase 0 §1 / Concurrent Workstream Plan §4):
+ *   POST /external/v1/signals (+ /signals:batch)
+ *   POST /external/v1/ingest/documents
+ *   GET  /external/v1/ingest/jobs/{id}
+ *   POST /external/v1/query
+ *   GET  /external/v1/narratives + /{id} + /{id}/evidence
+ *   GET  /external/v1/signals/{id}/evidence
+ *   GET  /external/v1/packs
+ *   GET  /external/v1/entitlements
+ *   GET  /external/v1/health
+ *
+ * Bind to this client by swapping the export in `./binding.ts` — no
+ * application code change.
+ */
+
+import type {
+  BatchAcceptResponse,
+  DocumentIngestRequest,
+  EntitlementResponse,
+  EvidenceChainResponse,
+  HealthResponse,
+  IngestionJobAcceptResponse,
+  IngestionJobStatus,
+  LoreVaultIntegrationClient,
+  NarrativeDetailResponse,
+  NarrativeFilter,
+  NarrativeListResponse,
+  PackCatalogResponse,
+  QueryResponse,
+  SignalAcceptResponse,
+  SignalAwareQuery,
+  SignalEvent,
+  SignalEvidenceResponse,
+} from "./client";
+
+export interface HttpLoreVaultClientConfig {
+  baseUrl: string;
+  apiKey: string;
+  knowledgeSpaceId: string;
+}
+
+const NOT_IMPLEMENTED = "Not implemented; bound after Wave 1 ships.";
+
+export class HttpLoreVaultClient implements LoreVaultIntegrationClient {
+  /** Retained for the eventual real implementation. Today the stub throws
+   * on every call, so the config is never read. */
+  readonly config: HttpLoreVaultClientConfig;
+
+  constructor(config: HttpLoreVaultClientConfig) {
+    this.config = config;
+  }
+
+  async emitSignal(_event: SignalEvent): Promise<SignalAcceptResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async emitSignalsBatch(_events: SignalEvent[]): Promise<BatchAcceptResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async ingestDocuments(
+    _payload: DocumentIngestRequest,
+  ): Promise<IngestionJobAcceptResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getIngestionJob(_id: string): Promise<IngestionJobStatus> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async query(_payload: SignalAwareQuery): Promise<QueryResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async listNarratives(
+    _filter: NarrativeFilter,
+  ): Promise<NarrativeListResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getNarrative(_id: string): Promise<NarrativeDetailResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getNarrativeEvidence(_id: string): Promise<EvidenceChainResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getSignalEvidence(_id: string): Promise<SignalEvidenceResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getEntitlements(): Promise<EntitlementResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getPacks(): Promise<PackCatalogResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async getHealth(): Promise<HealthResponse> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+}

--- a/modelguide-api/src/features/lorevault/index.ts
+++ b/modelguide-api/src/features/lorevault/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Public surface of the lorevault feature.
+ *
+ * Application code should depend ONLY on the interface + binding here.
+ * Never import a concrete client directly — that defeats the adapter
+ * swap (Phase 0 §3).
+ */
+
+export * from "./client";
+export { createLoreVaultClient } from "./binding";
+export type { LoreVaultClientConfig } from "./binding";

--- a/modelguide-api/src/features/lorevault/mock-client.ts
+++ b/modelguide-api/src/features/lorevault/mock-client.ts
@@ -75,6 +75,23 @@ export interface MockClientOptions {
   now?: () => Date;
   /** Deterministic ID factory for jobs / job IDs. */
   newId?: (prefix: string) => string;
+  /** Entitlement fixture override — supply the Starter-tier fixture to
+   * exercise Mode B fail-fast (Phase 0 §1.7). Defaults to the Enterprise
+   * fixture. */
+  entitlements?: EntitlementResponse;
+  /**
+   * Optional script for `emitSignal`: each call shifts one response from the
+   * head of the array. A `null` entry behaves as the default (idempotent
+   * append). A function entry can throw to simulate transient failures or
+   * compute a custom response. When the script is exhausted the client
+   * falls back to default behavior.
+   */
+  emitSignalScript?: Array<
+    | ((
+        event: SignalEvent,
+      ) => SignalAcceptResponse | Promise<SignalAcceptResponse>)
+    | null
+  >;
 }
 
 const DEFAULT_NOW = () => new Date("2026-05-28T00:00:00.000Z");
@@ -88,6 +105,8 @@ export class MockLoreVaultClient implements LoreVaultIntegrationClient {
 
   private readonly now: () => Date;
   private readonly newId: (prefix: string) => string;
+  private readonly entitlements: EntitlementResponse;
+  private readonly emitSignalScript: MockClientOptions["emitSignalScript"];
   private seq = 0;
 
   constructor(options: MockClientOptions = {}) {
@@ -96,6 +115,8 @@ export class MockLoreVaultClient implements LoreVaultIntegrationClient {
       options.newId ??
       ((prefix: string) =>
         `${prefix}_${(++this.seq).toString().padStart(6, "0")}`);
+    this.entitlements = options.entitlements ?? FIXTURE_ENTITLEMENTS;
+    this.emitSignalScript = options.emitSignalScript;
   }
 
   // -------------------------------------------------------------------------
@@ -103,6 +124,23 @@ export class MockLoreVaultClient implements LoreVaultIntegrationClient {
   // -------------------------------------------------------------------------
 
   async emitSignal(event: SignalEvent): Promise<SignalAcceptResponse> {
+    if (this.emitSignalScript && this.emitSignalScript.length > 0) {
+      const next = this.emitSignalScript.shift();
+      if (typeof next === "function") {
+        const response = await next(event);
+        // Recorded only when the scripted call accepts the event.
+        if (
+          response.accepted &&
+          !this.state.emittedSignals.some(
+            (e) => e.signal_id === event.signal_id,
+          )
+        ) {
+          this.state.emittedSignals.push(event);
+        }
+        return response;
+      }
+      // null entry → fall through to default behavior below.
+    }
     const alreadySeen = this.state.emittedSignals.some(
       (e) => e.signal_id === event.signal_id,
     );
@@ -262,7 +300,7 @@ export class MockLoreVaultClient implements LoreVaultIntegrationClient {
   // -------------------------------------------------------------------------
 
   async getEntitlements(): Promise<EntitlementResponse> {
-    return FIXTURE_ENTITLEMENTS;
+    return this.entitlements;
   }
 
   async getPacks(): Promise<PackCatalogResponse> {

--- a/modelguide-api/src/features/lorevault/mock-client.ts
+++ b/modelguide-api/src/features/lorevault/mock-client.ts
@@ -1,0 +1,275 @@
+/**
+ * MockLoreVaultClient — fixture-backed implementation of
+ * `LoreVaultIntegrationClient`. Used by Wevn build today; Wave-1
+ * HTTP client swaps in transparently when LoreVault ships.
+ *
+ * Behavior:
+ *   - `emitSignal` records the event in-memory and is idempotent on
+ *     `signal_id` (Phase 0 §1.9 — replay is observational, no state
+ *     resurrection, no side-effect re-firing).
+ *   - `ingestDocuments` upserts on `source_id` so re-running Mode C
+ *     produces no duplicates.
+ *   - All other reads return deterministic fixture data from
+ *     `./fixtures/index.ts`.
+ */
+
+import type {
+  BatchAcceptResponse,
+  DocumentIngestRequest,
+  EntitlementResponse,
+  EvidenceChainResponse,
+  HealthResponse,
+  IngestDocument,
+  IngestionJobAcceptResponse,
+  IngestionJobStatus,
+  LoreVaultIntegrationClient,
+  NarrativeDetailResponse,
+  NarrativeFilter,
+  NarrativeListResponse,
+  PackCatalogResponse,
+  QueryResponse,
+  SignalAcceptResponse,
+  SignalAwareQuery,
+  SignalEvent,
+  SignalEvidenceResponse,
+} from "./client";
+import {
+  FIXTURE_ENTITLEMENTS,
+  FIXTURE_HEALTH,
+  FIXTURE_IDS,
+  FIXTURE_NARRATIVES,
+  FIXTURE_NARRATIVE_EVIDENCE,
+  FIXTURE_NARRATIVE_LIST,
+  FIXTURE_PACKS,
+  FIXTURE_QUERY_RESPONSE,
+  FIXTURE_SIGNAL_EVIDENCE,
+} from "./fixtures";
+
+interface StoredDocument {
+  source_id: string;
+  dataset_id: string;
+  knowledge_space_id: string;
+  title: string;
+  content: string;
+  metadata: IngestDocument["metadata"];
+  first_ingested_at: string;
+  last_ingested_at: string;
+  revision: number;
+}
+
+interface StoredJob extends IngestionJobStatus {
+  source_ids: string[];
+}
+
+export interface MockState {
+  emittedSignals: SignalEvent[];
+  documents: Map<string, StoredDocument>;
+  jobs: Map<string, StoredJob>;
+}
+
+export interface MockClientOptions {
+  /**
+   * Deterministic clock for tests. Defaults to a frozen fixture timestamp so
+   * the mock never depends on `Date.now()`.
+   */
+  now?: () => Date;
+  /** Deterministic ID factory for jobs / job IDs. */
+  newId?: (prefix: string) => string;
+}
+
+const DEFAULT_NOW = () => new Date("2026-05-28T00:00:00.000Z");
+
+export class MockLoreVaultClient implements LoreVaultIntegrationClient {
+  readonly state: MockState = {
+    emittedSignals: [],
+    documents: new Map(),
+    jobs: new Map(),
+  };
+
+  private readonly now: () => Date;
+  private readonly newId: (prefix: string) => string;
+  private seq = 0;
+
+  constructor(options: MockClientOptions = {}) {
+    this.now = options.now ?? DEFAULT_NOW;
+    this.newId =
+      options.newId ??
+      ((prefix: string) =>
+        `${prefix}_${(++this.seq).toString().padStart(6, "0")}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Signal ingest
+  // -------------------------------------------------------------------------
+
+  async emitSignal(event: SignalEvent): Promise<SignalAcceptResponse> {
+    const alreadySeen = this.state.emittedSignals.some(
+      (e) => e.signal_id === event.signal_id,
+    );
+    if (!alreadySeen) {
+      this.state.emittedSignals.push(event);
+    }
+    return {
+      signal_id: event.signal_id,
+      accepted: true,
+      was_idempotent: alreadySeen,
+    };
+  }
+
+  async emitSignalsBatch(events: SignalEvent[]): Promise<BatchAcceptResponse> {
+    const accepted: SignalAcceptResponse[] = [];
+    for (const event of events) {
+      accepted.push(await this.emitSignal(event));
+    }
+    return { accepted, rejected: [] };
+  }
+
+  // -------------------------------------------------------------------------
+  // Document ingest (idempotent upsert on source_id)
+  // -------------------------------------------------------------------------
+
+  async ingestDocuments(
+    payload: DocumentIngestRequest,
+  ): Promise<IngestionJobAcceptResponse> {
+    const nowIso = this.now().toISOString();
+    const rejection_reasons: Array<{ source_id: string; reason: string }> = [];
+    let accepted_count = 0;
+    const sourceIds: string[] = [];
+    let bytes_requested = 0;
+
+    for (const doc of payload.documents) {
+      bytes_requested += Buffer.byteLength(doc.content ?? "", "utf8");
+      if (!doc.source_id) {
+        rejection_reasons.push({
+          source_id: doc.source_id,
+          reason: "source_id is required",
+        });
+        continue;
+      }
+      const existing = this.state.documents.get(doc.source_id);
+      const stored: StoredDocument = {
+        source_id: doc.source_id,
+        dataset_id: payload.dataset_id,
+        knowledge_space_id: payload.knowledge_space_id,
+        title: doc.title,
+        content: doc.content,
+        metadata: doc.metadata,
+        first_ingested_at: existing?.first_ingested_at ?? nowIso,
+        last_ingested_at: nowIso,
+        revision: (existing?.revision ?? 0) + 1,
+      };
+      this.state.documents.set(doc.source_id, stored);
+      sourceIds.push(doc.source_id);
+      accepted_count += 1;
+    }
+
+    const ingestion_job_id = this.newId("job");
+    const job: StoredJob = {
+      ingestion_job_id,
+      state: "complete",
+      knowledge_space_id: payload.knowledge_space_id,
+      dataset_id: payload.dataset_id,
+      bytes_requested,
+      bytes_processed: bytes_requested,
+      document_count: accepted_count,
+      started_at: nowIso,
+      completed_at: nowIso,
+      rejection_reasons: rejection_reasons.length
+        ? rejection_reasons
+        : undefined,
+      source_ids: sourceIds,
+    };
+    this.state.jobs.set(ingestion_job_id, job);
+
+    return {
+      ingestion_job_id,
+      accepted_count,
+      rejected_count: rejection_reasons.length,
+      rejection_reasons,
+    };
+  }
+
+  async getIngestionJob(id: string): Promise<IngestionJobStatus> {
+    const job = this.state.jobs.get(id);
+    if (!job) {
+      throw new Error(`Mock ingestion job not found: ${id}`);
+    }
+    const { source_ids: _, ...status } = job;
+    return status;
+  }
+
+  // -------------------------------------------------------------------------
+  // Query + narratives (fixture data)
+  // -------------------------------------------------------------------------
+
+  async query(_payload: SignalAwareQuery): Promise<QueryResponse> {
+    return FIXTURE_QUERY_RESPONSE;
+  }
+
+  async listNarratives(
+    filter: NarrativeFilter,
+  ): Promise<NarrativeListResponse> {
+    if (filter.knowledge_space_id !== FIXTURE_IDS.knowledgeSpaceId) {
+      return { narratives: [], total: 0 };
+    }
+    let narratives = FIXTURE_NARRATIVE_LIST.narratives;
+    if (filter.lifecycle_state?.length) {
+      narratives = narratives.filter((n) =>
+        filter.lifecycle_state?.includes(n.lifecycle_state),
+      );
+    }
+    if (filter.primary_lens?.length) {
+      narratives = narratives.filter((n) =>
+        filter.primary_lens?.includes(n.primary_lens),
+      );
+    }
+    if (filter.active !== undefined) {
+      narratives = narratives.filter((n) => n.active === filter.active);
+    }
+    const limit = filter.limit ?? narratives.length;
+    return {
+      narratives: narratives.slice(0, limit),
+      total: narratives.length,
+    };
+  }
+
+  async getNarrative(id: string): Promise<NarrativeDetailResponse> {
+    const narrative = FIXTURE_NARRATIVES.find((n) => n.narrative_id === id);
+    if (!narrative) {
+      throw new Error(`Mock narrative not found: ${id}`);
+    }
+    return narrative;
+  }
+
+  async getNarrativeEvidence(id: string): Promise<EvidenceChainResponse> {
+    const evidence = FIXTURE_NARRATIVE_EVIDENCE[id];
+    if (!evidence) {
+      throw new Error(`Mock narrative evidence not found: ${id}`);
+    }
+    return evidence;
+  }
+
+  async getSignalEvidence(id: string): Promise<SignalEvidenceResponse> {
+    const evidence = FIXTURE_SIGNAL_EVIDENCE[id];
+    if (!evidence) {
+      throw new Error(`Mock signal evidence not found: ${id}`);
+    }
+    return evidence;
+  }
+
+  // -------------------------------------------------------------------------
+  // Catalog / tenant
+  // -------------------------------------------------------------------------
+
+  async getEntitlements(): Promise<EntitlementResponse> {
+    return FIXTURE_ENTITLEMENTS;
+  }
+
+  async getPacks(): Promise<PackCatalogResponse> {
+    return FIXTURE_PACKS;
+  }
+
+  async getHealth(): Promise<HealthResponse> {
+    return FIXTURE_HEALTH;
+  }
+}

--- a/modelguide-api/tests/unit/connectors/hubspot-envelopes.test.ts
+++ b/modelguide-api/tests/unit/connectors/hubspot-envelopes.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Per-tool signal envelope construction (Phase 0 §1.1, HubSpot spec §5).
+ *
+ * Locks for every emitting tool:
+ *   - event_type
+ *   - canonical_object_identity ({tenant_id, source_system, object_type, object_id})
+ *   - declared_lens_hints (canonical snake_case lens IDs)
+ *   - entity.{type, id}
+ *
+ * Does NOT test enqueue wiring — that's covered by hubspot-mode-b-wiring.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  EMITTING_TOOL_EVENT_TYPES,
+  type EmissionConfig,
+  type EmittingToolName,
+  buildEnvelopeForTool,
+} from "@features/connectors/catalog/hubspot/ingest/mode-b/envelopes";
+import type { ToolExecutionContext } from "@features/connectors/catalog/types";
+import type { LensId } from "@features/lorevault/client";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+
+const EMISSION_CONFIG: EmissionConfig = {
+  knowledgeSpaceId: FIXTURE_IDS.knowledgeSpaceId,
+  vaultId: FIXTURE_IDS.vaultId,
+  sourceInstance: "98765",
+};
+
+function makeCtx(input: Record<string, unknown> = {}): ToolExecutionContext {
+  return {
+    config: { portalId: "98765" },
+    input,
+    organizationId: "org-1",
+    connectorId: "conn-1",
+  };
+}
+
+interface ToolFixture {
+  toolName: EmittingToolName;
+  ctx: ToolExecutionContext;
+  result: Record<string, unknown>;
+  expected: {
+    eventType: string;
+    entityType: string;
+    entityId: string;
+    lensHints: LensId[];
+  };
+}
+
+const FIXTURES: ToolFixture[] = [
+  {
+    toolName: "Create Contact",
+    ctx: makeCtx({ properties: { firstname: "Ada", email: "ada@x.com" } }),
+    result: { id: "c1", properties: { firstname: "Ada" } },
+    expected: {
+      eventType: "contact.created",
+      entityType: "contact",
+      entityId: "c1",
+      lensHints: ["customer_interaction"],
+    },
+  },
+  {
+    toolName: "Update Contact",
+    ctx: makeCtx({
+      contactId: "c1",
+      properties: { firstname: "Ada", lifecyclestage: "customer" },
+    }),
+    result: { id: "c1", properties: { firstname: "Ada" } },
+    expected: {
+      eventType: "contact.updated",
+      entityType: "contact",
+      entityId: "c1",
+      // lifecyclestage in properties_changed adds revenue_intelligence
+      lensHints: ["customer_interaction", "revenue_intelligence"],
+    },
+  },
+  {
+    toolName: "Create Deal",
+    ctx: makeCtx({ properties: { dealname: "D-1" } }),
+    result: { id: "d1", properties: { dealname: "D-1" } },
+    expected: {
+      eventType: "deal.created",
+      entityType: "deal",
+      entityId: "d1",
+      lensHints: ["revenue_intelligence"],
+    },
+  },
+  {
+    toolName: "Update Deal Stage",
+    ctx: makeCtx({ dealId: "d1", stage: "closedwon" }),
+    result: { id: "d1", properties: { dealstage: "closedwon" } },
+    expected: {
+      eventType: "deal.stage_changed",
+      entityType: "deal",
+      entityId: "d1",
+      lensHints: ["revenue_intelligence", "operational_workflow"],
+    },
+  },
+  {
+    toolName: "Create Ticket",
+    ctx: makeCtx({ properties: { subject: "Login failure" } }),
+    result: { id: "t1", properties: { subject: "Login failure" } },
+    expected: {
+      eventType: "ticket.created",
+      entityType: "ticket",
+      entityId: "t1",
+      lensHints: ["customer_interaction", "operational_workflow"],
+    },
+  },
+  {
+    toolName: "Update Ticket",
+    ctx: makeCtx({ ticketId: "t1", properties: { subject: "Updated" } }),
+    result: { id: "t1", properties: { subject: "Updated" } },
+    expected: {
+      eventType: "ticket.updated",
+      entityType: "ticket",
+      entityId: "t1",
+      lensHints: ["operational_workflow"],
+    },
+  },
+  {
+    toolName: "Close Ticket",
+    ctx: makeCtx({ ticketId: "t1" }),
+    result: { id: "t1", properties: { hs_pipeline_stage: "closed_stage" } },
+    expected: {
+      eventType: "ticket.closed",
+      entityType: "ticket",
+      entityId: "t1",
+      lensHints: ["operational_workflow", "customer_interaction"],
+    },
+  },
+  {
+    toolName: "Add Reply To Ticket",
+    ctx: makeCtx({ ticketId: "t1", text: "Investigating" }),
+    result: { id: "msg1" },
+    expected: {
+      eventType: "ticket.reply_sent",
+      entityType: "ticket",
+      entityId: "t1",
+      lensHints: ["customer_interaction", "knowledge_integrity"],
+    },
+  },
+  {
+    toolName: "Log Call Engagement",
+    ctx: makeCtx({ properties: { hs_call_title: "Onboarding call" } }),
+    result: { id: "call1", properties: {} },
+    expected: {
+      eventType: "call.logged",
+      entityType: "engagement",
+      entityId: "call1",
+      lensHints: ["customer_interaction", "operational_workflow"],
+    },
+  },
+  {
+    toolName: "Create Note",
+    ctx: makeCtx({ properties: { hs_note_body: "HITL handoff" } }),
+    result: { id: "note1", properties: {} },
+    expected: {
+      eventType: "note.created",
+      entityType: "note",
+      entityId: "note1",
+      lensHints: ["knowledge_integrity", "operational_workflow"],
+    },
+  },
+];
+
+describe("EMITTING_TOOL_EVENT_TYPES surface", () => {
+  test("declares exactly the per-row spec §5 set", () => {
+    const names = Object.keys(EMITTING_TOOL_EVENT_TYPES).sort();
+    expect(names).toEqual(
+      [
+        "Add Reply To Ticket",
+        "Close Ticket",
+        "Create Contact",
+        "Create Deal",
+        "Create Note",
+        "Create Ticket",
+        "Log Call Engagement",
+        "Update Contact",
+        "Update Deal Stage",
+        "Update Ticket",
+      ].sort(),
+    );
+  });
+});
+
+describe("Per-tool envelope construction", () => {
+  for (const fx of FIXTURES) {
+    test(`${fx.toolName} → ${fx.expected.eventType}`, () => {
+      const env = buildEnvelopeForTool(fx.toolName, {
+        ctx: fx.ctx,
+        result: fx.result,
+        config: EMISSION_CONFIG,
+        signalId: "sig_test",
+        emittedAt: "2026-05-28T00:00:00.000Z",
+      });
+      expect(env).not.toBeNull();
+      if (!env) return;
+
+      expect(env.event_type).toBe(fx.expected.eventType);
+      expect(env.signal_id).toBe("sig_test");
+      expect(env.signal_version).toBe("1");
+      expect(env.emitted_at).toBe("2026-05-28T00:00:00.000Z");
+      expect(env.source_system).toBe("hubspot");
+      expect(env.source_instance).toBe("98765");
+      expect(env.knowledge_space_id).toBe(FIXTURE_IDS.knowledgeSpaceId);
+      expect(env.vault_id).toBe(FIXTURE_IDS.vaultId);
+
+      expect(env.entity.type).toBe(fx.expected.entityType);
+      expect(env.entity.id).toBe(fx.expected.entityId);
+
+      expect(env.canonical_object_identity).toEqual({
+        tenant_id: FIXTURE_IDS.vaultId,
+        source_system: "hubspot",
+        object_type: fx.expected.entityType,
+        object_id: fx.expected.entityId,
+      });
+
+      expect([...env.declared_lens_hints].sort()).toEqual(
+        [...fx.expected.lensHints].sort(),
+      );
+    });
+  }
+
+  test("Update Contact omits revenue_intelligence when lifecyclestage not changed", () => {
+    const env = buildEnvelopeForTool("Update Contact", {
+      ctx: makeCtx({
+        contactId: "c1",
+        properties: { firstname: "Ada" },
+      }),
+      result: { id: "c1", properties: {} },
+      config: EMISSION_CONFIG,
+    });
+    expect(env?.declared_lens_hints).toEqual(["customer_interaction"]);
+  });
+
+  test("signal_id defaults to a UUID v4 string", () => {
+    const env = buildEnvelopeForTool("Create Contact", {
+      ctx: makeCtx({ properties: { firstname: "Ada" } }),
+      result: { id: "c1", properties: {} },
+      config: EMISSION_CONFIG,
+    });
+    expect(env?.signal_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+});

--- a/modelguide-api/tests/unit/connectors/hubspot-handlers.test.ts
+++ b/modelguide-api/tests/unit/connectors/hubspot-handlers.test.ts
@@ -1,0 +1,376 @@
+/**
+ * HubSpot handler unit tests.
+ *
+ * Mocks globalThis.fetch and verifies:
+ *   - Bearer auth header
+ *   - 429 retry with Retry-After
+ *   - Property allowlist enforcement on Update Contact and Update Ticket
+ *   - Close Ticket resolves the per-pipeline CLOSED stage
+ *   - Update Ticket rejects closed-stage moves
+ *   - Add Reply To Ticket writes via the Conversations API
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  addReplyToTicket,
+  closeTicket,
+  getContactByEmail,
+  updateContact,
+  updateTicket,
+} from "@features/connectors/catalog/hubspot/handlers";
+import type { ToolExecutionContext } from "@features/connectors/catalog/types";
+
+const BASE_CONFIG: Record<string, string> = {
+  accessToken: "pat-test-abc123",
+  portalId: "98765",
+};
+
+function makeCtx(
+  input: Record<string, unknown> = {},
+  config = BASE_CONFIG,
+): ToolExecutionContext {
+  return {
+    config,
+    input,
+    organizationId: "org-1",
+    connectorId: "conn-1",
+  };
+}
+
+type FetchResponder = (
+  url: string,
+  init: RequestInit,
+) => Response | Promise<Response>;
+
+const originalFetch = globalThis.fetch;
+let calls: Array<{ url: string; init: RequestInit }> = [];
+
+function installFetch(
+  responders: FetchResponder | FetchResponder[],
+): ReturnType<typeof mock> {
+  calls = [];
+  const queue = Array.isArray(responders) ? [...responders] : null;
+  const single = Array.isArray(responders) ? null : responders;
+  const fetchMock = mock((url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    const responder = queue ? queue.shift() : single;
+    if (!responder) {
+      throw new Error(`Unexpected extra fetch call: ${url}`);
+    }
+    return Promise.resolve(responder(url, init));
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Auth + base URL
+// ---------------------------------------------------------------------------
+
+describe("HubSpot auth + base URL", () => {
+  test("sends Bearer access token and hits api.hubapi.com", async () => {
+    installFetch(() => jsonResponse({ id: "1", properties: {} }));
+    const result = await getContactByEmail(
+      makeCtx({ email: "jane@example.com" }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls[0].url).toContain(
+      "https://api.hubapi.com/crm/v3/objects/contacts/",
+    );
+    expect(calls[0].url).toContain("idProperty=email");
+    expect(
+      (calls[0].init.headers as Record<string, string>).Authorization,
+    ).toBe("Bearer pat-test-abc123");
+  });
+
+  test("missing accessToken yields success:false with a clear error", async () => {
+    const result = await getContactByEmail(
+      makeCtx({ email: "x@y.com" }, { portalId: "1" }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("accessToken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 429 backoff (Retry-After respected)
+// ---------------------------------------------------------------------------
+
+describe("HubSpot 429 backoff", () => {
+  test("retries once on 429 then succeeds, respecting Retry-After=0", async () => {
+    installFetch([
+      () =>
+        new Response("rate limited", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        }),
+      () => jsonResponse({ id: "42", properties: {} }),
+    ]);
+    const result = await getContactByEmail(
+      makeCtx({ email: "throttle@example.com" }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Update Contact — property allowlist
+// ---------------------------------------------------------------------------
+
+describe("Update Contact allowlist", () => {
+  test("rejects non-allowlisted property before issuing a HubSpot call", async () => {
+    installFetch(() => jsonResponse({ id: "1" }));
+    const result = await updateContact(
+      makeCtx({
+        contactId: "1",
+        properties: { firstname: "Ada", hs_object_source: "MANUAL" },
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hs_object_source");
+    expect(calls.length).toBe(0);
+  });
+
+  test("PATCHes when all properties are allowlisted", async () => {
+    installFetch(() =>
+      jsonResponse({ id: "1", properties: { firstname: "Ada" } }),
+    );
+    const result = await updateContact(
+      makeCtx({
+        contactId: "1",
+        properties: { firstname: "Ada", lifecyclestage: "customer" },
+      }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls[0].init.method).toBe("PATCH");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Update Ticket — allowlist + closed-stage rejection
+// ---------------------------------------------------------------------------
+
+describe("Update Ticket governance", () => {
+  test("rejects non-allowlisted property", async () => {
+    installFetch(() => jsonResponse({}));
+    const result = await updateTicket(
+      makeCtx({
+        ticketId: "10",
+        properties: { subject: "ok", hs_object_id: "evil" },
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hs_object_id");
+  });
+
+  test("rejects an hs_pipeline_stage that resolves to a CLOSED stage", async () => {
+    installFetch([
+      // resolve current pipeline for the ticket
+      () => jsonResponse({ id: "10", properties: { hs_pipeline: "p1" } }),
+      // pipeline lookup
+      () =>
+        jsonResponse({
+          id: "p1",
+          label: "Service Pipeline",
+          stages: [
+            { id: "s_open", label: "Open", metadata: { ticketState: "OPEN" } },
+            {
+              id: "s_done",
+              label: "Closed",
+              metadata: { ticketState: "CLOSED" },
+            },
+          ],
+        }),
+    ]);
+
+    const result = await updateTicket(
+      makeCtx({
+        ticketId: "10",
+        properties: { hs_pipeline_stage: "s_done" },
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Close Ticket");
+  });
+
+  test("allows an hs_pipeline_stage that resolves to an OPEN stage", async () => {
+    installFetch([
+      () => jsonResponse({ id: "10", properties: { hs_pipeline: "p1" } }),
+      () =>
+        jsonResponse({
+          id: "p1",
+          label: "Service Pipeline",
+          stages: [
+            { id: "s_open", label: "Open", metadata: { ticketState: "OPEN" } },
+            {
+              id: "s_done",
+              label: "Closed",
+              metadata: { ticketState: "CLOSED" },
+            },
+          ],
+        }),
+      // PATCH ticket
+      () =>
+        jsonResponse({
+          id: "10",
+          properties: { hs_pipeline_stage: "s_open" },
+        }),
+    ]);
+
+    const result = await updateTicket(
+      makeCtx({
+        ticketId: "10",
+        properties: { hs_pipeline_stage: "s_open" },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close Ticket — resolves CLOSED stage at runtime
+// ---------------------------------------------------------------------------
+
+describe("Close Ticket", () => {
+  test("resolves the per-pipeline CLOSED stage and PATCHes the ticket", async () => {
+    installFetch([
+      () => jsonResponse({ id: "10", properties: { hs_pipeline: "p1" } }),
+      () =>
+        jsonResponse({
+          id: "p1",
+          label: "Service Pipeline",
+          stages: [
+            { id: "s_open", label: "Open", metadata: { ticketState: "OPEN" } },
+            {
+              id: "s_done",
+              label: "Closed",
+              metadata: { ticketState: "CLOSED" },
+            },
+          ],
+        }),
+      () =>
+        jsonResponse({
+          id: "10",
+          properties: { hs_pipeline_stage: "s_done" },
+        }),
+    ]);
+    const result = await closeTicket(makeCtx({ ticketId: "10" }));
+    expect(result.success).toBe(true);
+
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall.init.method).toBe("PATCH");
+    const body = JSON.parse(String(lastCall.init.body));
+    expect(body.properties.hs_pipeline_stage).toBe("s_done");
+  });
+
+  test("errors clearly when the pipeline has no closed stage configured", async () => {
+    installFetch([
+      () => jsonResponse({ id: "10", properties: { hs_pipeline: "p1" } }),
+      () =>
+        jsonResponse({
+          id: "p1",
+          label: "Pipeline",
+          stages: [
+            {
+              id: "s_open",
+              label: "Open",
+              metadata: { ticketState: "OPEN" },
+            },
+          ],
+        }),
+    ]);
+    const result = await closeTicket(makeCtx({ ticketId: "10" }));
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("CLOSED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Add Reply To Ticket — uses Conversations API
+// ---------------------------------------------------------------------------
+
+describe("Add Reply To Ticket", () => {
+  test("errors clearly when the ticket has no associated thread", async () => {
+    installFetch([
+      // ticket properties read (hs_thread_ids)
+      () => jsonResponse({ id: "10", properties: {} }),
+      // fallback associations endpoint
+      () => jsonResponse({ results: [] }),
+    ]);
+    const result = await addReplyToTicket(
+      makeCtx({ ticketId: "10", text: "hello" }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("no associated conversation thread");
+  });
+
+  test("POSTs to /conversations/v3/conversations/threads/.../messages", async () => {
+    installFetch([
+      // ticket properties: hs_thread_ids
+      () =>
+        jsonResponse({
+          id: "10",
+          properties: { hs_thread_ids: "thr_123" },
+        }),
+      // thread read
+      () =>
+        jsonResponse({
+          id: "thr_123",
+          channelId: "1000",
+          channelAccountId: "acct_email_1",
+          latestMessageReceivedTimestamp: "2026-05-27T12:00:00Z",
+        }),
+      // message history
+      () =>
+        jsonResponse({
+          results: [
+            {
+              id: "m_in",
+              type: "MESSAGE",
+              direction: "INCOMING",
+              channelId: "1000",
+              channelAccountId: "acct_email_1",
+              senders: [
+                { name: "Customer", deliveryIdentifier: { value: "c@x.com" } },
+              ],
+              recipients: [
+                { deliveryIdentifier: { value: "support@aura.example" } },
+              ],
+              subject: "Re: Login failure",
+              createdAt: "2026-05-27T12:00:00Z",
+            },
+          ],
+        }),
+      // POST reply
+      () => jsonResponse({ id: "m_out", type: "MESSAGE" }),
+    ]);
+
+    const result = await addReplyToTicket(
+      makeCtx({ ticketId: "10", text: "Investigating now" }),
+    );
+    expect(result.success).toBe(true);
+
+    const last = calls[calls.length - 1];
+    expect(last.url).toContain(
+      "/conversations/v3/conversations/threads/thr_123/messages",
+    );
+    expect(last.init.method).toBe("POST");
+    const body = JSON.parse(String(last.init.body));
+    expect(body.channelId).toBe("1000");
+    expect(body.channelAccountId).toBe("acct_email_1");
+    expect(body.text).toBe("Investigating now");
+  });
+});

--- a/modelguide-api/tests/unit/connectors/hubspot-ingest.test.ts
+++ b/modelguide-api/tests/unit/connectors/hubspot-ingest.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Mode C ingest end-to-end (against MockLoreVaultClient).
+ *
+ * Verifies:
+ *   - canonical source_id = `{tenant_id}:hubspot:{object_type}:{object_id}`
+ *   - tickets render to markdown with the thread inline
+ *   - the runner walks pages, batches into ingestDocuments, and updates
+ *     watermarks per Phase 0 §1.2
+ *   - re-running on the same canonical identity produces no duplicate
+ *     documents in mock state (idempotent upsert)
+ *   - incremental sync respects the persisted watermark
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { HubSpotKnowledgeArticle } from "@features/connectors/catalog/hubspot/handlers";
+import {
+  type CorpusIngestConfig,
+  type HubSpotIngestSource,
+  InMemoryWatermarkStore,
+  type Page,
+  runIncrementalSync,
+  runInitialBackfill,
+} from "@features/connectors/catalog/hubspot/ingest";
+import {
+  HUBSPOT_SOURCE_SYSTEM,
+  deriveSourceId,
+} from "@features/connectors/catalog/hubspot/ingest/canonical-identity";
+import {
+  type HubSpotContactWithContext,
+  type HubSpotTicketWithThread,
+  renderTicketAsMarkdown,
+} from "@features/connectors/catalog/hubspot/ingest/renderers";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+const VAULT_ID = FIXTURE_IDS.vaultId;
+const PORTAL_ID = "98765";
+
+const REPRESENTATIVE_TICKET: HubSpotTicketWithThread = {
+  id: "1001",
+  createdAt: "2026-05-01T10:00:00.000Z",
+  updatedAt: "2026-05-27T12:00:00.000Z",
+  properties: {
+    subject: "Login failure on Aura portal",
+    content: "Customer cannot complete MFA flow after v3.4 release.",
+    hs_pipeline: "p_support",
+    hs_pipeline_stage: "s_open",
+    hs_ticket_priority: "HIGH",
+    hs_ticket_category: "AUTH",
+    hubspot_owner_id: "owner_7",
+    createdate: "2026-05-01T10:00:00.000Z",
+    hs_lastmodifieddate: "2026-05-27T12:00:00.000Z",
+  },
+  thread: [
+    {
+      id: "m1",
+      type: "MESSAGE",
+      direction: "INCOMING",
+      createdAt: "2026-05-01T10:00:00.000Z",
+      senders: [
+        {
+          name: "Jane Operator",
+          deliveryIdentifier: { value: "jane@aura.example" },
+        },
+      ],
+      text: "Hit a hard error on MFA after the v3.4 release.",
+    },
+    {
+      id: "m2",
+      type: "MESSAGE",
+      direction: "OUTGOING",
+      createdAt: "2026-05-01T11:15:00.000Z",
+      senders: [{ name: "Aura Support" }],
+      text: "Investigating — we'll have an update by EOD.",
+    },
+  ],
+};
+
+const REPRESENTATIVE_KB: HubSpotKnowledgeArticle = {
+  id: "kb_42",
+  name: "Resetting MFA",
+  language: "en",
+  state: "PUBLISHED",
+  url: "https://aura.example/kb/resetting-mfa",
+  htmlBody: "<p>Step 1: visit the portal.</p><p>Step 2: choose reset.</p>",
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-15T00:00:00.000Z",
+};
+
+const REPRESENTATIVE_CONTACT: HubSpotContactWithContext = {
+  id: "5001",
+  createdAt: "2026-01-15T00:00:00.000Z",
+  updatedAt: "2026-05-27T12:00:00.000Z",
+  properties: {
+    firstname: "Jane",
+    lastname: "Operator",
+    email: "jane@aura.example",
+    phone: "+1-555-0100",
+    company: "Aura Industries",
+    lifecyclestage: "customer",
+  },
+  primaryCompany: {
+    id: "co_900",
+    properties: { name: "Aura Industries", domain: "aura.example" },
+  },
+  recentTickets: [
+    {
+      id: "1001",
+      properties: { subject: "Login failure", hs_pipeline_stage: "s_open" },
+    },
+  ],
+};
+
+class FakeSource implements HubSpotIngestSource {
+  public ticketsServed = 0;
+  public kbServed = 0;
+  public contactsServed = 0;
+
+  constructor(
+    private readonly tickets: HubSpotTicketWithThread[] = [
+      REPRESENTATIVE_TICKET,
+    ],
+    private readonly articles: HubSpotKnowledgeArticle[] = [REPRESENTATIVE_KB],
+    private readonly contacts: HubSpotContactWithContext[] = [
+      REPRESENTATIVE_CONTACT,
+    ],
+  ) {}
+
+  async listTickets(params: {
+    updatedSince?: string;
+    limit: number;
+  }): Promise<Page<HubSpotTicketWithThread>> {
+    const items = filterUpdatedSince(this.tickets, params.updatedSince);
+    this.ticketsServed += items.length;
+    return { items };
+  }
+  async listKnowledgeArticles(params: {
+    updatedSince?: string;
+    limit: number;
+  }): Promise<Page<HubSpotKnowledgeArticle>> {
+    const items = filterUpdatedSince(this.articles, params.updatedSince);
+    this.kbServed += items.length;
+    return { items };
+  }
+  async listContacts(params: {
+    updatedSince?: string;
+    limit: number;
+  }): Promise<Page<HubSpotContactWithContext>> {
+    const items = filterUpdatedSince(this.contacts, params.updatedSince);
+    this.contactsServed += items.length;
+    return { items };
+  }
+}
+
+function filterUpdatedSince<T extends { updatedAt?: string }>(
+  items: T[],
+  updatedSince: string | undefined,
+): T[] {
+  if (!updatedSince) return items;
+  return items.filter((i) => !i.updatedAt || i.updatedAt > updatedSince);
+}
+
+const CONFIG: CorpusIngestConfig = {
+  knowledgeSpaceId: FIXTURE_IDS.knowledgeSpaceId,
+  vaultId: VAULT_ID,
+  sourceInstance: PORTAL_ID,
+};
+
+// ---------------------------------------------------------------------------
+// Canonical identity
+// ---------------------------------------------------------------------------
+
+describe("canonical identity", () => {
+  test("source_id format matches Phase 0 §1.2", () => {
+    expect(
+      deriveSourceId({
+        tenantId: VAULT_ID,
+        objectType: "ticket",
+        objectId: "1001",
+      }),
+    ).toBe(`${VAULT_ID}:${HUBSPOT_SOURCE_SYSTEM}:ticket:1001`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+describe("renderTicketAsMarkdown", () => {
+  test("emits a markdown document with thread + properties header", () => {
+    const doc = renderTicketAsMarkdown(REPRESENTATIVE_TICKET, {
+      tenantId: VAULT_ID,
+      sourceInstance: PORTAL_ID,
+    });
+    expect(doc.source_id).toBe(`${VAULT_ID}:hubspot:ticket:1001`);
+    expect(doc.title).toBe("Login failure on Aura portal");
+    expect(doc.content).toContain("# Ticket #1001");
+    expect(doc.content).toContain("## Properties");
+    expect(doc.content).toContain("## Conversation thread");
+    expect(doc.content).toContain("Jane Operator");
+    expect(doc.content).toContain(
+      "Investigating — we'll have an update by EOD.",
+    );
+    expect(doc.metadata.source_system).toBe("hubspot");
+    expect(doc.metadata.source_instance).toBe(PORTAL_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Initial backfill — full corpus walk
+// ---------------------------------------------------------------------------
+
+describe("runInitialBackfill", () => {
+  test("renders all three entity types, calls ingestDocuments end-to-end", async () => {
+    const client = new MockLoreVaultClient();
+    const source = new FakeSource();
+
+    const result = await runInitialBackfill(source, client, CONFIG);
+    expect(result.totals.ticket.documents).toBe(1);
+    expect(result.totals.knowledge_article.documents).toBe(1);
+    expect(result.totals.contact.documents).toBe(1);
+
+    expect(client.state.documents.size).toBe(3);
+    const ids = [...client.state.documents.keys()].sort();
+    expect(ids).toContain(`${VAULT_ID}:hubspot:ticket:1001`);
+    expect(ids).toContain(`${VAULT_ID}:hubspot:knowledge_article:kb_42`);
+    expect(ids).toContain(`${VAULT_ID}:hubspot:contact:5001`);
+  });
+
+  test("re-running the backfill upserts on source_id (idempotent)", async () => {
+    const client = new MockLoreVaultClient();
+    const source = new FakeSource();
+
+    await runInitialBackfill(source, client, CONFIG);
+    const sizeAfterFirst = client.state.documents.size;
+    const ticketBefore = client.state.documents.get(
+      `${VAULT_ID}:hubspot:ticket:1001`,
+    );
+
+    await runInitialBackfill(source, client, CONFIG);
+    expect(client.state.documents.size).toBe(sizeAfterFirst);
+
+    const ticketAfter = client.state.documents.get(
+      `${VAULT_ID}:hubspot:ticket:1001`,
+    );
+    expect(ticketAfter?.revision).toBe((ticketBefore?.revision ?? 0) + 1);
+    expect(ticketAfter?.first_ingested_at).toBe(
+      ticketBefore?.first_ingested_at,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Incremental sync — watermark filtering
+// ---------------------------------------------------------------------------
+
+describe("runIncrementalSync", () => {
+  test("skips items unchanged since the persisted watermark", async () => {
+    const client = new MockLoreVaultClient();
+    const source = new FakeSource();
+    const watermarks = new InMemoryWatermarkStore();
+
+    await runIncrementalSync(source, client, CONFIG, watermarks);
+    expect(source.ticketsServed).toBe(1);
+
+    // Second pass with the same input: watermark now equals the ticket's
+    // updatedAt, so the source returns nothing.
+    const beforeSecondTickets = source.ticketsServed;
+    await runIncrementalSync(source, client, CONFIG, watermarks);
+    expect(source.ticketsServed).toBe(beforeSecondTickets);
+  });
+});

--- a/modelguide-api/tests/unit/connectors/hubspot-manifest.test.ts
+++ b/modelguide-api/tests/unit/connectors/hubspot-manifest.test.ts
@@ -1,0 +1,124 @@
+/**
+ * HubSpot manifest snapshot test.
+ *
+ * Locks the 19-tool MCP surface plus configuration shape per HubSpot
+ * Connector Spec §3 + §5. Failing this test means the connector contract
+ * has drifted and needs explicit reconciliation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  getKnowledgeArticle,
+  listKnowledgeArticles,
+} from "@features/connectors/catalog/hubspot/handlers";
+import hubspotManifest from "@features/connectors/catalog/hubspot/index";
+
+const EXPECTED_TOOL_NAMES = [
+  // Contacts (5)
+  "Get Contact By Email",
+  "Get Contact By Phone",
+  "Search Contacts",
+  "Create Contact",
+  "Update Contact",
+  // Companies (2)
+  "Get Company",
+  "List Companies For Contact",
+  // Deals (3)
+  "List Deals For Contact",
+  "Create Deal",
+  "Update Deal Stage",
+  // Tickets (7)
+  "Get Ticket",
+  "List Tickets For Contact",
+  "Search Tickets",
+  "Create Ticket",
+  "Update Ticket",
+  "Close Ticket",
+  "Add Reply To Ticket",
+  // Engagements (2)
+  "Log Call Engagement",
+  "Create Note",
+];
+
+const CONFIRMATION_GATED_TOOLS = [
+  "Create Deal",
+  "Update Deal Stage",
+  "Close Ticket",
+];
+
+describe("HubSpot manifest", () => {
+  test("has correct slug, name, and connectorType", () => {
+    expect(hubspotManifest.slug).toBe("hubspot");
+    expect(hubspotManifest.name).toBe("HubSpot");
+    expect(hubspotManifest.connectorType).toBe("api");
+  });
+
+  test("exposes exactly 19 MCP tools", () => {
+    expect(hubspotManifest.tools).toHaveLength(19);
+  });
+
+  test("tool names match the locked spec §5 surface", () => {
+    const toolNames = hubspotManifest.tools.map((t) => t.catalog.name).sort();
+    expect(toolNames).toEqual([...EXPECTED_TOOL_NAMES].sort());
+  });
+
+  test("every tool has inputSchema, defaultRequiresConfirmation, defaultTimeoutSeconds", () => {
+    for (const tool of hubspotManifest.tools) {
+      expect(tool.catalog.name).toBeTruthy();
+      expect(tool.catalog.description).toBeTruthy();
+      expect(tool.catalog.inputSchema).toBeDefined();
+      expect((tool.catalog.inputSchema as { type?: string }).type).toBe(
+        "object",
+      );
+      expect(typeof tool.catalog.defaultRequiresConfirmation).toBe("boolean");
+      expect(typeof tool.catalog.defaultTimeoutSeconds).toBe("number");
+      expect(tool.catalog.defaultTimeoutSeconds).toBeGreaterThan(0);
+      expect(tool.handler).toBeDefined();
+      expect(typeof tool.handler).toBe("function");
+    }
+  });
+
+  test("only Create Deal, Update Deal Stage, Close Ticket default to confirm:true", () => {
+    const gated = hubspotManifest.tools
+      .filter((t) => t.catalog.defaultRequiresConfirmation)
+      .map((t) => t.catalog.name)
+      .sort();
+    expect(gated).toEqual([...CONFIRMATION_GATED_TOOLS].sort());
+  });
+
+  test("KB ingest operations exist as internal functions, not MCP tools", () => {
+    expect(typeof listKnowledgeArticles).toBe("function");
+    expect(typeof getKnowledgeArticle).toBe("function");
+    const toolNames = hubspotManifest.tools.map((t) => t.catalog.name);
+    expect(toolNames).not.toContain("List Knowledge Articles");
+    expect(toolNames).not.toContain("Get Knowledge Article");
+  });
+
+  test("configSchema requires accessToken as a secret; portal + pipeline fields are optional", () => {
+    expect(hubspotManifest.configSchema.accessToken).toBeDefined();
+    expect(hubspotManifest.configSchema.accessToken.type).toBe("secret");
+    expect(hubspotManifest.configSchema.accessToken.required).toBe(true);
+
+    expect(hubspotManifest.configSchema.portalId.required).toBe(false);
+    expect(hubspotManifest.configSchema.defaultPipelineId.required).toBe(false);
+    expect(hubspotManifest.configSchema.defaultTicketPipelineId.required).toBe(
+      false,
+    );
+  });
+
+  test("healthCheck is defined", () => {
+    expect(typeof hubspotManifest.healthCheck).toBe("function");
+  });
+
+  test("handlers gracefully return success:false when config is missing", async () => {
+    for (const tool of hubspotManifest.tools) {
+      const result = await tool.handler({
+        config: {},
+        input: {},
+        organizationId: "test-org",
+        connectorId: "test-connector",
+      });
+      expect(typeof result.success).toBe("boolean");
+    }
+  });
+});

--- a/modelguide-api/tests/unit/connectors/hubspot-mode-b-wiring.test.ts
+++ b/modelguide-api/tests/unit/connectors/hubspot-mode-b-wiring.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Mode B handler wiring tests.
+ *
+ *   - Successful HubSpot tool calls enqueue exactly one envelope per call,
+ *     with the expected event_type, canonical_object_identity, and lens hints.
+ *   - The tool response returns immediately; emission runs out-of-band.
+ *   - Failures (success: false) do NOT enqueue.
+ *   - Read-only tools never enqueue.
+ *   - Idempotent replays return was_idempotent: true on every replay; the
+ *     connector does not retry.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  addReplyToTicket,
+  closeTicket,
+  createContact,
+  createDeal,
+  createNote,
+  createTicket,
+  logCallEngagement,
+  searchContacts,
+  updateContact,
+  updateDealStage,
+  updateTicket,
+} from "@features/connectors/catalog/hubspot/handlers";
+import {
+  resetQueuesForTesting,
+  setQueueFactoryForTesting,
+} from "@features/connectors/catalog/hubspot/ingest/mode-b/emit";
+import type { ToolExecutionContext } from "@features/connectors/catalog/types";
+import { fixedRetryPolicy } from "@features/lorevault/emission";
+import { SignalEmissionQueue } from "@features/lorevault/emission";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+const BASE_CONFIG: Record<string, string> = {
+  accessToken: "pat-test",
+  portalId: "98765",
+  lorevaultKnowledgeSpaceId: FIXTURE_IDS.knowledgeSpaceId,
+  lorevaultVaultId: FIXTURE_IDS.vaultId,
+};
+
+function makeCtx(
+  input: Record<string, unknown>,
+  config = BASE_CONFIG,
+): ToolExecutionContext {
+  return {
+    config,
+    input,
+    organizationId: "org-1",
+    connectorId: "conn-1",
+  };
+}
+
+const originalFetch = globalThis.fetch;
+let client: MockLoreVaultClient;
+let queue: SignalEmissionQueue;
+
+beforeEach(() => {
+  client = new MockLoreVaultClient();
+  queue = new SignalEmissionQueue({
+    client,
+    retryPolicy: fixedRetryPolicy(0, 1),
+    sleep: async () => {},
+  });
+  setQueueFactoryForTesting(() => queue);
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  setQueueFactoryForTesting(null);
+  resetQueuesForTesting();
+  await queue.stop();
+});
+
+function mockJson(body: unknown) {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  ) as unknown as typeof fetch;
+}
+
+function mockSequence(responses: unknown[]): void {
+  const queue = [...responses];
+  globalThis.fetch = mock(() => {
+    const next = queue.shift();
+    if (next === undefined) {
+      throw new Error("mockSequence: unexpected extra fetch call");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(next), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as unknown as typeof fetch;
+}
+
+async function flush(): Promise<void> {
+  await queue.stop();
+}
+
+describe("Mode B wiring — emitting tools enqueue exactly one envelope on success", () => {
+  test("Create Contact → contact.created", async () => {
+    mockJson({ id: "c1", properties: { firstname: "Ada" } });
+    const result = await createContact(
+      makeCtx({ properties: { firstname: "Ada" } }),
+    );
+    expect(result.success).toBe(true);
+    await flush();
+    expect(client.state.emittedSignals).toHaveLength(1);
+    const env = client.state.emittedSignals[0];
+    expect(env.event_type).toBe("contact.created");
+    expect(env.canonical_object_identity.object_type).toBe("contact");
+    expect(env.canonical_object_identity.object_id).toBe("c1");
+    expect(env.declared_lens_hints).toEqual(["customer_interaction"]);
+  });
+
+  test("Update Contact → contact.updated", async () => {
+    mockJson({ id: "c1", properties: {} });
+    await updateContact(
+      makeCtx({ contactId: "c1", properties: { firstname: "Ada" } }),
+    );
+    await flush();
+    expect(client.state.emittedSignals.map((s) => s.event_type)).toEqual([
+      "contact.updated",
+    ]);
+  });
+
+  test("Create Deal → deal.created", async () => {
+    mockJson({ id: "d1", properties: { dealname: "x" } });
+    await createDeal(makeCtx({ properties: { dealname: "x" } }));
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("deal.created");
+  });
+
+  test("Update Deal Stage → deal.stage_changed", async () => {
+    mockJson({ id: "d1", properties: { dealstage: "won" } });
+    await updateDealStage(makeCtx({ dealId: "d1", stage: "won" }));
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe(
+      "deal.stage_changed",
+    );
+  });
+
+  test("Create Ticket → ticket.created", async () => {
+    mockJson({ id: "t1", properties: { subject: "S" } });
+    await createTicket(makeCtx({ properties: { subject: "S" } }));
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("ticket.created");
+  });
+
+  test("Update Ticket → ticket.updated (when no pipeline-stage change)", async () => {
+    mockJson({ id: "t1", properties: { subject: "Updated" } });
+    await updateTicket(
+      makeCtx({ ticketId: "t1", properties: { subject: "Updated" } }),
+    );
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("ticket.updated");
+  });
+
+  test("Close Ticket → ticket.closed", async () => {
+    mockSequence([
+      // resolve current pipeline for the ticket
+      { id: "t1", properties: { hs_pipeline: "p1" } },
+      // pipeline → CLOSED stage lookup
+      {
+        id: "p1",
+        label: "Service Pipeline",
+        stages: [
+          { id: "s_open", label: "Open", metadata: { ticketState: "OPEN" } },
+          {
+            id: "s_done",
+            label: "Closed",
+            metadata: { ticketState: "CLOSED" },
+          },
+        ],
+      },
+      // PATCH ticket
+      { id: "t1", properties: { hs_pipeline_stage: "s_done" } },
+    ]);
+    const result = await closeTicket(makeCtx({ ticketId: "t1" }));
+    expect(result.success).toBe(true);
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("ticket.closed");
+    expect(client.state.emittedSignals[0].entity.id).toBe("t1");
+  });
+
+  test("Add Reply To Ticket → ticket.reply_sent", async () => {
+    mockSequence([
+      // ticket properties: hs_thread_ids
+      { id: "t1", properties: { hs_thread_ids: "thr_1" } },
+      // thread read
+      {
+        id: "thr_1",
+        channelId: "1000",
+        channelAccountId: "acct_email",
+        latestMessageReceivedTimestamp: "2026-05-27T12:00:00Z",
+      },
+      // message history (one inbound)
+      {
+        results: [
+          {
+            id: "m_in",
+            type: "MESSAGE",
+            direction: "INCOMING",
+            channelId: "1000",
+            channelAccountId: "acct_email",
+            senders: [
+              { name: "Customer", deliveryIdentifier: { value: "c@x.com" } },
+            ],
+            createdAt: "2026-05-27T12:00:00Z",
+          },
+        ],
+      },
+      // POST reply
+      { id: "m_out", type: "MESSAGE" },
+    ]);
+    const result = await addReplyToTicket(
+      makeCtx({ ticketId: "t1", text: "Investigating" }),
+    );
+    expect(result.success).toBe(true);
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("ticket.reply_sent");
+    expect(client.state.emittedSignals[0].entity.id).toBe("t1");
+  });
+
+  test("Log Call Engagement → call.logged", async () => {
+    mockJson({ id: "call1", properties: {} });
+    await logCallEngagement(
+      makeCtx({ properties: { hs_call_title: "Onboarding" } }),
+    );
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("call.logged");
+  });
+
+  test("Create Note → note.created", async () => {
+    mockJson({ id: "n1", properties: {} });
+    await createNote(makeCtx({ properties: { hs_note_body: "HITL" } }));
+    await flush();
+    expect(client.state.emittedSignals[0].event_type).toBe("note.created");
+  });
+});
+
+describe("Mode B wiring — read-only tools never enqueue", () => {
+  test("Search Contacts does not enqueue", async () => {
+    mockJson({ results: [] });
+    await searchContacts(makeCtx({ query: "ada" }));
+    await flush();
+    expect(client.state.emittedSignals).toHaveLength(0);
+  });
+});
+
+describe("Mode B wiring — failure paths do not enqueue", () => {
+  test("Update Contact rejecting non-allowlisted property does not enqueue", async () => {
+    mockJson({});
+    const result = await updateContact(
+      makeCtx({
+        contactId: "c1",
+        properties: { firstname: "Ada", hs_object_source: "evil" },
+      }),
+    );
+    expect(result.success).toBe(false);
+    await flush();
+    expect(client.state.emittedSignals).toHaveLength(0);
+  });
+});
+
+describe("Mode B wiring — Mode B disabled when KS/Vault unset", () => {
+  test("Without lorevaultKnowledgeSpaceId, no enqueue happens", async () => {
+    mockJson({ id: "c1", properties: {} });
+    const factorySpy = mock(() => null);
+    setQueueFactoryForTesting(factorySpy as unknown as () => null);
+    const result = await createContact(
+      makeCtx(
+        { properties: { firstname: "Ada" } },
+        { accessToken: "pat-test", portalId: "98765" },
+      ),
+    );
+    expect(result.success).toBe(true);
+    // No queue obtained — factory not called either because gating is checked
+    // first inside emit.ts.
+    expect(client.state.emittedSignals).toHaveLength(0);
+  });
+});
+
+describe("Mode B wiring — idempotent replay", () => {
+  test("Replaying 10 envelopes with the same signal_id is acked as idempotent and not retried", async () => {
+    // Manually push 10 envelopes with the same signal_id directly into the
+    // queue (bypasses the tool layer; this isolates the queue + client).
+    await queue.start();
+    for (let i = 0; i < 10; i++) {
+      queue.enqueue({
+        signal_id: "sig_replay",
+        signal_version: "1",
+        emitted_at: "2026-05-28T00:00:00.000Z",
+        source_system: "hubspot",
+        source_instance: "98765",
+        knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+        vault_id: FIXTURE_IDS.vaultId,
+        event_type: "ticket.created",
+        entity: { type: "ticket", id: "1" },
+        actor: { type: "ai_agent", id: "conn-1" },
+        declared_lens_hints: ["operational_workflow"],
+        canonical_object_identity: {
+          tenant_id: FIXTURE_IDS.vaultId,
+          source_system: "hubspot",
+          object_type: "ticket",
+          object_id: "1",
+        },
+        payload: { snapshot: {} },
+      });
+    }
+    await queue.stop();
+
+    // The mock client records the same signal_id only once.
+    expect(client.state.emittedSignals).toHaveLength(1);
+    // Every history entry for this signal lands as delivered + was_idempotent
+    // after the first; the connector never retries.
+    const entry = queue
+      .getRecentSignals()
+      .find((e) => e.signal_id === "sig_replay");
+    expect(entry?.status).toBe("delivered");
+    expect(entry?.was_idempotent).toBe(true);
+    expect(entry?.attempts).toBe(1); // last update wins — only one in-flight at a time
+  });
+});

--- a/modelguide-api/tests/unit/lorevault/adapter-swap.test.ts
+++ b/modelguide-api/tests/unit/lorevault/adapter-swap.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Adapter swap test (Phase 0 Integration Contract §3).
+ *
+ * Asserts that:
+ *   1. MockLoreVaultClient and HttpLoreVaultClient implement the same
+ *      LoreVaultIntegrationClient interface — application code references
+ *      only the interface and cannot tell them apart.
+ *   2. Swapping the binding is structurally a single statement in
+ *      `binding.ts` — no application-code change anywhere else.
+ *   3. Method surface is identical: every method on the interface is
+ *      present on both implementations.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { LoreVaultIntegrationClient } from "@features/lorevault/client";
+import { HttpLoreVaultClient } from "@features/lorevault/http-client";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+const REQUIRED_METHODS: Array<keyof LoreVaultIntegrationClient> = [
+  "emitSignal",
+  "emitSignalsBatch",
+  "ingestDocuments",
+  "getIngestionJob",
+  "query",
+  "listNarratives",
+  "getNarrative",
+  "getNarrativeEvidence",
+  "getSignalEvidence",
+  "getEntitlements",
+  "getPacks",
+  "getHealth",
+];
+
+describe("LoreVault adapter swap", () => {
+  test("both implementations conform to LoreVaultIntegrationClient", () => {
+    const mock: LoreVaultIntegrationClient = new MockLoreVaultClient();
+    const http: LoreVaultIntegrationClient = new HttpLoreVaultClient({
+      baseUrl: "https://example.invalid",
+      apiKey: "k",
+      knowledgeSpaceId: "ks",
+    });
+    expect(mock).toBeDefined();
+    expect(http).toBeDefined();
+  });
+
+  test("every interface method exists on both implementations", () => {
+    const mock = new MockLoreVaultClient() as unknown as Record<
+      string,
+      unknown
+    >;
+    const http = new HttpLoreVaultClient({
+      baseUrl: "x",
+      apiKey: "y",
+      knowledgeSpaceId: "z",
+    }) as unknown as Record<string, unknown>;
+    for (const method of REQUIRED_METHODS) {
+      expect(typeof mock[method]).toBe("function");
+      expect(typeof http[method]).toBe("function");
+    }
+  });
+
+  test("HttpLoreVaultClient throws the expected pre-Wave-1 message on every method", async () => {
+    const http = new HttpLoreVaultClient({
+      baseUrl: "x",
+      apiKey: "y",
+      knowledgeSpaceId: "z",
+    });
+
+    const calls: Array<Promise<unknown>> = [
+      http.emitSignal({
+        signal_id: "s",
+        signal_version: "1",
+        emitted_at: "",
+        source_system: "",
+        source_instance: "",
+        knowledge_space_id: "",
+        vault_id: "",
+        event_type: "",
+        entity: { type: "ticket", id: "1" },
+        actor: { type: "ai_agent", id: "a" },
+        declared_lens_hints: [],
+        canonical_object_identity: {
+          tenant_id: "",
+          source_system: "",
+          object_type: "",
+          object_id: "",
+        },
+        payload: {},
+      }),
+      http.emitSignalsBatch([]),
+      http.ingestDocuments({
+        knowledge_space_id: "",
+        dataset_id: "",
+        documents: [],
+      }),
+      http.getIngestionJob("j"),
+      http.query({ knowledge_space_id: "", match: {}, return: {} }),
+      http.listNarratives({ knowledge_space_id: "" }),
+      http.getNarrative("n"),
+      http.getNarrativeEvidence("n"),
+      http.getSignalEvidence("s"),
+      http.getEntitlements(),
+      http.getPacks(),
+      http.getHealth(),
+    ];
+
+    for (const call of calls) {
+      let err: unknown;
+      try {
+        await call;
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeDefined();
+      expect((err as Error).message).toContain(
+        "Not implemented; bound after Wave 1 ships.",
+      );
+    }
+  });
+
+  test("swap point in binding.ts is a single `new MockLoreVaultClient` statement", () => {
+    const path = resolve(
+      import.meta.dir,
+      "../../../src/features/lorevault/binding.ts",
+    );
+    const source = readFileSync(path, "utf8");
+    const matches = source.match(/new MockLoreVaultClient\b/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(source).toContain("change this one line");
+  });
+});

--- a/modelguide-api/tests/unit/lorevault/admin-view.test.ts
+++ b/modelguide-api/tests/unit/lorevault/admin-view.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Admin "Show Recent Signals" view (spec §11 acceptance criterion).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SignalEvent } from "@features/lorevault/client";
+import {
+  SignalEmissionQueue,
+  fixedRetryPolicy,
+  getRecentSignalsView,
+} from "@features/lorevault/emission";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+function envelope(signalId: string, eventType = "ticket.created"): SignalEvent {
+  return {
+    signal_id: signalId,
+    signal_version: "1",
+    emitted_at: "2026-05-28T00:00:00.000Z",
+    source_system: "hubspot",
+    source_instance: "portal_98765",
+    knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+    vault_id: FIXTURE_IDS.vaultId,
+    event_type: eventType,
+    entity: { type: "ticket", id: "1" },
+    actor: { type: "ai_agent", id: "conn-1" },
+    declared_lens_hints: ["operational_workflow"],
+    canonical_object_identity: {
+      tenant_id: FIXTURE_IDS.vaultId,
+      source_system: "hubspot",
+      object_type: "ticket",
+      object_id: "1",
+    },
+    payload: { snapshot: {} },
+  };
+}
+
+describe("getRecentSignalsView", () => {
+  test("returns delivery status for each emitted signal, newest first, plus stats", async () => {
+    const client = new MockLoreVaultClient({
+      // Send 1 to succeed, 2 to throw once then succeed, 3 to fail every time
+      // (capped by maxAttempts) → dead-lettered.
+      emitSignalScript: [
+        null, // sig_a delivered
+        () => {
+          throw new Error("transient");
+        },
+        null, // sig_b second attempt succeeds
+        () => {
+          throw new Error("permanent");
+        },
+        () => {
+          throw new Error("permanent");
+        },
+      ],
+    });
+    const queue = new SignalEmissionQueue({
+      client,
+      retryPolicy: fixedRetryPolicy(0, 2),
+      sleep: async () => {},
+    });
+    await queue.start();
+    queue.enqueue(envelope("sig_a"));
+    queue.enqueue(envelope("sig_b"));
+    queue.enqueue(envelope("sig_c"));
+    await queue.stop();
+
+    const view = getRecentSignalsView(queue);
+    expect(view.signals).toHaveLength(3);
+    const byId = Object.fromEntries(view.signals.map((s) => [s.signal_id, s]));
+    expect(byId.sig_a.status).toBe("delivered");
+    expect(byId.sig_b.status).toBe("delivered");
+    expect(byId.sig_b.attempts).toBe(2);
+    expect(byId.sig_c.status).toBe("dead_lettered");
+    expect(byId.sig_c.attempts).toBe(2);
+
+    expect(view.stats.deadLettered).toBe(1);
+    expect(view.stats.entitlementAllowed).toBe(true);
+  });
+
+  test("limit caps the result count", async () => {
+    const client = new MockLoreVaultClient();
+    const queue = new SignalEmissionQueue({
+      client,
+      sleep: async () => {},
+    });
+    await queue.start();
+    for (let i = 0; i < 5; i++) queue.enqueue(envelope(`sig_${i}`));
+    await queue.stop();
+    expect(getRecentSignalsView(queue, 2).signals).toHaveLength(2);
+  });
+});

--- a/modelguide-api/tests/unit/lorevault/emission-queue.test.ts
+++ b/modelguide-api/tests/unit/lorevault/emission-queue.test.ts
@@ -1,0 +1,178 @@
+/**
+ * SignalEmissionQueue tests.
+ *
+ * Covers:
+ *   - happy path: enqueue → delivered, status reflected in history
+ *   - idempotent ack: was_idempotent: true logged + no retry
+ *   - retry on transient failure: 2 fails then success
+ *   - dead-letter after max attempts: 6 fails → DLQ entry
+ *   - getStats reports pending / in-flight / dead-lettered
+ *   - admin view (getRecentSignalsView) reports delivery state
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SignalEvent } from "@features/lorevault/client";
+import {
+  InMemoryDeadLetterStore,
+  SignalEmissionQueue,
+  fixedRetryPolicy,
+  getRecentSignalsView,
+} from "@features/lorevault/emission";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+function makeEnvelope(overrides: Partial<SignalEvent> = {}): SignalEvent {
+  return {
+    signal_id:
+      overrides.signal_id ?? `sig_${Math.random().toString(36).slice(2, 10)}`,
+    signal_version: "1",
+    emitted_at: "2026-05-28T00:00:00.000Z",
+    source_system: "hubspot",
+    source_instance: "portal_98765",
+    knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+    vault_id: FIXTURE_IDS.vaultId,
+    event_type: "ticket.created",
+    entity: { type: "ticket", id: "1001" },
+    actor: { type: "ai_agent", id: "conn-1" },
+    declared_lens_hints: ["operational_workflow"],
+    canonical_object_identity: {
+      tenant_id: FIXTURE_IDS.vaultId,
+      source_system: "hubspot",
+      object_type: "ticket",
+      object_id: "1001",
+    },
+    payload: { snapshot: { subject: "Test" } },
+    ...overrides,
+  };
+}
+
+const NO_SLEEP = (_ms: number) => Promise.resolve();
+
+describe("SignalEmissionQueue — happy path", () => {
+  test("envelope flows pending → in_flight → delivered", async () => {
+    const client = new MockLoreVaultClient();
+    const queue = new SignalEmissionQueue({
+      client,
+      sleep: NO_SLEEP,
+      retryPolicy: fixedRetryPolicy(0, 1),
+    });
+    await queue.start();
+
+    queue.enqueue(makeEnvelope({ signal_id: "sig_happy_1" }));
+    await queue.stop();
+
+    expect(client.state.emittedSignals.map((s) => s.signal_id)).toEqual([
+      "sig_happy_1",
+    ]);
+    const view = getRecentSignalsView(queue);
+    expect(view.signals.length).toBe(1);
+    expect(view.signals[0].status).toBe("delivered");
+    expect(view.signals[0].attempts).toBe(1);
+    expect(view.stats.deadLettered).toBe(0);
+  });
+
+  test("idempotent ack is captured (was_idempotent: true) without retry", async () => {
+    const client = new MockLoreVaultClient();
+    // Pre-seed an emission so the second delivery is idempotent.
+    await client.emitSignal(makeEnvelope({ signal_id: "sig_idem_1" }));
+
+    const queue = new SignalEmissionQueue({
+      client,
+      sleep: NO_SLEEP,
+    });
+    await queue.start();
+    queue.enqueue(makeEnvelope({ signal_id: "sig_idem_1" }));
+    await queue.stop();
+
+    const entry = queue
+      .getRecentSignals()
+      .find((e) => e.signal_id === "sig_idem_1");
+    expect(entry?.status).toBe("delivered");
+    expect(entry?.was_idempotent).toBe(true);
+    expect(entry?.attempts).toBe(1);
+  });
+});
+
+describe("SignalEmissionQueue — retry behavior", () => {
+  test("retries with backoff and ultimately succeeds after 2 transient failures", async () => {
+    const client = new MockLoreVaultClient({
+      emitSignalScript: [
+        () => {
+          throw new Error("transient: 500");
+        },
+        () => {
+          throw new Error("transient: 503");
+        },
+        null, // fall through to default success behavior
+      ],
+    });
+    const sleeps: number[] = [];
+    const queue = new SignalEmissionQueue({
+      client,
+      retryPolicy: fixedRetryPolicy(10, 6),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    await queue.start();
+    queue.enqueue(makeEnvelope({ signal_id: "sig_retry_1" }));
+    await queue.stop();
+
+    const entry = queue
+      .getRecentSignals()
+      .find((e) => e.signal_id === "sig_retry_1");
+    expect(entry?.status).toBe("delivered");
+    expect(entry?.attempts).toBe(3);
+    expect(sleeps).toEqual([10, 10]);
+    expect(client.state.emittedSignals.map((s) => s.signal_id)).toEqual([
+      "sig_retry_1",
+    ]);
+    expect(queue.getStats().deadLettered).toBe(0);
+  });
+});
+
+describe("SignalEmissionQueue — dead-letter", () => {
+  test("after maxAttempts failures the envelope lands in the dead-letter store", async () => {
+    const client = new MockLoreVaultClient({
+      emitSignalScript: Array.from({ length: 6 }, () => () => {
+        throw new Error("permanent");
+      }),
+    });
+    const dlq = new InMemoryDeadLetterStore();
+    const queue = new SignalEmissionQueue({
+      client,
+      retryPolicy: fixedRetryPolicy(0, 6),
+      deadLetterStore: dlq,
+      sleep: NO_SLEEP,
+    });
+    await queue.start();
+    queue.enqueue(makeEnvelope({ signal_id: "sig_dlq_1" }));
+    await queue.stop();
+
+    expect(dlq.size()).toBe(1);
+    const [entry] = dlq.list();
+    expect(entry.envelope.signal_id).toBe("sig_dlq_1");
+    expect(entry.attempts).toBe(6);
+    expect(entry.last_error).toContain("permanent");
+
+    const historyEntry = queue
+      .getRecentSignals()
+      .find((e) => e.signal_id === "sig_dlq_1");
+    expect(historyEntry?.status).toBe("dead_lettered");
+    expect(historyEntry?.attempts).toBe(6);
+    expect(queue.getStats().deadLettered).toBe(1);
+  });
+});
+
+describe("SignalEmissionQueue — stats", () => {
+  test("getStats reports running and entitlementAllowed after start", async () => {
+    const client = new MockLoreVaultClient();
+    const queue = new SignalEmissionQueue({ client, sleep: NO_SLEEP });
+    expect(queue.getStats().running).toBe(false);
+    await queue.start();
+    expect(queue.getStats().running).toBe(true);
+    expect(queue.getStats().entitlementAllowed).toBe(true);
+    await queue.stop();
+    expect(queue.getStats().running).toBe(false);
+  });
+});

--- a/modelguide-api/tests/unit/lorevault/entitlement-gate.test.ts
+++ b/modelguide-api/tests/unit/lorevault/entitlement-gate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Entitlement fail-fast tests (Phase 0 §1.7 + spec §11).
+ *
+ *   - Starter-tier vault: gate denies, queue refuses to start the worker.
+ *   - osi_enabled: false: gate denies.
+ *   - Enterprise + osi_enabled: gate allows.
+ *   - Gated enqueue is recorded in history as `gated` with the reason,
+ *     not delivered, not retried.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  EntitlementResponse,
+  SignalEvent,
+} from "@features/lorevault/client";
+import {
+  SignalEmissionQueue,
+  checkEntitlement,
+} from "@features/lorevault/emission";
+import {
+  FIXTURE_ENTITLEMENTS_STARTER,
+  FIXTURE_IDS,
+} from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+function makeEnvelope(): SignalEvent {
+  return {
+    signal_id: "sig_gated_1",
+    signal_version: "1",
+    emitted_at: "2026-05-28T00:00:00.000Z",
+    source_system: "hubspot",
+    source_instance: "portal_98765",
+    knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+    vault_id: FIXTURE_IDS.vaultId,
+    event_type: "ticket.created",
+    entity: { type: "ticket", id: "1" },
+    actor: { type: "ai_agent", id: "conn-1" },
+    declared_lens_hints: ["operational_workflow"],
+    canonical_object_identity: {
+      tenant_id: FIXTURE_IDS.vaultId,
+      source_system: "hubspot",
+      object_type: "ticket",
+      object_id: "1",
+    },
+    payload: { snapshot: {} },
+  };
+}
+
+describe("checkEntitlement", () => {
+  test("denies Starter tier", async () => {
+    const client = new MockLoreVaultClient({
+      entitlements: FIXTURE_ENTITLEMENTS_STARTER,
+    });
+    const verdict = await checkEntitlement(client);
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) expect(verdict.reason).toContain("Starter");
+  });
+
+  test("denies when features.osi_enabled is false even on a paid tier", async () => {
+    const denied: EntitlementResponse = {
+      vault_id: FIXTURE_IDS.vaultId,
+      knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+      tier: "pro",
+      features: { osi_enabled: false, lssr_enabled: true },
+      quotas: {
+        monthly_signal_events: { limit: 1000, used: 0 },
+        monthly_ingest_mb: { limit: 100, used: 0 },
+        monthly_query_count: { limit: 1000, used: 0 },
+      },
+    };
+    const client = new MockLoreVaultClient({ entitlements: denied });
+    const verdict = await checkEntitlement(client);
+    expect(verdict.allowed).toBe(false);
+  });
+
+  test("allows Enterprise + osi_enabled", async () => {
+    const client = new MockLoreVaultClient();
+    const verdict = await checkEntitlement(client);
+    expect(verdict.allowed).toBe(true);
+  });
+});
+
+describe("SignalEmissionQueue + Starter entitlements", () => {
+  test("Mode B refuses to start; enqueues are recorded as gated and never delivered", async () => {
+    const client = new MockLoreVaultClient({
+      entitlements: FIXTURE_ENTITLEMENTS_STARTER,
+    });
+    const queue = new SignalEmissionQueue({ client });
+
+    const verdict = await queue.start();
+    expect(verdict.allowed).toBe(false);
+    expect(queue.getStats().running).toBe(false);
+    expect(queue.isEntitled()).toBe(false);
+
+    queue.enqueue(makeEnvelope());
+    // Nothing delivered; gated history entry recorded.
+    expect(client.state.emittedSignals).toHaveLength(0);
+    const entry = queue
+      .getRecentSignals()
+      .find((e) => e.signal_id === "sig_gated_1");
+    expect(entry?.status).toBe("gated");
+    expect(entry?.last_error).toContain("Starter");
+
+    await queue.stop();
+  });
+});

--- a/modelguide-api/tests/unit/lorevault/mock-client.test.ts
+++ b/modelguide-api/tests/unit/lorevault/mock-client.test.ts
@@ -1,0 +1,138 @@
+/**
+ * MockLoreVaultClient unit tests — verifies fixture contract conformance
+ * and the idempotent upsert behavior the Mode C ingest path depends on.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { FIXTURE_IDS } from "@features/lorevault/fixtures";
+import { MockLoreVaultClient } from "@features/lorevault/mock-client";
+
+describe("MockLoreVaultClient", () => {
+  test("emitSignal is idempotent on signal_id", async () => {
+    const client = new MockLoreVaultClient();
+    const event = {
+      signal_id: "sig_001",
+      signal_version: "1" as const,
+      emitted_at: "2026-05-28T00:00:00.000Z",
+      source_system: "hubspot",
+      source_instance: "portal_98765",
+      knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+      vault_id: FIXTURE_IDS.vaultId,
+      event_type: "ticket.created",
+      entity: { type: "ticket", id: "100" },
+      actor: { type: "ai_agent" as const, id: "agent_1" },
+      declared_lens_hints: ["operational_workflow" as const],
+      canonical_object_identity: {
+        tenant_id: FIXTURE_IDS.vaultId,
+        source_system: "hubspot",
+        object_type: "ticket",
+        object_id: "100",
+      },
+      payload: { snapshot: { subject: "x" } },
+    };
+
+    const first = await client.emitSignal(event);
+    expect(first.was_idempotent).toBe(false);
+
+    const second = await client.emitSignal(event);
+    expect(second.was_idempotent).toBe(true);
+
+    expect(client.state.emittedSignals).toHaveLength(1);
+  });
+
+  test("ingestDocuments upserts on source_id (idempotent re-run)", async () => {
+    const client = new MockLoreVaultClient();
+    const payload = {
+      knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+      dataset_id: "hubspot-tickets",
+      documents: [
+        {
+          source_id: `${FIXTURE_IDS.vaultId}:hubspot:ticket:1001`,
+          title: "Ticket 1001",
+          content: "first revision",
+          metadata: {
+            source_system: "hubspot",
+            source_instance: "portal_98765",
+            entity_type: "ticket",
+            entity_id: "1001",
+            created_at: "2026-05-01T00:00:00.000Z",
+            last_modified_at: "2026-05-01T00:00:00.000Z",
+          },
+        },
+      ],
+    };
+
+    await client.ingestDocuments(payload);
+    await client.ingestDocuments({
+      ...payload,
+      documents: [{ ...payload.documents[0], content: "second revision" }],
+    });
+
+    expect(client.state.documents.size).toBe(1);
+    const stored = [...client.state.documents.values()][0];
+    expect(stored.content).toBe("second revision");
+    expect(stored.revision).toBe(2);
+  });
+
+  test("listNarratives returns fixtures keyed to FIXTURE_IDS.knowledgeSpaceId", async () => {
+    const client = new MockLoreVaultClient();
+    const empty = await client.listNarratives({
+      knowledge_space_id: "ks_unknown",
+    });
+    expect(empty.narratives).toHaveLength(0);
+
+    const all = await client.listNarratives({
+      knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+    });
+    expect(all.narratives.length).toBeGreaterThan(0);
+    for (const n of all.narratives) {
+      expect([
+        "emerging",
+        "active",
+        "deteriorating",
+        "stabilized",
+        "resolved",
+        "monitoring",
+      ]).toContain(n.lifecycle_state);
+    }
+  });
+
+  test("getPacks polarity entries use wevn_default until LSSR-010 ships", async () => {
+    const client = new MockLoreVaultClient();
+    const packs = await client.getPacks();
+    expect(packs.packs.length).toBeGreaterThan(0);
+    for (const pack of packs.packs) {
+      for (const signal of pack.signals_contributed) {
+        expect(["concern", "health"]).toContain(signal.polarity);
+        expect(signal.default_weight_source).toBe("wevn_default");
+      }
+    }
+  });
+
+  test("getEntitlements returns the expected enterprise fixture", async () => {
+    const client = new MockLoreVaultClient();
+    const ent = await client.getEntitlements();
+    expect(ent.tier).toBe("enterprise");
+    expect(ent.features.osi_enabled).toBe(true);
+  });
+
+  test("getHealth returns ok", async () => {
+    const client = new MockLoreVaultClient();
+    const health = await client.getHealth();
+    expect(health.status).toBe("ok");
+  });
+
+  test("evidence chain references use locked resolution states (live | orphaned)", async () => {
+    const client = new MockLoreVaultClient();
+    const nar = (
+      await client.listNarratives({
+        knowledge_space_id: FIXTURE_IDS.knowledgeSpaceId,
+      })
+    ).narratives[0];
+    const evidence = await client.getNarrativeEvidence(nar.narrative_id);
+    expect(evidence.evidence.length).toBeGreaterThan(0);
+    for (const ev of evidence.evidence) {
+      expect(["live", "orphaned"]).toContain(ev.status);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the Wevn build. End-to-end Mode B signal emission against MockLoreVaultClient. The wire from a state-changing connector tool call to LoreVault — through queue, retry, dead-letter, idempotency, and entitlement gate — is in place. Real HTTP transport still ships in Wave 1.

This PR stacks on #265 (Phase 1). Review independently — the queue + envelope + wiring are self-contained.

## Gates

- `make api-typecheck` ✓
- `make api-lint-check` ✓
- `make api-test-unit` ✓ — 971 pass / 0 fail (3277 expect calls), +5 new test files

## Deliverable 1 — Signal envelope construction

`catalog/hubspot/ingest/mode-b/envelopes.ts` — one builder per emitting tool. Per Phase 0 §1.1 + HubSpot spec §5:

| Tool | event_type | entity.type | declared_lens_hints |
|---|---|---|---|
| Create Contact | contact.created | contact | customer_interaction |
| Update Contact | contact.updated | contact | customer_interaction (+ revenue_intelligence when properties_changed includes `lifecyclestage`) |
| Create Deal | deal.created | deal | revenue_intelligence |
| Update Deal Stage | deal.stage_changed | deal | revenue_intelligence, operational_workflow |
| Create Ticket | ticket.created | ticket | customer_interaction, operational_workflow |
| Update Ticket | ticket.updated | ticket | operational_workflow |
| Close Ticket | ticket.closed | ticket | operational_workflow, customer_interaction |
| Add Reply To Ticket | ticket.reply_sent | ticket | customer_interaction, knowledge_integrity |
| Log Call Engagement | call.logged | engagement | customer_interaction, operational_workflow |
| Create Note | note.created | note | knowledge_integrity, operational_workflow |

**Spec count discrepancy flagged.** Spec §5 summary line says "12 signal-emitting" but the per-row table enumerates exactly 10 emitting tools. I implemented from the per-row table (the source of truth for per-tool behavior). The exit criterion "Each of the 12 signal-emitting tools..." is satisfied for the 10 the spec actually defines; if the intent was 12, the table needs to add two more rows and tell us which.

`canonical_object_identity` is derived deterministically via `deriveSourceId({tenantId, objectType, objectId})`. `signal_id` defaults to `crypto.randomUUID()`, `emitted_at` to `new Date().toISOString()`, `signal_version` is `"1"`.

## Deliverable 2 — Asynchronous emission queue (`lorevault/emission/`)

- `queue.ts` — `SignalEmissionQueue`. Tool handlers `enqueue()` and return immediately. Worker drains and calls `LoreVaultIntegrationClient.emitSignal`. One in-flight call at a time; `start()`/`stop()`/`getStats()` lifecycle.
- `retry.ts` — Spec §7.2 backoff: 1s, 5s, 30s, 60s, 240s, 300s (max 6 attempts, ~10 min). `fixedRetryPolicy` exposed for tests.
- `dead-letter.ts` — `InMemoryDeadLetterStore`. Production wires a Drizzle table (out of scope per dispatch).
- `history.ts` — bounded ring buffer (default 100) backing the admin view.
- `entitlement-gate.ts` — one-time `getEntitlements()` check at queue start. Denies Starter-tier or `osi_enabled: false`. Verdict cached for the queue's lifetime.

## Deliverable 3 — Handler wiring

- `mode-b/emit.ts` — `withSignalEmission(toolName, inner)` HOC. After the inner handler returns `success: true`, builds the envelope and enqueues. Emission errors are caught + logged, never fail the tool response. Per-connector queue registry caches one queue per `connectorId`.
- 10 emitting handlers in `handlers.ts` renamed to `*Impl` and re-exported wrapped with the HOC. Read-only handlers and the 2 internal KB ops are untouched.
- 3 new manifest config fields: `lorevaultKnowledgeSpaceId`, `lorevaultVaultId`, `signalEmissionEnabled` (default true when KS+Vault are set).
- When KS or Vault is unset, Mode B is silently disabled. Mode A + Mode C unaffected.

## Deliverable 4 — Entitlement fail-fast

- `MockLoreVaultClient` now accepts an `entitlements` constructor override.
- `FIXTURE_ENTITLEMENTS_STARTER` added: Starter tier, `osi_enabled: false`.
- Queue refuses to start; subsequent enqueues are silently dropped but appear in the admin view as status `gated` with the reason. Mode A and Mode C are unaffected — only Mode B is gated.

## Deliverable 5 — Admin view

- `getRecentSignalsView(queue, limit?)` (internal — NOT MCP-exposed) returns the most recent N (default 100) signals with delivery status: `pending | in_flight | delivered (was_idempotent) | retrying | dead_lettered | gated`, plus queue stats (pending, inFlight, deadLettered, entitlementAllowed, running).

## Tests

All 5 exit criteria covered:

- **Each of the emitting tools produces exactly one envelope** — `hubspot-mode-b-wiring.test.ts` exercises all 10 emitting handlers end-to-end through the wrapped exports against a controlled queue. Close Ticket and Add Reply To Ticket are tested through their multi-step HubSpot sequences.
- **Idempotency** — `hubspot-mode-b-wiring.test.ts` replays 10 envelopes with the same `signal_id`; mock records only one; connector does not retry.
- **Retry** — `emission-queue.test.ts` scripts the client to fail twice then succeed; verifies delivery on attempt 3 with the correct backoff sequence.
- **Dead-letter** — `emission-queue.test.ts` scripts 6 failures; envelope lands in DLQ; history reflects `dead_lettered`.
- **Entitlement fail-fast** — `entitlement-gate.test.ts` covers Starter tier and `osi_enabled: false` paths; queue refuses to start; gated enqueues recorded but never delivered.
- **Admin view** — `admin-view.test.ts` covers mixed delivery statuses, stats, and limit.

## Spec discrepancy surfaced

`HubSpot Connector Spec §5` summary says "12 signal-emitting" but the per-row table I implemented from enumerates 10. This PR implements 10. Please confirm intent — if you want 12, the table needs the missing rows.

## Out of scope (per dispatch)

- Real HTTP transport to LoreVault (Wave 1 still pending).
- Mode D webhook capture.
- Persistent dead-letter store (InMemory only for now).
- UI for the admin view (method-level helper only).

## Test plan

- [ ] `make api-typecheck`
- [ ] `make api-lint-check`
- [ ] `make api-test-unit`
- [ ] Manual: create a Mode B-configured HubSpot connector, fire any emitting tool, confirm the admin view records the envelope as `delivered` with `was_idempotent: false`, then re-fire the same tool with the same input + same signal_id (test seam) and confirm `was_idempotent: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
