### PR TITLE
feat(agents): prompt-sync prototype — talk to LiveKit agent with the latest compiled prompt (ADR-015)

### DIFF
--- a/docs/decisions/015-livekit-prompt-sync-prototype.md
+++ b/docs/decisions/015-livekit-prompt-sync-prototype.md
@@ -1,0 +1,195 @@
+# ADR-015: LiveKit Voice-Test with Compiled-Prompt Sync (Prototype)
+
+**Status:** Proposed (prototype)
+
+## Context
+
+ADR-014 ships "Talk to agent" — one-click WebRTC voice testing against a
+deployed LiveKit worker. It works well for verifying that the worker's
+**baked-in** profile (prompt + tools) sounds right end-to-end. It does
+not help when an operator is iterating on a **prompt** in the dashboard:
+each edit currently requires building, pushing, and redeploying a new
+worker profile before the change can be heard. The feedback loop is
+minutes, not seconds.
+
+The acme website (`examples/customer-apps/acme/src/App.tsx`) and the
+[voiceblox](https://github.com/voiceblox-ai/voiceblox) reference both
+support a tighter loop: edit a prompt, click sync, hear the result. We
+want the same loop in ModelGuide for LiveKit-based agents.
+
+ADR-014 deliberately rejected prompt injection on three grounds:
+
+1. **Drift in testing.** "Works in voice-test, broken in prod" if the
+   injected prompt differs from the deployed profile.
+2. **Metadata size discipline.** LiveKit dispatch metadata is bounded
+   (~48KB) and the prompt-injection patch was ~100 lines of byte-size
+   guards.
+3. **The "right" answer was to build a new profile.** Redeploy is the
+   honest test.
+
+This ADR re-opens that decision — narrowly, as an **opt-in prototype**
+— because the redeploy-per-edit cost has turned out to be the dominant
+friction in prompt work for operators on the platform.
+
+## Decision
+
+Extend `POST /agents/:id/voice-test-token` with an optional body field:
+
+```json
+{ "useCompiledPrompt": true }
+```
+
+When set, the dispatcher reads `agents.compiledInstructions` and
+`agents.compiledAt` and adds them to the LiveKit dispatch metadata
+under `compiled_prompt` and `compiled_prompt_compiled_at`. A
+prompt-sync-aware worker reads these fields and uses the supplied
+string as the agent's instructions instead of its baked-in prompt.
+
+The default — no body, or `{ "useCompiledPrompt": false }` — is
+byte-for-byte identical to ADR-014. The prototype rides alongside
+the existing flow; nothing about the production "Talk to agent"
+behavior changes unless the operator opts in.
+
+### Wire contract
+
+The dispatcher (`buildVoiceTestDispatchMetadata` in
+`modelguide-api/src/features/agents/agents.service.ts`) emits this
+JSON shape, which is also what the worker reads from
+`ctx.job.metadata`:
+
+```json
+{
+  "mode": "voice-test",
+  "agentName": "<agent.slug>",
+  "session_id": "<uuid>",
+  "user_identifier": "<email>",
+  "email": "<email>",
+  "compiled_prompt": "<string, omitted when not opted in>",
+  "compiled_prompt_compiled_at": "<ISO 8601, omitted when not opted in>"
+}
+```
+
+The contract is locked by two paired tests:
+
+- `modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts`
+  — covers the dispatcher side. New cases verify that the field is
+  *absent* by default and *present and verbatim* when supplied.
+- `examples/agents/livekit-agent/tests/test_prompt_sync.py`
+  — covers the worker side. New cases verify that the field name
+  matches the dispatcher, that an absent field falls back to the
+  baked-in prompt, and that empty / whitespace-only overrides are
+  ignored.
+
+If either side drifts on the field name, both sides still compile and
+pass type checks, but prompt-sync silently regresses to ADR-014
+behavior. The two tests together are the type system between TS and
+Python.
+
+### Endpoint shape
+
+`POST /agents/:id/voice-test-token`
+
+Request body (optional):
+
+```json
+{ "useCompiledPrompt": true }
+```
+
+Behavior:
+
+| `useCompiledPrompt` | `agents.compiledInstructions` | Result |
+|---|---|---|
+| `false` / omitted / no body | any | ADR-014 path — worker uses baked-in prompt |
+| `true` | non-null | Prompt rides in dispatch metadata |
+| `true` | `null` | **400** — must compile the agent first |
+
+The 400 guard is the precondition that makes this safe to ship: an
+operator never gets dispatched into a room with a half-baked agent
+because the dashboard told the worker to use a prompt that doesn't
+exist.
+
+### What this deliberately keeps the same as ADR-014
+
+- **The room, session, and token mint are identical.** The same
+  `voice-test-<nanoid>` room, the same `agents:activate` permission,
+  the same 15-minute token TTL, the same RLS-scoped secret load.
+- **The worker-profile ↔ agent.slug routing contract is unchanged.**
+  `agentName` still equals `agent.slug`. A multi-profile worker still
+  picks a profile from its registry; the override only changes the
+  instructions on that profile.
+- **No new endpoints.** One body field, one opt-in.
+
+### What this deliberately reverses from ADR-014
+
+- The "no prompt injection, ever" rule. Now: prompt injection is
+  allowed when the operator explicitly asks for it, and only when a
+  compiled prompt exists for that agent.
+
+## Alternatives Considered
+
+**Worker fetches the prompt from a new ModelGuide REST endpoint.**
+Cleaner separation, no metadata size pressure, prompt always fresh.
+Rejected for the prototype because it requires the worker to hold a
+long-lived MG API key and to learn about a new endpoint shape. The
+current dispatch-metadata path requires zero new auth and ships in
+one place.
+
+**A new endpoint (`POST /agents/:id/prompt-sync-token`) alongside
+the existing one.** Cleaner contract, easier to revert, fits "prototype
+status" better. Rejected because it duplicates ~80% of the existing
+endpoint's logic, and the opt-in flag is a one-bit change that does
+not pollute the default path.
+
+**A separate "prompt-test" agent in the worker.** Tested-in-isolation,
+no contamination of the BuildPro profile. Rejected for the prototype
+because then "test prompt" and "test live agent" diverge on STT/TTS
+provider, voice, etc., and a difference there is the bug operators
+hit first.
+
+**Cap `compiled_prompt` size at 40KB.** Considered. Not yet enforced
+in the prototype — most compiled prompts in production are well under
+10KB. If we ship this beyond prototype, the cap goes in
+`createVoiceTestSession` with a 400 if exceeded, and the dispatcher
+test pins the cap.
+
+## Consequences
+
+- **Faster prompt iteration loop.** Edit → compile → "Talk to agent"
+  → hear it. The redeploy step is skipped for prompt-only changes.
+- **Same drift risk ADR-014 called out, now scoped.** "Works in
+  voice-test, broken in prod" is still possible — the prototype
+  doesn't *eliminate* the risk, it just makes it opt-in and signaled
+  on the panel ("Prototype" badge). The mitigation is to follow
+  prompt-sync testing with a normal voice-test against the deployed
+  profile before shipping.
+- **Metadata size discipline is now load-bearing.** No cap is
+  enforced in the prototype. If an operator compiles a 60KB prompt,
+  the dispatch will fail at the LiveKit edge. Acceptable for a
+  prototype; not acceptable to ship.
+- **The wire contract is now a two-sided type system.** A field-name
+  rename on either side breaks prompt-sync without breaking any
+  build. The paired tests in TS + Python guard against this; reviewers
+  must keep them in sync.
+
+## Graduation criteria
+
+The prototype graduates to a real feature (rolling into ADR-014 or
+replacing it) when:
+
+1. A byte cap on `compiled_prompt` is enforced and tested.
+2. The dashboard shows a visible "you are testing prompt X, deployed
+   profile is on prompt Y" diff before the call so the drift risk is
+   no longer hidden.
+3. A small handful of operators report sustained use without
+   complaining about drift.
+
+Until then, the toggle stays opt-in and badged "Prototype" on the
+panel.
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls
+- ADR-014: Browser Voice Testing via LiveKit Dispatch — the flow this
+  extends
+- `examples/agents/livekit-agent/PROMPT_SYNC.md` — worker-side usage
+  notes

--- a/examples/agents/livekit-agent/PROMPT_SYNC.md
+++ b/examples/agents/livekit-agent/PROMPT_SYNC.md
@@ -1,0 +1,134 @@
+# Prompt Sync (ADR-015 Prototype)
+
+A short feedback loop for prompt iteration: edit a prompt in the
+ModelGuide dashboard, compile it, click "Talk to agent" with **Use
+latest compiled prompt** enabled, and hear the result without
+redeploying the worker.
+
+> **Status:** Prototype. The default "Talk to agent" path
+> (ADR-014) is unchanged — the worker uses its baked-in profile
+> prompt unless the operator opts in.
+
+## How it works
+
+```
+Dashboard                                    LiveKit worker
+─────────                                    ──────────────
+1. Operator edits / compiles a prompt
+   → agents.compiledInstructions
+   → agents.compiledAt
+
+2. Operator toggles "Use latest compiled prompt"
+   on the Voice Test panel and clicks "Talk to agent"
+
+3. POST /agents/:id/voice-test-token
+   { "useCompiledPrompt": true }
+
+   API reads compiledInstructions + compiledAt,
+   adds them to LiveKit dispatch metadata as
+   `compiled_prompt` + `compiled_prompt_compiled_at`,
+   then dispatches the worker into a fresh room.
+                                            ↓
+4. Browser joins room                       Worker entrypoint reads
+   via the returned token                   ctx.job.metadata, finds
+                                            `compiled_prompt`, and
+                                            passes it to BuildProAgent
+                                            via `instructions_override=...`.
+
+5. Operator talks to the agent — the LLM's system prompt is the
+   string the dashboard just compiled, not the one baked into the
+   worker image.
+```
+
+When `useCompiledPrompt=false` (or the body is omitted), the worker
+takes the existing ADR-014 path and uses its baked-in prompt — the
+prompt-sync code is a no-op.
+
+## Wire contract
+
+The dispatcher emits this JSON in `ctx.job.metadata`:
+
+```json
+{
+  "mode": "voice-test",
+  "agentName": "<agent.slug>",
+  "session_id": "<uuid>",
+  "user_identifier": "<email>",
+  "email": "<email>",
+  "compiled_prompt": "<string>",
+  "compiled_prompt_compiled_at": "<ISO 8601>"
+}
+```
+
+The last two fields are present only when the operator opted in. The
+worker uses `dict.get("compiled_prompt")` so an absent field falls
+through to the baked-in path.
+
+The contract is pinned from both ends:
+
+- **Dispatcher side:** `modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts`
+  — `buildVoiceTestDispatchMetadata` test cases for
+  `compiled_prompt` absence and presence.
+- **Worker side:** `examples/agents/livekit-agent/tests/test_prompt_sync.py`
+  — `BuildProAgent` test cases for the override path and parsing
+  the dispatcher's exact JSON shape.
+
+If either side renames the field, both sides keep building and only
+the paired tests catch it. Keep them in sync.
+
+## Testing the worker side locally
+
+```bash
+# Run just the prompt-sync tests
+cd examples/agents/livekit-agent
+uv run pytest tests/test_prompt_sync.py -v
+```
+
+The tests don't need a LiveKit server, an MCP backend, or any
+network. They construct `BuildProAgent` directly with an
+`instructions_override` arg and assert that the instructions match.
+
+## End-to-end sanity check (with a local LiveKit server)
+
+```bash
+# Terminal 1 — LiveKit server
+make livekit-up
+
+# Terminal 2 — voice agent
+make lk-agent-dev
+
+# Terminal 3 — fire a token with useCompiledPrompt=true (replace IDs)
+curl -X POST "$API_URL/api/agents/<agent-id>/voice-test-token" \
+  -H "Authorization: Bearer <dashboard-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"useCompiledPrompt": true}'
+```
+
+The worker log should include:
+
+```
+agent | INFO  | Prompt-sync test: using compiled prompt (len=<N>, compiled_at=<ts>)
+```
+
+If that line doesn't appear, the dispatch metadata didn't carry the
+field — usually because the agent's `compiledInstructions` is
+`null`. Compile the agent first.
+
+## What this does NOT do
+
+- It does **not** override tools. The worker's profile still owns the
+  tool set and tool execution. Prompt-sync is for prompt iteration
+  only.
+- It does **not** persist anything new. The same session is created,
+  the same transcript is collected, the same analytics row is
+  written.
+- It does **not** cap the prompt size. Currently relies on operators
+  not compiling 40KB+ prompts. A byte cap is a graduation criterion
+  before this leaves prototype status (see ADR-015).
+
+## Reverting
+
+The whole prototype is gated by one body field. To revert to pure
+ADR-014 behavior platform-wide, hide the toggle on the dashboard —
+the API + worker code stay functionally idempotent (an absent
+`compiled_prompt` is the existing path).

--- a/examples/agents/livekit-agent/src/agent.py
+++ b/examples/agents/livekit-agent/src/agent.py
@@ -84,7 +84,8 @@ async def entrypoint(ctx: agents.JobContext):
             trace_provider.force_flush()
         ctx.add_shutdown_callback(_flush_traces)
 
-    # Parse dispatch metadata (outbound calls include phone_number)
+    # Parse dispatch metadata (outbound calls include phone_number;
+    # prompt-sync test sessions include `compiled_prompt`)
     outbound_phone = None
     dispatch_metadata: dict = {}
     if ctx.job.metadata:
@@ -93,6 +94,19 @@ async def entrypoint(ctx: agents.JobContext):
             outbound_phone = dispatch_metadata.get("phone_number")
         except json.JSONDecodeError:
             logger.warning("Invalid JSON in job metadata: %s", ctx.job.metadata[:100])
+
+    # Prompt-sync prototype (ADR-015): when the dashboard ships the latest
+    # compiled prompt via dispatch metadata, log which version we're
+    # running with so a broken session can be traced back to a specific
+    # compile. Pass through to BuildProAgent below.
+    compiled_prompt: str | None = dispatch_metadata.get("compiled_prompt")
+    compiled_at: str | None = dispatch_metadata.get("compiled_prompt_compiled_at")
+    if compiled_prompt:
+        logger.info(
+            "Prompt-sync test: using compiled prompt (len=%d, compiled_at=%s)",
+            len(compiled_prompt),
+            compiled_at or "unknown",
+        )
 
     await ctx.connect()
 
@@ -158,7 +172,12 @@ async def entrypoint(ctx: agents.JobContext):
     logger.info("ModelGuide session: %s (user: %s)", session_id, user_identifier)
 
     # Build agent + session
-    agent = BuildProAgent(session_id=session_id, user_email=user_identifier, mcp=mcp)
+    agent = BuildProAgent(
+        session_id=session_id,
+        user_email=user_identifier,
+        mcp=mcp,
+        instructions_override=compiled_prompt,
+    )
     stt = create_stt()
     tts = create_tts()
 

--- a/examples/agents/livekit-agent/src/buildpro.py
+++ b/examples/agents/livekit-agent/src/buildpro.py
@@ -36,13 +36,26 @@ class BuildProAgent(MCPAgent):
     ]
 
     def __init__(
-        self, *, session_id: str | None, user_email: str, mcp: mg_client.MCPConnection | None = None
+        self,
+        *,
+        session_id: str | None,
+        user_email: str,
+        mcp: mg_client.MCPConnection | None = None,
+        instructions_override: str | None = None,
     ) -> None:
         self._active_cart_id: str | None = None
         self._cart_ready = asyncio.Event()
         self._reorder_product_ids: list[str] = []
 
