### PR TITLE
feat(agents): LiveKit prototype agent fetches compiled prompt at session start (ADR-015)

### DIFF
--- a/docs/decisions/015-livekit-runtime-prompt-fetch.md
+++ b/docs/decisions/015-livekit-runtime-prompt-fetch.md
@@ -1,0 +1,192 @@
+# ADR-015: LiveKit Voice Worker Fetches Compiled Prompt at Session Start
+
+**Status:** Accepted
+
+## Context
+
+ADR-014 wired up the dashboard's **Talk to agent** button. The button mints a
+LiveKit token, dispatches a worker, and the operator joins via WebRTC. What it
+doesn't do is propagate prompt changes: the BuildPro example agent
+(`examples/agents/livekit-agent/`) bakes its prompt into Python files at
+worker-image-build time, so iterating on the prompt means a redeploy.
+
+ADR-014 explicitly rejected one workaround: **shipping the prompt as a
+`prompt_override` field on the dispatch metadata**. The grounds: it creates a
+"works in voice-test, breaks in prod" failure mode because the worker's profile
+(tools + pipeline + persona) becomes inconsistent with the prompt the operator
+just tested.
+
+This ADR proposes the alternative the dashboard team actually wants — change
+the prompt in the UI, click Compile, click Talk, and the very next call uses
+the freshest compiled prompt without a worker redeploy and without breaking
+the property ADR-014 was protecting.
+
+## Decision
+
+Add `GET /api/agents/me`. Authenticated by the agent's API key (`mgk_...`),
+so the worker authenticates as the agent record it's serving and gets back:
+
+```jsonc
+{
+  "id": "...",
+  "slug": "...",
+  "name": "...",
+  "modality": "voice",
+  "modelFamily": "gpt",
+  "agentPlatform": "livekit",
+  "isActive": true,
+  "promptConfig": { "persona": "..." },
+  "metadata": { "livekit": { "url": "...", "agentName": "..." } },
+  "compiledInstructions": "...",     // ← latest compiled prompt
+  "compiledAt": "2026-02-01T...",
+  "updatedAt": "2026-02-01T..."
+}
+```
+
+Add a new prototype LiveKit agent (`examples/agents/livekit-prototype-agent/`)
+that hits this endpoint at session start and uses `compiledInstructions` as
+the system prompt. Fallback chain: compiled prompt → `promptConfig.persona` →
+generic identity string. The prototype is single-provider (OpenAI Realtime),
+no tools, ~150 LOC — its job is to demonstrate the freshness loop, not to be a
+production agent.
+
+### Why pull-at-session-start, not push-via-metadata
+
+| Aspect | Push (rejected by ADR-014) | Pull at session start (this ADR) |
+|---|---|---|
+| Where the worker reads the prompt | Dispatch metadata blob | REST call to `/api/agents/me` |
+| Operator clicks Compile, then Talk → what runs? | The just-compiled prompt (because the API copies it into metadata at dispatch time) | The just-compiled prompt (because the API persisted it before dispatch + the worker reads on connect) |
+| Operator clicks Talk twice in a row without recompiling → what runs? | Identical, because metadata is the source of truth | Identical, because `compiledInstructions` hasn't changed |
+| Operator edits the prompt directly in the DB → what runs? | Stale (cached on the worker until next dispatch) | Fresh on the next call (worker re-reads every session) |
+| Wire size pressure | Prompt-shaped (10–50KB) added to every dispatch metadata blob | Zero — metadata stays small |
+| Failure mode if the prompt source is unreachable | Dispatch fails → user sees an error before the room | Worker fetches at connect → can fall back to `persona` or generic; never blocks the call |
+| Tools / pipeline / persona stay consistent with the prompt? | No — that's ADR-014's "works in voice-test, breaks in prod" concern | Yes — only the *prompt text* changes; tools and pipeline are still defined by what's deployed |
+
+The "works in voice-test, breaks in prod" concern only applies when *more than
+the prompt text* differs between the test and prod environment. The pull model
+fetches the same `compiledInstructions` value from the same row in the same
+database whether the call came from the dashboard's voice-test or from a real
+inbound call. There's nothing for the two to diverge on.
+
+### Why a separate endpoint, not `GET /api/agents/:id`
+
+Two reasons:
+
+1. **Auth shape.** `GET /api/agents/:id` is user-JWT-authenticated. The voice
+   worker only has an agent API key. Forking an agent-authenticated route
+   keeps the user-facing endpoint's permission model unchanged.
+2. **Wire format.** The user-facing endpoint exposes `integrationUrls`,
+   `secrets` ref map, ElevenLabs flags, `evalSuiteCount`, etc. — none of which
+   the worker needs and several of which (`secrets`) should never travel over
+   an agent-auth channel. The runtime-config endpoint returns the minimum the
+   worker needs and nothing else.
+
+### Why a separate prototype agent, not modifying the BuildPro example
+
+The BuildPro example is the reference implementation for *production* features
+— SIP, Langfuse tracing, 11 MCP tools, hangup state machine, transcript
+posting. Bolting runtime-prompt-fetch onto it would either obscure the
+demonstration (the freshness loop drowns in the SIP setup) or fork it (now
+there are two versions of BuildPro that disagree on prompt source). A
+single-purpose prototype keeps the demonstration clean and lets us evolve the
+two examples independently. When operators want both runtime-prompt-fetch
+*and* tools, they copy from both — the README spells that out.
+
+### Endpoint shape
+
+`GET /api/agents/me` — middleware: `requireAgent()`.
+
+| Status | Condition |
+|---|---|
+| 200 | success, returns `AgentRuntimeConfig` |
+| 401 | no API key, or API key isn't agent-scoped, or agent inactive |
+| 404 | agent record was deleted between API key issue and call (unreachable in practice; defence in depth) |
+
+The endpoint is registered *before* `GET /api/agents/:id` in `agents.routes.ts`
+so the literal `/me` wins routing. Hono's router would also reject `/me` as a
+non-UUID via the `:id` param's Zod schema, but explicit ordering is the safer
+contract.
+
+### Security
+
+- **No secrets in the response.** Helper strips `secrets` (ref map) and
+  `metadata.webhook_hmac_secret` defensively. Pinned by
+  `tests/unit/agents/agent-runtime-config.test.ts`.
+- **Agent API key auth + RLS.** `getAgentRuntimeConfig` runs inside `forOrg`,
+  so even if a malformed API key ever crossed orgs (it shouldn't, by
+  construction), Postgres-level RLS would 404 the lookup.
+- **No `slug` rewrite.** The endpoint echoes `agent.slug` verbatim — same
+  contract as the voice-test dispatch metadata (ADR-014). A worker that wants
+  to defensively assert "I'm running for the slug I was dispatched as" can
+  compare `cfg.slug` against `dispatch.agent_slug`.
+
+## Alternatives Considered
+
+**Re-open ADR-014's `prompt_override` proposal.** Rejected — its consequences
+section spelled out the exact reason: the prompt becomes inconsistent with the
+worker's tool set, so a passing voice-test no longer guarantees production
+behaves the same. The pull model doesn't have this property: the same
+`compiledInstructions` runs in every dispatch.
+
+**MCP resource (`GET resources/agent_config`).** Rejected for the prototype.
+The BuildPro example already opens an MCP connection for tool execution, but
+introducing a runtime-config resource over MCP couples prompt freshness to
+the MCP transport's lifecycle (initialize, resources/read, etc.) and adds a
+spec-layer schema for a single payload. A REST call is simpler and reuses the
+auth + RLS we already have. If/when the prototype graduates to tools, we can
+revisit whether to fold runtime-config into the MCP resources catalog.
+
+**Worker-side polling.** Rejected. Polling either races with a Compile-then-Talk
+(stale prompt for the first call after a recompile) or wastes API quota when
+nothing changes. Fetch-on-connect is the simplest version of "freshness only
+where it matters."
+
+**Push from API to all live workers on Compile.** Rejected — LiveKit Cloud
+workers don't expose a control-plane API for that, and even if they did, the
+prototype already gets fresh-per-call which is sufficient. There's no need
+for hot-reload mid-call.
+
+## Consequences
+
+- **The Compile-then-Talk loop is fast.** Operator edits the prompt → clicks
+  Compile (~1s) → clicks Talk to agent (~2s dispatch + connect) → talks to the
+  agent running the just-compiled prompt. No worker rebuild, no LiveKit Cloud
+  redeploy, no waiting for a CI build.
+
+- **A new contract spans the TypeScript/Python boundary.** The wire format of
+  `GET /api/agents/me` is consumed by code in two languages with no shared
+  type system. Both sides pin the contract:
+
+  - TS: `tests/unit/agents/agent-runtime-config.test.ts` (formatter shape)
+  - TS: `tests/integration/agents.test.ts` (HTTP wire contract)
+  - Python: `tests/test_runtime_config.py` (parser + fallback chain)
+  - Python: `tests/test_mg_client.py` (REST headers/paths)
+
+  If either side drops a field, the matching test on the opposite side fails.
+
+- **The prototype is the simplest possible agent.** No tools, no SIP, no
+  Langfuse, no transcript posting. It serves one purpose: prove the freshness
+  loop. The BuildPro example stays as the production reference. The README
+  documents how to combine them.
+
+- **`compiledInstructions` is now a public surface.** Anything that mutates it
+  has to consider: this string ends up as the worker's system prompt on the
+  next dispatched call. The compiler service already treats it that way, but
+  any future code path that writes to the column (data backfill, manual
+  override, SOP republish) needs the same scrutiny.
+
+- **Agent-deactivation has teeth.** The endpoint runs through `requireAgent()`,
+  which 401s when `agent.isActive === false`. If an operator deactivates an
+  agent mid-call to "kill" a runaway worker, the *next* call's runtime-config
+  fetch fails and the worker can't boot — useful kill switch.
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls — original dispatch pattern.
+- ADR-014: Browser Voice Testing — the click-Talk dispatch flow this ADR
+  extends, and the source of the rejected push-via-metadata alternative this
+  ADR replaces.
+- `examples/agents/livekit-prototype-agent/` — the prototype agent that
+  consumes this endpoint.
+- `examples/agents/livekit-agent/` — the BuildPro reference agent, still the
+  template for production-shaped agents with tools.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing via LiveKit Dispatch | Accepted |
+| [015-livekit-runtime-prompt-fetch.md](015-livekit-runtime-prompt-fetch.md) | LiveKit Voice Worker Fetches Compiled Prompt at Session Start | Accepted |

--- a/examples/agents/livekit-prototype-agent/.dockerignore
+++ b/examples/agents/livekit-prototype-agent/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+tests/
+livekit.toml
+README.md

--- a/examples/agents/livekit-prototype-agent/.env.example
+++ b/examples/agents/livekit-prototype-agent/.env.example
@@ -1,0 +1,19 @@
+# --- LiveKit ----------------------------------------------------------------
+# Locally: dev keys printed by `livekit-server --dev` (devkey / secret).
+# Cloud:   injected automatically by LiveKit Cloud, leave these unset.
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# Worker name — must match what the MG agent record's metadata.livekit.agentName
+# field points to so dispatch lands here.
+AGENT_NAME=modelguide-prototype
+
+# --- OpenAI Realtime --------------------------------------------------------
+OPENAI_API_KEY=sk-...
+LLM_MODEL=gpt-4o-realtime-preview
+
+# --- ModelGuide -------------------------------------------------------------
+# Same MG API key the BuildPro example uses — mgk_xxx, scoped to the agent.
+MODELGUIDE_API_URL=http://localhost:3000
+MODELGUIDE_API_KEY=mgk_your_agent_api_key

--- a/examples/agents/livekit-prototype-agent/.gitignore
+++ b/examples/agents/livekit-prototype-agent/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+livekit.toml

--- a/examples/agents/livekit-prototype-agent/Dockerfile
+++ b/examples/agents/livekit-prototype-agent/Dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Download Silero VAD at build time so the first call doesn't pay the cost.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/agent.py", "start"]