-        instructions = build_system_prompt(session_id or "", user_email=user_email)
+        # Prompt-sync prototype (ADR-015): when the dispatcher passes a
+        # compiled prompt via job metadata, use it verbatim — the operator
+        # is testing the prompt they just edited in the dashboard. Empty
+        # strings are ignored so accidental "" overrides don't blank the
+        # agent. Otherwise fall through to the baked-in BuildPro prompt.
+        if instructions_override and instructions_override.strip():
+            instructions = instructions_override
+        else:
+            instructions = build_system_prompt(session_id or "", user_email=user_email)
         super().__init__(session_id=session_id, mcp=mcp, instructions=instructions)
 
     # ------------------------------------------------------------------

--- a/examples/agents/livekit-agent/tests/test_prompt_sync.py
+++ b/examples/agents/livekit-agent/tests/test_prompt_sync.py
@@ -1,0 +1,111 @@
+"""Prompt-sync prototype (ADR-015) tests.
+
+The dashboard ships the latest compiled prompt to the worker via LiveKit
+dispatch metadata under the key ``compiled_prompt``. When that key is
+present, ``BuildProAgent`` must use the supplied string as its system
+instructions instead of the prompt baked into the worker profile via
+``build_system_prompt``.
+
+These tests pin the contract from the worker side — the matching contract
+on the dispatcher side is locked in
+``modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts``. If
+either side drifts, prompt-sync silently regresses to "worker uses its
+baked-in prompt".
+"""
+
+from __future__ import annotations
+
+import json
+
+from buildpro import BuildProAgent
+
+
+class TestPromptSyncOverride:
+    def test_uses_override_when_provided(self):
+        # When the dashboard ships a compiled prompt, the agent's
+        # ``instructions`` must be that exact string, byte-for-byte.
+        override = (
+            "You are a banking voice agent. Confirm account number "
+            "before sharing balances."
+        )
+        agent = BuildProAgent(
+            session_id="sess_test",
+            user_email="alice@example.com",
+            instructions_override=override,
+        )
+        assert agent.instructions == override
+
+    def test_falls_back_to_baked_prompt_when_override_is_none(self):
+        # No override → baked-in BuildPro prompt. We don't pin the exact
+        # text (it's huge and evolves), but a stable marker is fair game:
+        # the BuildPro prompt always contains the brand name "BuildPro"
+        # somewhere.
+        agent = BuildProAgent(
+            session_id="sess_test",
+            user_email="alice@example.com",
+            instructions_override=None,
+        )
+        assert "BuildPro" in agent.instructions
+        # And the session_id / user_email must still flow into the prompt
+        # because some workflows interpolate them.
+        assert "alice@example.com" in agent.instructions
+
+    def test_falls_back_to_baked_prompt_when_override_is_empty_string(self):
+        # Empty / whitespace-only overrides are ignored. Belt-and-braces
+        # guard against an accidental "" rendering in the dispatch
+        # payload silently blanking the agent. The fallback path is the
+        # same as ``None``.
+        agent = BuildProAgent(
+            session_id="sess_test",
+            user_email="alice@example.com",
+            instructions_override="   ",
+        )
+        assert "BuildPro" in agent.instructions
+
+
+class TestDispatchMetadataParsing:
+    """Confirms the wire shape the dispatcher emits is the shape the worker reads.
+
+    Mirrors the dispatcher contract test in
+    ``buildVoiceTestDispatchMetadata`` (TypeScript). If the field name
+    drifts on either side, the worker reads ``None`` and silently falls
+    back to the baked-in prompt — exactly the kind of "tests pass, prod
+    breaks" failure the ADR calls out.
+    """
+
+    def test_compiled_prompt_field_name_matches_dispatcher(self):
+        # The TS side serialises this exact JSON shape (see
+        # voice-test-dispatch.test.ts → "carries compiled_prompt
+        # verbatim when supplied").
+        wire = {
+            "mode": "voice-test",
+            "agentName": "banknowa_v1",
+            "session_id": "sess-1",
+            "user_identifier": "tester@corp.com",
+            "email": "tester@corp.com",
+            "compiled_prompt": "You are Sam. Answer in one sentence.",
+            "compiled_prompt_compiled_at": "2026-06-07T00:00:00.000Z",
+        }
+        # Round-trip through JSON because that's what the worker does
+        # with ``ctx.job.metadata``.
+        parsed = json.loads(json.dumps(wire))
+        # These two assertions ARE the contract.
+        assert parsed.get("compiled_prompt") == wire["compiled_prompt"]
+        assert (
+            parsed.get("compiled_prompt_compiled_at")
+            == wire["compiled_prompt_compiled_at"]
+        )
+
+    def test_absent_compiled_prompt_returns_none(self):
+        # The default voice-test path (no opt-in) omits the field
+        # entirely — ``.get()`` must return ``None`` so the worker takes
+        # the baked-in branch.
+        wire = {
+            "mode": "voice-test",
+            "agentName": "banknowa_v1",
+            "session_id": "sess-1",
+            "user_identifier": "tester@corp.com",
+            "email": "tester@corp.com",
+        }
+        parsed = json.loads(json.dumps(wire))
+        assert parsed.get("compiled_prompt") is None

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -1310,6 +1310,15 @@ router.post(
   requireOrganization(),
 );
 