--- a/examples/agents/livekit-prototype-agent/README.md
+++ b/examples/agents/livekit-prototype-agent/README.md
@@ -1,0 +1,156 @@
+# LiveKit Prototype Agent
+
+A minimal LiveKit voice agent that pulls its system prompt from ModelGuide at
+session start. Voiceblox-inspired single-file scaffold — the whole worker is
+~150 lines of Python.
+
+## What this proves
+
+The dashboard already has a one-click **Talk to agent** button and a one-click
+**Compile** button. What it didn't have until now is a worker that respects the
+*latest* compiled prompt. Edit prompt → click Compile → click Talk → the very
+next call uses the freshly compiled prompt. No redeploy, no sync step.
+
+```text
+┌──────────────────────────┐         ┌────────────────────────┐
+│  modelguide-ui           │         │  modelguide-api        │
+│   Compile button         │ ──────► │  POST /agents/:id/     │
+│                          │         │       compile          │
+│   Talk to agent button   │ ──────► │  POST /agents/:id/     │
+│                          │         │       voice-test-token │
+└──────────────────────────┘         └──────────┬─────────────┘
+                                                │ dispatch (LiveKit)
+                                                ▼
+                                  ┌──────────────────────────────┐
+                                  │  livekit-prototype-agent     │
+                                  │   ① parse dispatch metadata  │
+                                  │   ② GET /api/agents/me       │  ◄── pulls latest
+                                  │   ③ start AgentSession with  │      compiledInstructions
+                                  │      compiledInstructions    │
+                                  └──────────────────────────────┘
+```
+
+The pull is at **session start**, not at worker boot — so a prompt edited
+between calls takes effect on the next call.
+
+## How is this different from `examples/agents/livekit-agent/` (BuildPro Sam)?
+
+| Aspect | BuildPro Sam | Prototype |
+|---|---|---|
+| Prompt source | Python files in `prompts/` | `GET /api/agents/me` at session start |
+| Pipeline | Deepgram STT → OpenAI LLM → ElevenLabs TTS | OpenAI Realtime (one provider) |
+| Tools | 11 MCP-backed tools | None — conversational only |
+| SIP support | Inbound + outbound | Inbound only (no Twilio integration) |
+| Tracing | Langfuse | None |
+| Lines of Python | ~700 | ~150 |
+
+The BuildPro example is the reference implementation for a *production* agent
+with tools. The prototype is the reference implementation for the **prompt
+freshness loop**. Copy from BuildPro if you need tools / SIP / tracing.
+
+See [ADR-015](../../../docs/decisions/015-livekit-runtime-prompt-fetch.md) for
+the design rationale and the tradeoff against ADR-014.
+
+## Prerequisites
+
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
+- An OpenAI API key with Realtime API access
+- A running ModelGuide API with an active agent + LiveKit configured
+- For local voice dev: LiveKit server (`brew install livekit livekit-cli` or
+  Docker — see the BuildPro README)
+
+## Local development
+
+```bash
+cd examples/agents/livekit-prototype-agent
+
+# 1. Install deps + download VAD
+uv venv && uv pip install -e .
+
+# 2. Configure
+cp .env.example .env
+# Edit .env — set OPENAI_API_KEY, MODELGUIDE_API_URL, MODELGUIDE_API_KEY
+```
+
+Two terminals:
+
+```bash
+# Terminal 1 — LiveKit server (dev mode)
+livekit-server --dev
+
+# Terminal 2 — Prototype agent
+source .venv/bin/activate
+python src/agent.py dev
+```
+
+Then click **Talk to agent** in the dashboard, and the prototype joins the
+room. The prompt the agent uses is whatever appeared in the dashboard's
+"Compiled Prompt" card the last time you clicked Compile.
+
+### Console mode (no LiveKit, no mic — text only)
+
+```bash
+python src/agent.py console
+```
+
+Great for quickly verifying a new prompt without setting up audio.
+
+## Running the tests
+
+```bash
+uv pip install -e ".[test]"
+python -m pytest -v
+```
+
+Tests cover three layers:
+
+| File | What it pins |
+|---|---|
+| `tests/test_runtime_config.py` | Parser + fallback chain (compiled → persona → generic) |
+| `tests/test_dispatch.py` | Dispatch-metadata contract with the API |
+| `tests/test_mg_client.py` | REST client headers/paths (mocked HTTP via respx) |
+
+The wire-format contract with `GET /api/agents/me` is double-locked by
+`modelguide-api/tests/unit/agents/agent-runtime-config.test.ts` on the TypeScript
+side. If either side changes a field name without the other, the matching test
+on the opposite side fails — that's the type system across the language
+boundary.
+
+## Cloud deploy
+
+Same pattern as the BuildPro example — see [its DEPLOY.md](../livekit-agent/DEPLOY.md)
+for the full guide. Short version:
+
+```bash
+lk cloud auth login
+cd examples/agents/livekit-prototype-agent
+
+lk agent update-secrets \
+  OPENAI_API_KEY=sk-... \
+  LLM_MODEL=gpt-4o-realtime-preview \
+  MODELGUIDE_API_URL=https://your-api.up.railway.app \
+  MODELGUIDE_API_KEY=mgk_your_agent_key \
+  AGENT_NAME=modelguide-prototype
+
+lk agent create --region us-east -y
+```
+
+Then in the dashboard: open the agent → **LiveKit** card → set **Agent Name**
+to `modelguide-prototype` (matching the `AGENT_NAME` secret above).
+
+## Graduating to tools
+
+When the prototype proves out and you want MCP-backed tools, copy from the
+BuildPro example:
+
+1. Copy `mcp_agent.py` and the MCP client bits from
+   `examples/agents/livekit-agent/src/mg_client.py`.
+2. Subclass `MCPAgent` instead of using `Agent` directly.
+3. Add `@function_tool` methods on your subclass.
+4. Make sure your agent's MG record has the connector tools assigned in the
+   dashboard so they show up via MCP.
+
+The runtime-config fetch from this prototype stays — the worker still pulls
+the latest `compiledInstructions` at session start. The compiled prompt
+includes the tool descriptions, so a freshly compiled prompt + a redeploy of
+the tools layer is the iteration loop for full-featured agents.

--- a/examples/agents/livekit-prototype-agent/pyproject.toml
+++ b/examples/agents/livekit-prototype-agent/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "livekit-prototype-agent"
+version = "0.1.0"
+description = "Minimal LiveKit voice agent that pulls its compiled prompt from ModelGuide at session start"
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/examples/agents/livekit-prototype-agent/src/agent.py
+++ b/examples/agents/livekit-prototype-agent/src/agent.py
@@ -1,0 +1,148 @@
+"""LiveKit prototype voice agent.
+
+Voiceblox-inspired minimal agent. One job: prove that the dashboard's
+click-Compile → click-Talk loop can drive what the agent actually says,
+without redeploying.
+
+Entry point lifecycle (each dispatched call):
+
+  1. Parse dispatch metadata (mode, agentName slug, session_id).
+  2. ``GET /api/agents/me`` → latest compiled prompt + persona.
+  3. Reuse the session ID from voice-test dispatch, or open a new one.
+  4. Start an OpenAI Realtime AgentSession with the compiled prompt.
+  5. On disconnect, mark the session completed.
+
+No MCP / tools yet — the prototype is conversational only. See the README
+for how to graduate to the full BuildPro example with tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from livekit import agents, rtc
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import openai, silero
+
+import config
+import mg_client
+from dispatch import parse_dispatch_metadata
+from runtime_config import build_session_instructions
+
+VERSION = "0.1.0"
+
+logging.basicConfig(
+    level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("prototype-agent")
+
+
+def _identifier_for_call(
+    participant: rtc.RemoteParticipant, dispatched_user: str | None
+) -> str:
+    """Pick the user identifier we'll attribute the session to.
+
+    Priority: dispatch metadata (voice-test sets caller email) → SIP phone
+    number → participant identity → generic fallback.
+    """
+    if dispatched_user:
+        return dispatched_user
+    attrs = participant.attributes or {}
+    sip_phone = attrs.get("sip.phoneNumber")
+    if sip_phone:
+        return sip_phone
+    return participant.identity or "voice-caller"
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    config.validate()
+    logger.info(
+        "%s v%s entrypoint — room=%s",
+        config.AGENT_NAME,
+        VERSION,
+        ctx.room.name,
+    )
+
+    dispatch = parse_dispatch_metadata(ctx.job.metadata)
+    logger.info(
+        "Dispatch metadata: mode=%s slug=%s session=%s",
+        dispatch.mode,
+        dispatch.agent_slug,
+        dispatch.session_id,
+    )
+
+    await ctx.connect()
+
+    # Fetch the latest compiled prompt and wait for the caller in parallel.
+    # If the runtime-config call fails we can't proceed — there's nothing to
+    # say. Let the worker crash so LiveKit retries with a fresh dispatch.
+    cfg, participant = await asyncio.gather(
+        mg_client.fetch_runtime_config(),
+        ctx.wait_for_participant(),
+    )
+
+    user_identifier = _identifier_for_call(participant, dispatch.user_identifier)
+
+    # Reuse the API-side session ID for voice-test dispatches so the
+    # transcript / analytics row already created on the API matches up.
+    # Otherwise open a fresh session here.
+    session_id = dispatch.session_id
+    if not session_id:
+        try:
+            session_id = await mg_client.create_session(user_identifier)
+        except Exception:
+            logger.exception(
+                "Failed to create ModelGuide session — running without tracking"
+            )
+
+    instructions = build_session_instructions(cfg)
+    logger.info(
+        "Booting agent slug=%s session=%s prompt_len=%d",
+        cfg.slug,
+        session_id,
+        len(instructions),
+    )
+
+    # OpenAI Realtime keeps the prototype to a single provider (STT + LLM +
+    # TTS in one round trip). Swap to the STT/LLM/TTS pipeline used by the
+    # BuildPro example agent (../livekit-agent/src/providers.py) if you need
+    # Deepgram or ElevenLabs.
+    realtime = openai.realtime.RealtimeModel(
+        model=config.LLM_MODEL,
+        api_key=config.OPENAI_API_KEY,
+    )
+
+    session = AgentSession(
+        llm=realtime,
+        vad=silero.VAD.load(),
+    )
+
+    session_done = asyncio.Event()
+
+    @session.on("close")
+    def _on_close() -> None:
+        session_done.set()
+
+    @ctx.room.on("disconnected")
+    def _on_disconnected() -> None:
+        session_done.set()
+
+    await session.start(room=ctx.room, agent=Agent(instructions=instructions))
+    await session.say(f"Hi, this is {cfg.name}. How can I help?")
+
+    try:
+        await session_done.wait()
+    finally:
+        if session_id:
+            await mg_client.complete_session(session_id, status="completed")
+        await mg_client.close_http_client()
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-prototype-agent/src/config.py
+++ b/examples/agents/livekit-prototype-agent/src/config.py
@@ -1,0 +1,56 @@
+"""Environment variable loading for the LiveKit prototype agent.
+
+Only three variables are required. Everything else (LiveKit URL/keys, model,
+voice, etc.) is injected by LiveKit Cloud or carried through dispatch metadata
+— the prototype's whole point is that the *prompt* lives in ModelGuide, not in
+config.
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+# Read at import time so WorkerOptions can use AGENT_NAME before validate().
+AGENT_NAME: str = os.getenv("AGENT_NAME", "modelguide-prototype")
+
+# Set by validate() at entrypoint time.
+OPENAI_API_KEY: str = ""
+LLM_MODEL: str = "gpt-4o-realtime-preview"
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+
+REQUIRED_VARS = ["OPENAI_API_KEY", "MODELGUIDE_API_URL", "MODELGUIDE_API_KEY"]
+
+_validated = False
+
+
+def validate() -> None:
+    """Populate module-level constants from os.environ. Idempotent."""
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    g = globals()
+    g.update(
+        {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4o-realtime-preview"),
+            "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+            "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+        }
+    )
+
+    _validated = True