+const voiceTestTokenBodySchema = z
+  .object({
+    useCompiledPrompt: z.boolean().optional().openapi({
+      description:
+        "Prompt-sync prototype (ADR-015): when true, the agent's latest compiled prompt rides in dispatch metadata so a prompt-sync-aware worker uses it instead of the prompt baked into the worker profile. Defaults to false — the worker uses its baked-in profile (ADR-014 behavior).",
+    }),
+  })
+  .openapi("VoiceTestTokenBody");
+
 const voiceTestTokenResponseSchema = z.object({
   livekitUrl: z.string(),
   roomName: z.string(),
@@ -1327,10 +1336,16 @@ const voiceTestTokenRoute = createRoute({
   tags: ["Agents"],
   summary: "Issue a LiveKit voice-test token",
   description:
-    "Creates a ModelGuide session, dispatches the configured LiveKit worker into a fresh room with the agent's slug as `agentName` in metadata (so a multi-profile worker picks the correct profile), and returns a short-lived LiveKit AccessToken so the browser can join via WebRTC and talk to the agent.",
+    "Creates a ModelGuide session, dispatches the configured LiveKit worker into a fresh room with the agent's slug as `agentName` in metadata (so a multi-profile worker picks the correct profile), and returns a short-lived LiveKit AccessToken so the browser can join via WebRTC and talk to the agent. When body.useCompiledPrompt=true, the agent's latest compiled prompt is included in dispatch metadata for a prompt-sync-aware worker (ADR-015 prototype).",
   security: [{ bearerAuth: [] }],
   request: {
     params: agentIdParams,
+    body: {
+      required: false,
+      content: {
+        "application/json": { schema: voiceTestTokenBodySchema },
+      },
+    },
   },
   responses: {
     201: {
@@ -1340,7 +1355,7 @@ const voiceTestTokenRoute = createRoute({
       },
     },
     400: errorResponse(
-      "LiveKit not configured, missing credentials, or wrong modality",
+      "LiveKit not configured, missing credentials, wrong modality, or useCompiledPrompt=true with no compiled prompt available",
     ),
     401: errorResponse("Not authenticated"),
     403: errorResponse("Insufficient permissions"),
@@ -1352,12 +1367,27 @@ router.openapi(voiceTestTokenRoute, async (c) => {
   const orgId = getOrganizationId(c);
   const user = getCurrentUser(c);
   const { id } = c.req.valid("param");
+  // Body is optional — tolerate clients that POST without one.
+  let useCompiledPrompt = false;
+  try {
+    const parsed = c.req.valid("json") as
+      | z.infer<typeof voiceTestTokenBodySchema>
+      | undefined;
+    useCompiledPrompt = parsed?.useCompiledPrompt ?? false;
+  } catch {
+    // No body or invalid body — fall back to the default ADR-014 path.
+  }
 
-  const result = await createVoiceTestSession(orgId, id, {
-    userId: user.id,
-    email: user.email,
-    name: user.name,
-  });
+  const result = await createVoiceTestSession(
+    orgId,
+    id,
+    {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+    },
+    { useCompiledPrompt },
+  );
 
   return c.json(result, 201);
 });

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -904,19 +904,40 @@ export function buildVoiceTestDispatchMetadata(input: {
   agentSlug: string;
   sessionId: string;
   callerEmail: string;
+  /**
+   * Optional compiled prompt to ride along in the dispatch metadata.
+   * When set, a prompt-sync-aware worker (see ADR-015) uses it as the
+   * agent's instructions instead of the prompt baked into the worker
+   * profile. When omitted, the dispatch is byte-for-byte identical to
+   * the ADR-014 flow and the worker uses its baked-in prompt.
+   */
+  compiledPrompt?: string;
+  compiledAt?: string;
 }): {
   mode: "voice-test";
   agentName: string;
   session_id: string;
   user_identifier: string;
   email: string;
+  compiled_prompt?: string;
+  compiled_prompt_compiled_at?: string;
 } {
-  return {
+  const base = {
     mode: "voice-test" as const,
     agentName: input.agentSlug,
     session_id: input.sessionId,
     user_identifier: input.callerEmail,
     email: input.callerEmail,
+  };
+  if (input.compiledPrompt === undefined) {
+    return base;
+  }
+  return {
+    ...base,
+    compiled_prompt: input.compiledPrompt,
+    ...(input.compiledAt !== undefined && {
+      compiled_prompt_compiled_at: input.compiledAt,
+    }),
   };
 }
 
@@ -935,6 +956,7 @@ export async function createVoiceTestSession(
   orgId: string,
   agentId: string,
   caller: { userId: string; email: string; name: string },
+  options: { useCompiledPrompt?: boolean } = {},
 ): Promise<VoiceTestSession> {
   const agent = await forOrg(orgId, async (tx) => {
     const a = await requireAgent(tx, agentId);
@@ -951,6 +973,23 @@ export async function createVoiceTestSession(
     }
     return a;
   });
+
+  // Prompt-sync prototype (ADR-015): when the caller opts in, the agent's
+  // latest compiled prompt rides along in dispatch metadata so the worker
+  // can talk with the prompt the operator just edited — without redeploying
+  // the worker profile. The default path remains ADR-014 (worker uses its
+  // baked-in profile prompt).
+  let compiledPrompt: string | undefined;
+  let compiledAt: string | undefined;
+  if (options.useCompiledPrompt) {
+    if (!agent.compiledInstructions) {
+      throw Errors.invalidInput(
+        "useCompiledPrompt=true but the agent has no compiled prompt. Compile the agent first.",
+      );
+    }
+    compiledPrompt = agent.compiledInstructions;
+    compiledAt = agent.compiledAt?.toISOString();
+  }
 
   const meta = (agent.metadata ?? {}) as Record<string, unknown>;
   const lkMeta = (meta.livekit ?? {}) as Record<string, unknown>;
@@ -996,6 +1035,8 @@ export async function createVoiceTestSession(
     agentSlug: agent.slug,
     sessionId: session.id,
     callerEmail: caller.email,
+    compiledPrompt,
+    compiledAt,
   });
 
   let dispatchId: string;

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -1009,6 +1009,71 @@ describe("POST /api/agents/:id/voice-test-token", () => {
 
     expect(response.status).toBe(403);
   });
+
+  // --------------------------------------------------------------------
+  // ADR-015 prompt-sync prototype: the body's `useCompiledPrompt` flag
+  // requires the agent to have a non-null `compiledInstructions`. If the
+  // flag is true but no prompt exists, the route must 400 before any
+  // LiveKit dispatch — this is the precondition that makes the prototype
+  // safe to ship: the worker never gets a half-baked dispatch.
+  // --------------------------------------------------------------------
+
+  test("useCompiledPrompt=true with no compiled prompt returns 400", async () => {
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ name: "Prompt Sync No Prompt Agent" }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    // Activate + configure LiveKit so the modality / platform / cred
+    // checks all pass — the useCompiledPrompt guard is the one that
+    // should trip. compiledInstructions stays null (fresh agent).
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          agentPlatform: "livekit",
+          metadata: {
+            livekit: { url: "wss://test.livekit.cloud", agentName: "w" },
+          },
+        })
+        .where(eq(agents.id, agentId)),
+    );
+
+    const response = await request(`/api/agents/${agentId}/voice-test-token`, {
+      method: "POST",
+      headers: { ...orgAAdminHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ useCompiledPrompt: true }),
+    });
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(JSON.stringify(body)).toMatch(/compiled prompt/i);
+  });
+
+  test("useCompiledPrompt=false is the same code path as no body", async () => {
+    // Doesn't matter that LiveKit isn't configured — we're checking that
+    // passing the flag explicitly false doesn't trip the new guard and
+    // ends up on the existing "LiveKit not configured" path.
+    const response = await request(
+      `/api/agents/${s.orgAAgentId}/voice-test-token`,
+      {
+        method: "POST",
+        headers: { ...orgAAdminHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ useCompiledPrompt: false }),
+      },
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    // The error must be the LiveKit-not-configured one — NOT the new
+    // compiled-prompt guard. If this assertion ever flips it means the
+    // body parser is mis-defaulting useCompiledPrompt to true.
+    expect(JSON.stringify(body)).toMatch(/LiveKit/i);
+    expect(JSON.stringify(body)).not.toMatch(/compiled prompt/i);
+  });
 });
 
 describe("Agent slug uniqueness", () => {

--- a/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
@@ -81,4 +81,54 @@ describe("buildVoiceTestDispatchMetadata", () => {
     const roundTripped = JSON.parse(JSON.stringify(md));
     expect(roundTripped).toEqual(md);
   });
+
+  // --------------------------------------------------------------------
+  // Prompt-sync prototype (ADR-015): when the dashboard wants the worker
+  // to use the *latest compiled prompt* instead of its baked-in profile
+  // prompt, the prompt rides in the dispatch metadata under
+  // `compiled_prompt` (snake_case to match the rest of the worker-facing
+  // payload). `compiled_prompt_compiled_at` carries the timestamp so the
+  // worker can log which version it ran with.
+  // --------------------------------------------------------------------
+
+  test("omits compiled_prompt when caller does not opt in", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect("compiled_prompt" in md).toBe(false);
+    expect("compiled_prompt_compiled_at" in md).toBe(false);
+  });
+
+  test("carries compiled_prompt verbatim when supplied", () => {
+    const promptBody = "You are Sam. Answer in one sentence.";
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "banknowa_v1",
+      sessionId: "sess-1",
+      callerEmail: "tester@corp.com",
+      compiledPrompt: promptBody,
+      compiledAt: "2026-06-07T00:00:00.000Z",
+    });
+    expect(md.compiled_prompt).toBe(promptBody);
+    expect(md.compiled_prompt_compiled_at).toBe("2026-06-07T00:00:00.000Z");
+    // Routing field MUST still be the slug — the prompt-sync prototype
+    // adds a payload but does not change which worker profile is picked.
+    expect(md.agentName).toBe("banknowa_v1");
+  });
+
+  test("compiled_prompt round-trips through JSON unchanged", () => {
+    // Worker uses json.loads() — verify Unicode / newline / quote chars
+    // survive untouched.
+    const tricky = "Línea 1\nLínea 2 — “quoted” \\backslash";
+    const md = buildVoiceTestDispatchMetadata({
+      agentSlug: "x",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+      compiledPrompt: tricky,
+      compiledAt: "2026-06-07T00:00:00.000Z",
+    });
+    const roundTripped = JSON.parse(JSON.stringify(md));
+    expect(roundTripped.compiled_prompt).toBe(tricky);
+  });
 });

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
@@ -22,8 +22,11 @@ const mockTokenResponse = {
 
 vi.mock('~/lib/api', () => ({
   api: {
-    post: (url: string) => {
-      mockPost(url)
+    post: (url: string, opts?: { json?: unknown }) => {
+      // Capture body so prompt-sync tests can assert the flag was sent.
+      // ky's API is `post(url, { json: body })` — we unwrap once so the
+      // assertion reads naturally as `(url, { useCompiledPrompt: ... })`.
+      mockPost(url, opts?.json)
       return {
         json: () => Promise.resolve(mockTokenResponse),
       }
@@ -156,7 +159,13 @@ describe('VoiceTestPanel', () => {
     fireEvent.click(btn)
 
     await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/voice-test-token')
+      // Default behavior — body says the worker should use its baked-in
+      // profile prompt (ADR-014). The flag is included explicitly false
+      // so a future server-side default change can't silently flip the
+      // behavior of an idle dashboard.
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/voice-test-token', {
+        useCompiledPrompt: false,
+      })
     })
     // Once we have a token, <LiveKitRoom> mounts.
     await waitFor(() => {
@@ -166,6 +175,43 @@ describe('VoiceTestPanel', () => {
     // Session id appears in the footer for debugging.
     await waitFor(() => {
       expect(screen.getByText(/Session/)).toBeInTheDocument()
+    })
+  })
+
+  // --------------------------------------------------------------------
+  // Prompt-sync prototype (ADR-015): a toggle on the panel asks the
+  // server to ship the agent's compiled prompt to the worker via
+  // dispatch metadata. The toggle is only useful when a compiled prompt
+  // actually exists.
+  // --------------------------------------------------------------------
+
+  it('shows the prompt-sync toggle when a compiled prompt exists', () => {
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+    const toggle = screen.getByRole('checkbox', { name: /use latest compiled prompt/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).not.toBeDisabled()
+  })
+
+  it('disables the prompt-sync toggle when there is no compiled prompt', () => {
+    stubMicPermission(true)
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    render(<VoiceTestPanel agent={noPrompt} canMutate />, { wrapper })
+    const toggle = screen.getByRole('checkbox', { name: /use latest compiled prompt/i })
+    expect(toggle).toBeDisabled()
+  })
+
+  it('sends useCompiledPrompt=true when the toggle is enabled', async () => {
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /use latest compiled prompt/i }))
+    fireEvent.click(screen.getByRole('button', { name: /talk to agent/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/voice-test-token', {
+        useCompiledPrompt: true,
+      })
     })
   })
 

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
@@ -23,7 +23,7 @@
 
 import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
 import { useMutation } from '@tanstack/react-query'
-import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { AlertTriangle, Mic, Radio, Sparkles } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -46,6 +46,13 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
   const [wsUrl, setWsUrl] = useState<string | null>(null)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  // Prompt-sync prototype (ADR-015): when true, the API ships the agent's
+  // latest compiled prompt to the worker as part of dispatch metadata. The
+  // toggle only makes sense for agents that already have a compiled prompt
+  // — for fresh agents the option is rendered disabled and the panel falls
+  // back to the ADR-014 "worker uses its baked-in profile" default.
+  const hasCompiledPrompt = !!agent.compiledInstructions
+  const [useCompiledPrompt, setUseCompiledPrompt] = useState(false)
 
   // Hang-up generation counter: once the operator hangs up, the in-flight
   // token fetch's onSuccess must not drag the UI back into a CONNECTING
@@ -80,7 +87,13 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
       setState('CHECKING_MIC')
       await ensureMicPermission()
       setState('REQUESTING_TOKEN')
-      return api.post(`agents/${agent.id}/voice-test-token`).json<VoiceTestTokenResponse>()
+      // Always send the flag explicitly — if the server-side default ever
+      // changes, an idle dashboard shouldn't silently flip behavior.
+      return api
+        .post(`agents/${agent.id}/voice-test-token`, {
+          json: { useCompiledPrompt: useCompiledPrompt && hasCompiledPrompt },
+        })
+        .json<VoiceTestTokenResponse>()
     },
     onSuccess: (resp) => {
       setSessionId(resp.sessionId)
@@ -163,6 +176,33 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
             Configure the LiveKit URL, API key, and secret for this agent before testing.
           </div>
         )}
+
+        {/* Prompt-sync toggle — ADR-015. Shown for every LiveKit agent so the
+            affordance is discoverable; disabled until the agent has been
+            compiled. The label sits inside the same label element as the
+            checkbox so click-on-text toggles the checkbox. */}
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-bg-subtle bg-bg-subtle/30 p-3">
+          <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-brand-500" />
+          <div className="flex flex-col gap-1">
+            <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-primary">
+              <input
+                type="checkbox"
+                className="h-3.5 w-3.5 rounded border-bg-subtle accent-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+                checked={useCompiledPrompt && hasCompiledPrompt}
+                onChange={(e) => setUseCompiledPrompt(e.target.checked)}
+                disabled={!hasCompiledPrompt || inCall}
+                aria-label="Use latest compiled prompt"
+              />
+              Use latest compiled prompt
+              <Badge variant="default">Prototype</Badge>
+            </label>
+            <p className="text-xs text-fg-muted">
+              {hasCompiledPrompt
+                ? 'Ships the dashboard-compiled prompt to the worker via dispatch metadata so you can talk with the prompt you just edited — no redeploy needed.'
+                : 'Compile this agent first to enable prompt-sync testing.'}
+            </p>
+          </div>
+        </div>
 
         <div className="mt-4 flex flex-wrap items-center gap-3">
           {showStartButton ? (


### PR DESCRIPTION
## Summary

Closes the "edit prompt → hear it" loop for LiveKit voice agents — no worker redeploy required.

A new opt-in toggle on the Voice Test panel — **Use latest compiled prompt** — tells `POST /agents/:id/voice-test-token` to read the agent's `compiledInstructions` and add it to LiveKit dispatch metadata as `compiled_prompt`. A prompt-sync-aware worker (`BuildProAgent` in `examples/agents/livekit-agent/`) reads that field and uses it verbatim as the agent's instructions instead of the prompt baked into the worker profile.

When the toggle is off (default), the dispatch is byte-for-byte identical to ADR-014 and the worker uses its baked-in prompt. The prototype rides alongside the existing "Talk to agent" flow; nothing in production behavior changes unless the operator opts in.

## Why a new ADR

ADR-014 deliberately rejected prompt injection because of drift risk ("works in voice-test, broken in prod"). ADR-015 re-opens that decision, narrowly, as an opt-in prototype — the redeploy-per-edit cost has turned out to be the dominant friction in prompt iteration. The toggle is badged "Prototype" on the panel and graduation criteria are spelled out in the ADR (byte cap, visible drift warning, operator-tested sustained use).

## What's in the PR

**API (`modelguide-api`):**
- `POST /agents/:id/voice-test-token` accepts an optional body `{ useCompiledPrompt: boolean }`.
- `createVoiceTestSession` loads `agents.compiledInstructions` + `compiledAt` when the flag is true, and 400s if no compiled prompt exists.
- `buildVoiceTestDispatchMetadata` gains optional `compiledPrompt` / `compiledAt` args; the resulting metadata adds `compiled_prompt` + `compiled_prompt_compiled_at` keys when supplied, and is unchanged otherwise.

**Worker (`examples/agents/livekit-agent`):**
- `agent.py` parses `compiled_prompt` from `ctx.job.metadata` and logs the length + compiled_at timestamp.
- `BuildProAgent.__init__` takes a new `instructions_override` kwarg; if non-empty, it replaces the baked-in `build_system_prompt(...)` output. Empty / whitespace-only values are ignored (belt-and-braces against an accidental "" blanking the agent).

**UI (`modelguide-ui`):**
- `VoiceTestPanel` renders a "Use latest compiled prompt" checkbox with a "Prototype" badge. Disabled until the agent has been compiled.
- The mutation body now always sends `useCompiledPrompt: boolean` explicitly so a future server-side default change can't silently flip behavior.

**Docs:**
- `docs/decisions/015-livekit-prompt-sync-prototype.md` — ADR (proposed/prototype) covering motivation, the wire contract, what's same/different vs ADR-014, alternatives, consequences, and graduation criteria.
- `examples/agents/livekit-agent/PROMPT_SYNC.md` — operator-facing README for the worker side: how it works, the wire contract, how to test locally, and how to revert.

## Tests (red-green TDD)

- **TS unit (`voice-test-dispatch.test.ts`)** — `buildVoiceTestDispatchMetadata` omits `compiled_prompt` by default, carries it verbatim when supplied, and survives a JSON round-trip with Unicode / newlines / quotes.
- **TS integration (`agents.test.ts`)** — `useCompiledPrompt=true` with no compiled instructions returns 400; `useCompiledPrompt=false` follows the existing LiveKit-not-configured path.
- **Python (`test_prompt_sync.py`)** — `BuildProAgent` uses the override verbatim when supplied; falls back to the baked-in BuildPro prompt when override is `None` or whitespace; the dispatcher's exact JSON shape round-trips into the worker correctly.
- **UI (`voice-test-panel.test.tsx`)** — toggle shows for compiled agents, disabled otherwise; clicking it flips the POST body to `{ useCompiledPrompt: true }`.

The TS unit + Python tests form a two-sided type system between the dispatcher and the worker — both sides build cleanly even if a field name drifts, so the paired tests are the contract. Called out in the ADR and in `PROMPT_SYNC.md`.

## Test plan

- [x] `cd modelguide-api && bun test --preload ./tests/setup/unit-preload.ts tests/unit/agents/` — 21 pass
- [x] `cd modelguide-api && bun run typecheck` — clean
- [x] `cd modelguide-api && bun run lint:check` — clean
- [x] `cd modelguide-ui && npx vitest run --root . src/features/agents/` — 9 pass
- [x] `cd modelguide-ui && npm run typecheck` — clean
- [x] `cd modelguide-ui && npm run lint` — clean
- [x] `cd examples/agents/livekit-agent && uv run pytest tests/test_prompt_sync.py -v` — 5 pass
- [ ] `make api-test-integration` — requires Postgres; not run locally in the sandbox (no Docker), expected to run in CI
- [ ] Manual: spin up local LiveKit + agent, compile an agent in the dashboard, toggle on, click "Talk to agent", confirm the worker log line `Prompt-sync test: using compiled prompt (len=N, compiled_at=...)` appears

## Notes

- `test_agent.py` (pre-existing) fails to collect on `main` due to a stale `TOOL_NAME_MAP` import — unrelated to this PR. Left untouched.
- No new endpoints, no schema migration, no new env vars. The whole prototype is gated by one optional body field.

https://claude.ai/code/session_015bMSXxZauuBLWYG6Rmn4Ap

---
_Generated by [Claude Code](https://claude.ai/code/session_015bMSXxZauuBLWYG6Rmn4Ap)_