--- a/examples/agents/livekit-prototype-agent/src/dispatch.py
+++ b/examples/agents/livekit-prototype-agent/src/dispatch.py
@@ -1,0 +1,50 @@
+"""Parser for the LiveKit dispatch metadata blob.
+
+The ModelGuide API stuffs a JSON object into ``ctx.job.metadata`` when it
+dispatches a worker. We need a tiny, defensive parser:
+
+- Voice-test calls carry ``{mode: "voice-test", agentName, session_id, …}``
+- Outbound calls carry ``{mode: "outbound", phone_number, …}``
+- Inbound / WebRTC calls without a dispatch can have empty metadata
+
+Producers live in ``modelguide-api/src/features/agents/agents.service.ts``
+(``buildVoiceTestDispatchMetadata`` / ``buildOutboundDispatchMetadata``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DispatchMeta:
+    mode: str | None
+    agent_slug: str | None
+    session_id: str | None
+    user_identifier: str | None
+    phone_number: str | None
+
+
+def parse_dispatch_metadata(raw: str | None) -> DispatchMeta:
+    if not raw:
+        return DispatchMeta(None, None, None, None, None)
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        # Defence in depth — only the API writes this blob, but a malformed
+        # value shouldn't crash the worker before the LLM gets a chance to
+        # greet the caller.
+        return DispatchMeta(None, None, None, None, None)
+
+    if not isinstance(data, dict):
+        return DispatchMeta(None, None, None, None, None)
+
+    return DispatchMeta(
+        mode=data.get("mode"),
+        agent_slug=data.get("agentName"),
+        session_id=data.get("session_id"),
+        user_identifier=data.get("user_identifier"),
+        phone_number=data.get("phone_number"),
+    )

--- a/examples/agents/livekit-prototype-agent/src/mg_client.py
+++ b/examples/agents/livekit-prototype-agent/src/mg_client.py
@@ -1,0 +1,107 @@
+"""Minimal ModelGuide REST client — just what the prototype needs.
+
+The full BuildPro example agent (../livekit-agent/src/mg_client.py) adds an
+MCP transport on top of REST. The prototype intentionally skips MCP — its
+only job is to demonstrate the fetch-prompt-at-session-start pattern, so it
+sticks to two REST endpoints:
+
+  GET  /api/agents/me   — fetch the calling agent's runtime config
+  POST /api/sessions    — create a session for the call
+  PATCH /api/sessions/:id — mark the session completed/abandoned
+
+If/when tools are added to the prototype, copy the MCP machinery from
+``examples/agents/livekit-agent/src/mg_client.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+import config
+from runtime_config import RuntimeConfig, parse_runtime_config
+
+logger = logging.getLogger("mg_client")
+
+_http: httpx.AsyncClient | None = None
+
+
+def _client() -> httpx.AsyncClient:
+    """Lazy shared httpx.AsyncClient — one TCP pool for the call's lifetime.
+
+    Calls ``config.validate()`` on first use so the module-level URL/key
+    constants are populated. Safe for tests that import mg_client without
+    going through the agent entrypoint.
+    """
+    global _http
+    if _http is None or _http.is_closed:
+        config.validate()
+        _http = httpx.AsyncClient(
+            base_url=config.MODELGUIDE_API_URL,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {config.MODELGUIDE_API_KEY}",
+            },
+            timeout=15.0,
+        )
+    return _http
+
+
+async def close_http_client() -> None:
+    """Close the pooled client. Call during worker shutdown."""
+    global _http
+    if _http and not _http.is_closed:
+        await _http.aclose()
+        _http = None
+
+
+async def fetch_runtime_config() -> RuntimeConfig:
+    """Pull the calling agent's runtime config from ModelGuide.
+
+    This is the click-Compile-then-Talk freshness path: each call hits a
+    fresh row, so editing the prompt in the dashboard takes effect on the
+    *next* dispatched call without redeploying the worker.
+    """
+    res = await _client().get("/api/agents/me")
+    res.raise_for_status()
+    cfg = parse_runtime_config(res.json())
+    logger.info(
+        "Fetched runtime config: slug=%s compiled=%s",
+        cfg.slug,
+        bool(cfg.compiled_instructions),
+    )
+    return cfg
+
+
+async def create_session(user_identifier: str) -> str:
+    """Create a ModelGuide session. Returns the session ID."""
+    res = await _client().post(
+        "/api/sessions",
+        json={
+            "channelType": "voice",
+            "userIdentifier": user_identifier,
+        },
+    )
+    res.raise_for_status()
+    session_id: str = res.json()["id"]
+    logger.info("Session created: %s", session_id)
+    return session_id
+
+
+async def complete_session(session_id: str, status: str = "completed") -> None:
+    """Mark a session as completed/abandoned. Errors logged, never raised."""
+    try:
+        res = await _client().patch(
+            f"/api/sessions/{session_id}",
+            json={"status": status},
+        )
+        if not res.is_success:
+            logger.warning(
+                "Failed to complete session %s (%s): %s",
+                session_id,
+                res.status_code,
+                res.text,
+            )
+    except Exception:
+        logger.exception("Error completing session %s", session_id)

--- a/examples/agents/livekit-prototype-agent/src/runtime_config.py
+++ b/examples/agents/livekit-prototype-agent/src/runtime_config.py
@@ -1,0 +1,82 @@
+"""Parser + fallbacks for `GET /api/agents/me`.
+
+Pure module — no I/O. The transport layer lives in `mg_client.py`.
+
+The wire shape is locked by the TypeScript helper
+`formatAgentRuntimeConfig` in
+`modelguide-api/src/features/agents/agents.service.ts`. If you change a
+field name on this side, change it on the other side (and vice versa) —
+there's no shared type system across the boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    id: str
+    slug: str
+    name: str
+    modality: str
+    model_family: str
+    agent_platform: str
+    is_active: bool
+    persona: str
+    compiled_instructions: str | None
+    compiled_at: str | None
+
+
+def parse_runtime_config(payload: dict[str, Any]) -> RuntimeConfig:
+    """Convert a `/api/agents/me` response into a typed RuntimeConfig.
+
+    Pulls `persona` out of `promptConfig` so callers don't dig through nested
+    dicts. Everything else is a 1:1 mapping with the wire field.
+    """
+    prompt_config = payload.get("promptConfig") or {}
+    persona = prompt_config.get("persona") or ""
+
+    return RuntimeConfig(
+        id=payload["id"],
+        slug=payload["slug"],
+        name=payload["name"],
+        modality=payload["modality"],
+        model_family=payload["modelFamily"],
+        agent_platform=payload["agentPlatform"],
+        is_active=bool(payload.get("isActive", True)),
+        persona=persona,
+        compiled_instructions=payload.get("compiledInstructions"),
+        compiled_at=payload.get("compiledAt"),
+    )
+
+
+def build_session_instructions(cfg: RuntimeConfig) -> str:
+    """Pick the right text to seed the LLM with as the system prompt.
+
+    Priority:
+      1. ``compiledInstructions`` — what the operator clicked Compile on.
+      2. ``promptConfig.persona`` — soft fallback if nothing is compiled yet
+         (still useful during initial bring-up).
+      3. Generic identity blurb so the agent doesn't boot mute.
+
+    The fallback chain is deliberate so the worker can always boot something
+    coherent — silence is a worse failure mode than a generic greeting.
+    """
+    if cfg.compiled_instructions and cfg.compiled_instructions.strip():
+        return cfg.compiled_instructions
+
+    if cfg.persona and cfg.persona.strip():
+        return (
+            f"You are {cfg.name}, a voice assistant.\n\n"
+            f"Persona: {cfg.persona}\n\n"
+            "The operator hasn't compiled a prompt yet — keep responses short "
+            "and ask the caller what they need."
+        )
+
+    return (
+        f"You are {cfg.name}, a voice assistant. The operator hasn't yet "
+        "configured your prompt. Greet the caller politely and ask what they "
+        "need help with. Keep responses brief."
+    )

--- a/examples/agents/livekit-prototype-agent/tests/conftest.py
+++ b/examples/agents/livekit-prototype-agent/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures and sys.path setup for tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Set dummy env vars BEFORE any src imports.
+_TEST_ENV = {
+    "OPENAI_API_KEY": "test_openai_key",
+    "MODELGUIDE_API_URL": "http://localhost:3000",
+    "MODELGUIDE_API_KEY": "mgk_test_key",
+}
+
+for k, v in _TEST_ENV.items():
+    os.environ.setdefault(k, v)
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/examples/agents/livekit-prototype-agent/tests/test_dispatch.py
+++ b/examples/agents/livekit-prototype-agent/tests/test_dispatch.py
@@ -1,0 +1,52 @@
+"""Tests for parse_dispatch_metadata — voice-test routing contract.
+
+This is the Python end of the contract that
+`buildVoiceTestDispatchMetadata` (modelguide-api/src/features/agents/
+agents.service.ts) writes. If the field names drift on either side the
+dispatched call goes silent — the test is the type system.
+"""
+
+import pytest
+
+from dispatch import DispatchMeta, parse_dispatch_metadata
+
+
+class TestParseDispatchMetadata:
+    def test_voice_test_payload_extracts_session_and_user(self):
+        raw = (
+            '{"mode":"voice-test","agentName":"sam","session_id":"sess_abc",'
+            '"user_identifier":"a@b.com","email":"a@b.com"}'
+        )
+        m = parse_dispatch_metadata(raw)
+        assert isinstance(m, DispatchMeta)
+        assert m.mode == "voice-test"
+        assert m.agent_slug == "sam"
+        assert m.session_id == "sess_abc"
+        assert m.user_identifier == "a@b.com"
+
+    def test_empty_metadata_returns_defaults(self):
+        m = parse_dispatch_metadata("")
+        assert m.mode is None
+        assert m.agent_slug is None
+        assert m.session_id is None
+        # The worker must still boot — never crash on a stale or missing
+        # metadata blob.
+        assert isinstance(m, DispatchMeta)
+
+    def test_invalid_json_returns_defaults_without_raising(self):
+        # The dispatching API is the only producer of this blob, but defence
+        # in depth: a malformed payload (e.g. truncated) shouldn't crash the
+        # worker before it can even greet the caller.
+        m = parse_dispatch_metadata("{not json")
+        assert m.mode is None
+        assert m.agent_slug is None
+
+    def test_outbound_payload_carries_phone_number(self):
+        raw = (
+            '{"mode":"outbound","agentName":"sam","session_id":"sess_xyz",'
+            '"phone_number":"+15555550100","user_identifier":"+15555550100"}'
+        )
+        m = parse_dispatch_metadata(raw)
+        assert m.mode == "outbound"
+        assert m.phone_number == "+15555550100"
+        assert m.user_identifier == "+15555550100"

--- a/examples/agents/livekit-prototype-agent/tests/test_mg_client.py
+++ b/examples/agents/livekit-prototype-agent/tests/test_mg_client.py
@@ -1,0 +1,72 @@
+"""Tests for the minimal ModelGuide REST client."""
+
+import httpx
+import pytest
+import respx
+
+import mg_client
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_runtime_config_uses_bearer_auth_and_correct_path():
+    route = respx.get("http://localhost:3000/api/agents/me").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "agt_1",
+                "slug": "sam",
+                "name": "Sam",
+                "modality": "voice",
+                "modelFamily": "gpt",
+                "agentPlatform": "livekit",
+                "isActive": True,
+                "promptConfig": {},
+                "metadata": {},
+                "compiledInstructions": "Hi",
+                "compiledAt": None,
+                "updatedAt": None,
+            },
+        )
+    )
+
+    cfg = await mg_client.fetch_runtime_config()
+    assert cfg.id == "agt_1"
+    assert cfg.compiled_instructions == "Hi"
+
+    # Ensure the worker authenticates with the agent's mgk_ key.
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == "Bearer mgk_test_key"
+
+    # Cleanup the pooled http client so it doesn't leak between tests.
+    await mg_client.close_http_client()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_runtime_config_raises_on_401():
+    respx.get("http://localhost:3000/api/agents/me").mock(
+        return_value=httpx.Response(401, json={"code": "UNAUTHORIZED"})
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await mg_client.fetch_runtime_config()
+
+    await mg_client.close_http_client()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_session_posts_channel_and_user():
+    route = respx.post("http://localhost:3000/api/sessions").mock(
+        return_value=httpx.Response(201, json={"id": "sess_xyz"})
+    )
+
+    session_id = await mg_client.create_session("caller@example.com")
+    assert session_id == "sess_xyz"
+
+    body = route.calls.last.request.content.decode()
+    assert "voice" in body
+    assert "caller@example.com" in body
+
+    await mg_client.close_http_client()

--- a/examples/agents/livekit-prototype-agent/tests/test_runtime_config.py
+++ b/examples/agents/livekit-prototype-agent/tests/test_runtime_config.py
@@ -1,0 +1,87 @@
+"""Tests for runtime_config — the pure helper that consumes /api/agents/me.
+
+The HTTP contract with ModelGuide is locked in `modelguide-api`'s
+`tests/unit/agents/agent-runtime-config.test.ts`. These tests cover the
+agent-side parsing + fallbacks: what does the worker boot with when the
+prompt is missing? when only `promptConfig.persona` is set? when both?
+"""
+
+from runtime_config import RuntimeConfig, build_session_instructions, parse_runtime_config
+
+
+SAMPLE = {
+    "id": "00000000-0000-0000-0000-0000000000aa",
+    "slug": "buildpro-sam",
+    "name": "Sam",
+    "modality": "voice",
+    "modelFamily": "gpt",
+    "agentPlatform": "livekit",
+    "isActive": True,
+    "promptConfig": {"persona": "Friendly contractor supply assistant"},
+    "metadata": {"livekit": {"agentName": "buildpro"}},
+    "compiledInstructions": "You are Sam. Help with orders.",
+    "compiledAt": "2026-02-01T00:00:00.000Z",
+    "updatedAt": "2026-02-01T00:00:00.000Z",
+}
+
+
+class TestParseRuntimeConfig:
+    def test_parses_minimal_shape(self):
+        cfg = parse_runtime_config(SAMPLE)
+        assert isinstance(cfg, RuntimeConfig)
+        assert cfg.id == SAMPLE["id"]
+        assert cfg.slug == "buildpro-sam"
+        assert cfg.name == "Sam"
+        assert cfg.modality == "voice"
+        assert cfg.compiled_instructions == "You are Sam. Help with orders."
+
+    def test_accepts_null_compiled_fields(self):
+        payload = {**SAMPLE, "compiledInstructions": None, "compiledAt": None}
+        cfg = parse_runtime_config(payload)
+        assert cfg.compiled_instructions is None
+        assert cfg.compiled_at is None
+
+    def test_persona_falls_back_to_empty_string_when_missing(self):
+        payload = {**SAMPLE, "promptConfig": {}}
+        cfg = parse_runtime_config(payload)
+        assert cfg.persona == ""
+
+    def test_extracts_persona_from_promptConfig(self):
+        cfg = parse_runtime_config(SAMPLE)
+        assert cfg.persona == "Friendly contractor supply assistant"
+
+
+class TestBuildSessionInstructions:
+    def test_uses_compiled_instructions_when_present(self):
+        cfg = parse_runtime_config(SAMPLE)
+        prompt = build_session_instructions(cfg)
+        assert "You are Sam. Help with orders." in prompt
+
+    def test_falls_back_to_persona_when_no_compiled_prompt(self):
+        # Operator hasn't clicked Compile yet — the worker should still boot
+        # with something coherent rather than an empty system prompt.
+        payload = {**SAMPLE, "compiledInstructions": None}
+        cfg = parse_runtime_config(payload)
+        prompt = build_session_instructions(cfg)
+        assert "Friendly contractor supply assistant" in prompt
+
+    def test_uses_generic_fallback_when_nothing_configured(self):
+        payload = {
+            **SAMPLE,
+            "compiledInstructions": None,
+            "promptConfig": {},
+        }
+        cfg = parse_runtime_config(payload)
+        prompt = build_session_instructions(cfg)
+        # The fallback must mention the agent name so the worker still
+        # responds with some identity rather than going silent.
+        assert "Sam" in prompt
+
+    def test_prefers_compiled_instructions_over_persona(self):
+        # If both are set the compiled prompt wins — that's the operator's
+        # authored prompt + SOPs, the persona is just a hint.
+        cfg = parse_runtime_config(SAMPLE)
+        prompt = build_session_instructions(cfg)
+        # Compiled instructions live verbatim, persona is not duplicated.
+        assert prompt.count("Friendly contractor supply assistant") == 0
+        assert "You are Sam. Help with orders." in prompt

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRuntimeConfig,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -292,6 +295,59 @@ function formatAgent(
 // ============================================================================
 // Routes
 // ============================================================================
+
+// ----------------------------------------------------------------------------
+// GET /me — runtime config for the calling agent (api-key auth)
+//
+// Registered BEFORE /:id so the literal `me` segment wins routing even though
+// `:id` is uuid-validated. Pull model — voice workers fetch their own compiled
+// prompt at session start (ADR-015).
+// ----------------------------------------------------------------------------
+
+const agentRuntimeConfigResponseSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string(),
+  name: z.string(),
+  modality: z.enum(["voice", "text"]),
+  modelFamily: modelFamilySchema,
+  agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]),
+  isActive: z.boolean(),
+  promptConfig: z.record(z.unknown()),
+  metadata: z.record(z.unknown()).optional(),
+  compiledInstructions: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+});
+
+router.get("/me", requireAgent());
+
+const getAgentRuntimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me",
+  tags: ["Agents"],
+  summary: "Get the calling agent's runtime config",
+  description:
+    "Returns the calling agent's identity + compiled prompt + persona. Used by voice workers (e.g. the LiveKit prototype agent) to fetch the latest compiled instructions at session start without redeploying. Requires an agent API key (mgk_…).",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Agent runtime config",
+      content: {
+        "application/json": {
+          schema: agentRuntimeConfigResponseSchema,
+        },
+      },
+    },
+    401: errorResponse("Agent API key required"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(getAgentRuntimeConfigRoute, async (c) => {
+  const agent = getCurrentAgent(c);
+  const config = await getAgentRuntimeConfig(agent.organizationId, agent.id);
+  return c.json(config, 200);
+});
 
 // GET /
 router.get(

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -1060,3 +1060,97 @@ export async function createVoiceTestSession(
     identity,
   };
 }
+
+// ============================================================================
+// Runtime config — what a voice worker reads at session start (api-key auth)
+//
+// Pull model, not push: the worker fetches its own compiled prompt + identity
+// each time a call lands. This keeps the worker authoritative on tools and
+// pipeline wiring (per ADR-014) while letting the prompt iterate without a
+// worker redeploy (ADR-015).
+//
+// Pure formatter so the wire contract is unit-testable independent of routing,
+// auth, or DB shape changes. Mirrors `formatAgent` but is deliberately leaner:
+// no `secrets` map, no `integrationUrls`, no compile-provenance — only the
+// fields the worker needs to boot a session.
+// ============================================================================
+
+export type AgentRuntimeConfig = {
+  id: string;
+  slug: string;
+  name: string;
+  modality: Modality;
+  modelFamily: ModelFamily;
+  agentPlatform: AgentPlatform;
+  isActive: boolean;
+  promptConfig: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  compiledInstructions: string | null;
+  compiledAt: string | null;
+  updatedAt: string | null;
+};
+
+export function formatAgentRuntimeConfig(agent: {
+  id: string;
+  name: string;
+  slug: string;
+  modality: Modality;
+  modelFamily: ModelFamily;
+  promptConfig: PromptConfig | null;
+  agentPlatform: AgentPlatform;
+  isActive: boolean;
+  metadata: Record<string, unknown> | null;
+  compiledInstructions: string | null;
+  compiledAt: Date | null;
+  updatedAt: Date | null;
+}): AgentRuntimeConfig {
+  // Strip webhook_hmac_secret defensively — even though it lives in metadata
+  // for historical reasons, it must never appear in any agent-facing response.
+  const metadata = agent.metadata
+    ? (() => {
+        const { webhook_hmac_secret, ...rest } = agent.metadata as Record<
+          string,
+          unknown
+        >;
+        return Object.keys(rest).length > 0 ? rest : undefined;
+      })()
+    : undefined;
+
+  return {
+    id: agent.id,
+    slug: agent.slug,
+    name: agent.name,
+    modality: agent.modality,
+    modelFamily: agent.modelFamily,
+    agentPlatform: agent.agentPlatform,
+    isActive: agent.isActive,
+    promptConfig: (agent.promptConfig ?? {}) as Record<string, unknown>,
+    metadata,
+    compiledInstructions: agent.compiledInstructions ?? null,
+    compiledAt: agent.compiledAt?.toISOString() ?? null,
+    updatedAt: agent.updatedAt?.toISOString() ?? null,
+  };
+}
+
+/**
+ * Load the calling agent's row and return its runtime config. Used by
+ * `GET /api/agents/me` — the auth layer has already resolved the API key to
+ * an agent ID, so this is a single RLS-scoped lookup.
+ */
+export async function getAgentRuntimeConfig(
+  orgId: string,
+  agentId: string,
+): Promise<AgentRuntimeConfig> {
+  return forOrg(orgId, async (tx) => {
+    const [agent] = await tx
+      .select()
+      .from(agents)
+      .where(eq(agents.id, agentId));
+
+    if (!agent) {
+      throw Errors.agentNotFound(agentId);
+    }
+
+    return formatAgentRuntimeConfig(agent);
+  });
+}

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,7 +8,12 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
@@ -860,6 +865,81 @@ describe("Strict PATCH schema", () => {
     expect(response.status).toBe(422);
     const body = await response.json();
     expect(body.error?.formErrors || body.error?.fieldErrors).toBeDefined();
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me — runtime config fetch by the calling agent (api-key auth)
+//
+// This is the endpoint LiveKit voice workers hit at session start to pull the
+// latest compiled prompt + identity for "their" agent record. ADR-015 — runtime
+// pull keeps the worker authoritative on tools/structure while letting the
+// prompt iterate without redeploying.
+// ============================================================================
+
+describe("GET /api/agents/me", () => {
+  test("returns the calling agent's runtime config (200)", async () => {
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me", { headers });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.slug).toBeDefined();
+    expect(body.name).toBeDefined();
+    expect(body.modality).toBeDefined();
+    expect(body.modelFamily).toBeDefined();
+    expect(body.agentPlatform).toBeDefined();
+    // compiledInstructions / compiledAt may be null but must be present in the
+    // response shape so callers don't have to do `in`-checks.
+    expect("compiledInstructions" in body).toBe(true);
+    expect("compiledAt" in body).toBe(true);
+  });
+
+  test("returns updated compiledInstructions after the prompt changes", async () => {
+    const fresh = `Test prompt baked at ${Date.now()}`;
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({ compiledInstructions: fresh, compiledAt: new Date() })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me", { headers });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.compiledInstructions).toBe(fresh);
+    expect(body.compiledAt).toBeTruthy();
+  });
+
+  test("rejects user JWT auth (401) — agent API key only", async () => {
+    const response = await request("/api/agents/me", {
+      headers: orgAAdminHeaders,
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me");
+
+    expect(response.status).toBe(401);
+  });
+
+  test("does not leak agent secrets in the response", async () => {
+    const headers = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me", { headers });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const stringified = JSON.stringify(body);
+    // Secrets are stored as encrypted refs by ID, never as plaintext on the
+    // agent record. Sanity-check no obvious credential field leaks anyway.
+    expect(stringified).not.toContain("apiSecret");
+    expect(stringified).not.toContain("webhook_hmac_secret");
   });
 });
 

--- a/modelguide-api/tests/unit/agents/agent-runtime-config.test.ts
+++ b/modelguide-api/tests/unit/agents/agent-runtime-config.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Runtime-config shape — locks the wire format that voice workers consume.
+ *
+ * The LiveKit prototype agent (examples/agents/livekit-prototype-agent) hits
+ * `GET /api/agents/me` at session start and reads `compiledInstructions` to
+ * build its system prompt. The field names and nullability are part of an
+ * implicit contract across the TS/Python boundary — this test pins them.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatAgentRuntimeConfig } from "../../../src/features/agents/agents.service";
+
+const baseAgent = {
+  id: "00000000-0000-0000-0000-0000000000aa",
+  organizationId: "00000000-0000-0000-0000-0000000000b0",
+  name: "Sam",
+  slug: "buildpro-sam",
+  description: null,
+  modality: "voice" as const,
+  modelFamily: "gpt" as const,
+  promptConfig: { persona: "Friendly contractor supply assistant" },
+  agentPlatform: "livekit" as const,
+  isActive: true,
+  createdBy: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  metadata: {
+    livekit: { url: "wss://x.livekit.cloud", agentName: "buildpro" },
+    webhook_hmac_secret: "should-not-leak",
+  },
+  secrets: { livekit_api_key: "00000000-0000-0000-0000-0000000000c0" },
+  compiledInstructions: "You are Sam.",
+  compiledAt: new Date("2026-02-01T00:00:00.000Z"),
+  compiledFrom: null,
+  updatedAt: null,
+};
+
+describe("formatAgentRuntimeConfig", () => {
+  test("returns identity + compiled prompt fields the worker reads", () => {
+    const cfg = formatAgentRuntimeConfig(baseAgent);
+    expect(cfg.id).toBe(baseAgent.id);
+    expect(cfg.slug).toBe("buildpro-sam");
+    expect(cfg.name).toBe("Sam");
+    expect(cfg.modality).toBe("voice");
+    expect(cfg.modelFamily).toBe("gpt");
+    expect(cfg.agentPlatform).toBe("livekit");
+    expect(cfg.compiledInstructions).toBe("You are Sam.");
+    expect(cfg.compiledAt).toBe("2026-02-01T00:00:00.000Z");
+  });
+
+  test("returns the persona under promptConfig so the worker can build a greeting", () => {
+    const cfg = formatAgentRuntimeConfig(baseAgent);
+    expect(cfg.promptConfig).toEqual({
+      persona: "Friendly contractor supply assistant",
+    });
+  });
+
+  test("nulls compiledInstructions / compiledAt when the agent was never compiled", () => {
+    const cfg = formatAgentRuntimeConfig({
+      ...baseAgent,
+      compiledInstructions: null,
+      compiledAt: null,
+    });
+    expect(cfg.compiledInstructions).toBeNull();
+    expect(cfg.compiledAt).toBeNull();
+  });
+
+  test("strips webhook_hmac_secret from metadata so it can't leak via /me", () => {
+    const cfg = formatAgentRuntimeConfig(baseAgent);
+    const stringified = JSON.stringify(cfg);
+    expect(stringified).not.toContain("webhook_hmac_secret");
+    expect(stringified).not.toContain("should-not-leak");
+  });
+
+  test("strips agent secrets map (only refs, but keep it off the wire anyway)", () => {
+    const cfg = formatAgentRuntimeConfig(baseAgent) as Record<string, unknown>;
+    // Secrets are stored as encrypted refs by ID on the agent row, never as
+    // plaintext credentials, so leaking the map IDs isn't catastrophic — but
+    // the runtime-config endpoint has no need for them, so they must not be
+    // in the response.
+    expect("secrets" in cfg).toBe(false);
+  });
+
+  test("passes through livekit metadata so the worker can sanity-check its own agentName", () => {
+    const cfg = formatAgentRuntimeConfig(baseAgent);
+    const metadata = cfg.metadata as Record<string, unknown> | undefined;
+    expect(metadata).toBeDefined();
+    expect((metadata?.livekit as Record<string, unknown>).agentName).toBe(
+      "buildpro",
+    );
+  });
+
+  test("response shape is stable — keys are exactly the documented set", () => {
+    // If anyone adds a new field, they have to update this list AND the
+    // Python prototype agent's expectations, AND the ADR. Drift-prevention.
+    const cfg = formatAgentRuntimeConfig(baseAgent) as Record<string, unknown>;
+    expect(Object.keys(cfg).sort()).toEqual(
+      [
+        "agentPlatform",
+        "compiledAt",
+        "compiledInstructions",
+        "id",
+        "isActive",
+        "metadata",
+        "modality",
+        "modelFamily",
+        "name",
+        "promptConfig",
+        "slug",
+        "updatedAt",
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **click-Compile → click-Talk** freshness loop without redeploying the LiveKit worker. Edit a prompt in the dashboard, click Compile, click *Talk to agent* — the very next call uses the freshly compiled prompt.

The voice-test dispatch infra (ADR-014) and the compile endpoint were already there. The missing piece was making the worker actually *read* the compiled prompt at session start.

## What's in the PR

**API — `GET /api/agents/me` (agent-API-key auth)**
Returns the calling agent's runtime config: `compiledInstructions`, `compiledAt`, persona, identity, modality, platform. Stripped of secrets / integration URLs / compile provenance — only what a worker needs to boot.

- `src/features/agents/agents.service.ts`: `formatAgentRuntimeConfig` (pure helper) + `getAgentRuntimeConfig` (RLS-scoped loader)
- `src/features/agents/agents.routes.ts`: new `GET /me` route registered *before* `/:id` so the literal segment wins routing
- Hooked through existing `requireAgent()` middleware — same auth path as MCP

**Python — `examples/agents/livekit-prototype-agent/`**
Voiceblox-inspired minimal LiveKit worker. ~150 LOC. Single-provider (OpenAI Realtime), no tools, no SIP, no tracing — its job is to demonstrate the freshness loop, not to be a production agent.

Lifecycle per dispatched call:
1. Parse dispatch metadata (mode, agentName slug, session_id)
2. `GET /api/agents/me` → latest compiled prompt + persona
3. Start `AgentSession` with `compiledInstructions` as the system prompt
4. Reuse the API-side session ID; complete on disconnect

Includes Dockerfile + `.env.example` for `lk agent create` cloud deploys.

**Docs**
- [ADR-015: LiveKit Voice Worker Fetches Compiled Prompt at Session Start](https://github.com/modelguide/modelguide/blob/claude/ecstatic-mayer-9atES/docs/decisions/015-livekit-runtime-prompt-fetch.md) — design rationale, tradeoff matrix vs ADR-014's rejected push-via-metadata, security & consequences
- README in the prototype agent folder — quickstart, console mode, cloud deploy, how to graduate to tools

## Relationship to ADR-014

ADR-014 explicitly rejected a `prompt_override` field on dispatch metadata because it created a "works in voice-test, breaks in prod" failure mode (the prompt could drift from the worker's tool set). The pull-at-session-start model in this PR sidesteps that: voice-test and production fetch the same `compiledInstructions` value from the same row, so they can't disagree. ADR-015 captures the full reasoning.

## Test plan

Red-green TDD on both sides — failing tests first, then implementation.

- [x] `make api-typecheck` — clean
- [x] `make api-lint-check` — clean
- [x] `bun test tests/unit/` — 903 pass, 0 fail (includes 7 new tests in `tests/unit/agents/agent-runtime-config.test.ts`)
- [x] `python -m pytest` in the prototype agent — 15 pass, 0 fail
- [ ] `make api-test-integration` — couldn't run locally (no Docker in the sandbox); CI covers the 5 new tests in `tests/integration/agents.test.ts`:
  - `returns the calling agent's runtime config (200)`
  - `returns updated compiledInstructions after the prompt changes`
  - `rejects user JWT auth (401)` — agent key only
  - `rejects unauthenticated request (401)`
  - `does not leak agent secrets in the response`
- [ ] Manual smoke test on a real LiveKit dev setup: edit prompt → click Compile → click Talk → confirm the worker greets with the new wording

## Out of scope

Kept the PR tight:
- No UI changes — `voice-test-panel.tsx` already drives this flow as-is
- No tools / MCP wiring in the prototype (pure conversational POC)
- No SIP / outbound / Langfuse — copy from the BuildPro example if/when the prototype graduates


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqsjbVs1atzVau52mCzfpa)_