### PR TITLE
feat(agents): runtime prompt fetch for LiveKit voice workers (ADR-015)

### DIFF
--- a/docs/decisions/015-runtime-prompt-fetch-for-livekit.md
+++ b/docs/decisions/015-runtime-prompt-fetch-for-livekit.md
@@ -1,0 +1,179 @@
+# ADR-015: Runtime Prompt Fetch for LiveKit Voice Agents
+
+**Status:** Accepted
+
+## Context
+
+The dashboard already lets admins:
+
+1. Edit `promptConfig` (persona / language / filler phrases)
+2. Compile a prompt from one or more assigned SOPs → `agents.compiledInstructions`
+3. Click **Talk to agent** in the voice-test panel (ADR-014) to dispatch the
+   deployed LiveKit worker and join the room from the browser
+
+The gap: step 3 reaches a worker whose system prompt is **baked into the worker
+image** (e.g. `examples/agents/livekit-agent/src/prompts/`). When step 2 produces
+a new compiled prompt, the next "Talk to agent" call still uses the **old**
+prompt — admins have to redeploy the worker to see the change. That kills the
+compile-and-talk feedback loop the platform was built around.
+
+The closely related ADR-014 specifically rejected solving this by having the
+**client** inject the prompt into LiveKit dispatch metadata. That rejection
+stands: it would let any caller smuggle arbitrary instructions into a
+voice-test, and force the client to know byte limits / encoding rules / the
+worker's profile structure.
+
+This ADR addresses the same gap from the other side: have the **worker**
+authoritatively pull the latest compiled prompt from ModelGuide at session
+start. ModelGuide remains the canonical source — the client never names a
+prompt, never sends bytes the worker has to bound-check.
+
+## Decision
+
+Add an agent-authenticated `GET /api/agents/me/runtime-config` endpoint and a
+`INSTRUCTIONS_SOURCE=local|remote` switch on the LiveKit worker. When set to
+`remote`, the worker fetches the latest `compiledInstructions` on each session
+start and uses it as the system prompt (after the usual `{{mg_session_id}}` /
+`{{userEmail}}` interpolation). Failure to fetch falls back to the baked-in
+prompt — the worker is never blocked.
+
+### Endpoint shape
+
+`GET /api/agents/me/runtime-config` — auth: `requireAgent()` (API key only,
+`mgk_*`).
+
+```ts
+{
+  id: string,           // agent uuid
+  name: string,
+  slug: string,
+  modality: "voice" | "text",
+  modelFamily: "gpt" | "claude" | "gemini" | "generic",
+  promptConfig: { persona?, language?, fillerPhrases? } | {},
+  compiledInstructions: string | null,   // latest compiled prompt
+  compiledAt: string | null,             // ISO timestamp
+  isActive: boolean,
+}
+```
+
+Deliberately narrower than `GET /api/agents/:id`: no secrets map, no
+integration URLs, no metadata, no eval counts. The worker doesn't need those
+to bootstrap a session, and shipping them would leak more org-internal state
+than necessary into the runtime envelope.
+
+The worker authenticates with its own API key (the one minted at agent
+creation), so the endpoint trivially scopes to the calling agent — no `:id`
+in the path means there's no enumeration surface and no cross-org footgun.
+
+### Worker side
+
+`examples/agents/livekit-agent/src/agent.py` gains a `_resolve_instructions_override()`
+helper called once per session, after session creation, before the agent is
+constructed:
+
+```python
+async def _resolve_instructions_override() -> str | None:
+    if config.INSTRUCTIONS_SOURCE != "remote":
+        return None
+    cfg = await mg_client.get_runtime_config()
+    if not cfg or not cfg.get("compiledInstructions"):
+        return None
+    return cfg["compiledInstructions"]
+```
+
+`BuildProAgent.__init__(..., instructions_override=...)` threads the value
+into `build_system_prompt(template=...)`, which keeps placeholder
+interpolation working identically whether the prompt is baked-in or
+freshly compiled.
+
+### Failure modes
+
+The fetch is best-effort. Every failure path falls back to the baked-in
+template — never to a half-loaded prompt:
+
+| Condition | Behavior |
+|---|---|
+| `INSTRUCTIONS_SOURCE=local` (default) | Skip fetch entirely. No network call. |
+| Network error / timeout | Log a warning, use baked-in. |
+| 4xx / 5xx from API | Log a warning, use baked-in. |
+| `compiledInstructions: null` (no compile yet) | Use baked-in. |
+| `compiledInstructions: ""` (explicitly empty) | Use baked-in. An empty prompt is never useful. |
+| Valid compiled prompt | Use it as the system prompt. |
+
+`local` stays the default to keep first-time setup and the "I just want to
+try the example" path zero-config. New customer agents flip to `remote` once
+they've compiled at least one prompt from the dashboard.
+
+## What this is NOT
+
+- **Not a prompt-override channel from the client.** The client never names
+  a prompt; the worker authenticates as itself and asks MG. ADR-014's
+  rejection of client-side injection still stands.
+- **Not a hot-reload during a live call.** Fetch happens once per session
+  start, before LLM context is built. Changing the compiled prompt mid-call
+  doesn't reach an in-progress session — by design (mid-call prompt swaps
+  produce chaotic LLM behavior).
+- **Not a replacement for redeploying tool wiring.** Tool registration
+  (`@function_tool` methods, MCP name mapping, guardrails) is still baked
+  into the worker image. The runtime fetch only swaps the system-prompt
+  *string*. Adding a new tool still needs a worker release.
+- **Not coupled to the voice-test endpoint.** Every dispatch — voice-test,
+  outbound call (ADR-011), or production inbound — uses the same resolver.
+  The dashboard "Talk to agent" button just becomes a faster feedback loop
+  on top of the same path.
+
+## Alternatives Considered
+
+**Hot-reload the prompt during a live session.** Rejected — LLMs respond
+poorly to mid-conversation system-prompt rewrites (lost context, contradiction
+with prior turns). Swap at session start only.
+
+**Worker subscribes to a "prompt updated" webhook from MG.** Considered;
+rejected for the prototype. A pull-at-session-start model has zero new
+infrastructure (no webhook secrets, no retry queue, no worker-side HTTP
+listener). If real-time invalidation ever becomes necessary, this ADR's
+pull path stays compatible.
+
+**Embed `compiledInstructions` in `dispatch_metadata` (the rejected
+ADR-014 design).** Still rejected for the same reasons: drift between
+"what the client sent" and "what the agent profile actually does" + byte
+caps to enforce.
+
+**Expand `GET /api/agents/:id` to accept agent-key auth.** Rejected —
+that endpoint returns secrets refs, external IDs, eval counts, and other
+admin-shaped fields. Loosening its auth would either leak admin data to
+workers or require a fork of the response shape. A dedicated runtime
+endpoint with a narrower payload is cleaner.
+
+## Consequences
+
+- The compile → talk loop is **one click** when `INSTRUCTIONS_SOURCE=remote`:
+  edit prompt config → Compile → Talk to agent → new prompt is live in the
+  next call.
+- Per-session latency cost: one extra HTTPS GET to MG at connection setup.
+  Measured at ~80–150 ms in `make api-dev` against localhost; negligible
+  against LiveKit's own connection setup.
+- Failure of the MG API does not break voice calls — the worker uses its
+  baked-in fallback. Operationally this means a dashboard outage degrades
+  to "old prompt" rather than "no calls work."
+- The baked-in prompt now serves as the **safety net**, not the source of
+  truth, when `remote` is enabled. Keeping the baked-in copy reasonably
+  fresh is still a good practice (it's what gets used during MG outages).
+- Drift watch: `mg_client.get_runtime_config()` swallows errors and returns
+  `None`. If MG ever changes the response shape (e.g. moves
+  `compiledInstructions` under a `prompt: { … }` envelope), the worker
+  silently falls back to baked-in instead of crashing. This is the right
+  trade-off for runtime stability — but means a schema change without a
+  worker bump produces "compiled prompt isn't taking effect anymore" rather
+  than a loud error. Mitigation: the integration test
+  (`agents.test.ts` → `GET /api/agents/me/runtime-config`) asserts the
+  exact field name, so a server-side rename has to update the test, which
+  is the prompt to also bump the worker.
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls — the dispatch pattern this builds on.
+- ADR-014: Browser Voice Testing — the "Talk to agent" flow this completes.
+- `examples/agents/livekit-agent/README.md` — worker-side usage.
+- PR introducing this ADR adds: API endpoint, Python client + tests, agent
+  resolver + tests, UI hint in the voice-test panel.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing via LiveKit Dispatch | Accepted |
+| [015-runtime-prompt-fetch-for-livekit.md](015-runtime-prompt-fetch-for-livekit.md) | Runtime Prompt Fetch for LiveKit Voice Agents | Accepted |

--- a/examples/agents/livekit-agent/.env.example
+++ b/examples/agents/livekit-agent/.env.example
@@ -38,6 +38,13 @@ USER_EMAIL=demo@buildpro.com
 # Set to empty string to disable all stubs: STUBBED_TOOLS=
 STUBBED_TOOLS=send_email
 
+# System prompt source (ADR-015):
+#   local  — baked-in prompts/base.py + prompts/workflows/ (default, fastest boot)
+#   remote — fetch the latest compiled prompt from MG at every session start.
+#            Lets the dashboard's compile → talk loop take effect without
+#            redeploying the worker. Falls back to local if the fetch fails.
+INSTRUCTIONS_SOURCE=local
+
 # SIP / Telephony
 # Outbound trunk ID for Twilio (get from `lk sip outbound list` after setup)
 # See sip/README.md for full setup instructions

--- a/examples/agents/livekit-agent/README.md
+++ b/examples/agents/livekit-agent/README.md
@@ -156,6 +156,9 @@ ModelGuide API
 
 **Session lifecycle:**
 - On connect: Creates a ModelGuide session via `POST /api/sessions`
+- On connect (when `INSTRUCTIONS_SOURCE=remote`): pulls the latest compiled prompt
+  via `GET /api/agents/me/runtime-config` so the dashboard's compile → talk loop
+  takes effect without redeploying the worker (see ADR-015)
 - During call: LLM tool calls execute via ModelGuide's MCP endpoint (`POST /mcp/:agentId`)
 - On goodbye: Agent signs off → user confirms → agent replies once → auto-disconnect after 3s
 - On close: Posts the full transcript to ModelGuide, then marks the session as completed
@@ -264,6 +267,37 @@ from your_agent import YourAgent as AgentClass
 ```
 
 That's it. Langfuse traces, ModelGuide session tracking, transcript posting, and the MCP connection all work without changes.
+
+## Runtime Prompt Fetch (ADR-015)
+
+By default the worker uses its baked-in prompt (`prompts/base.py` +
+`prompts/workflows/`). That keeps first-time setup zero-config and gives
+the example a known-good fallback.
+
+For the "compile in the dashboard → click Talk to agent → hear the new
+prompt immediately" loop, set:
+
+```bash
+INSTRUCTIONS_SOURCE=remote
+```
+
+When set, the worker calls `GET /api/agents/me/runtime-config` on every
+session start (using its API key) and uses the returned `compiledInstructions`
+as the system prompt. The baked-in prompt becomes the fallback for any
+fetch failure (network error, MG outage, no compile yet, empty prompt).
+
+**Operational consequence:** an MG outage degrades to "old prompt" rather
+than "no calls work." The runtime fetch never blocks call setup.
+
+**What this does NOT do:**
+
+- Hot-reload during a live call — the fetch happens at session start only.
+  A compile mid-call doesn't reach an in-progress session (by design — LLMs
+  respond poorly to mid-conversation system-prompt swaps).
+- Replace redeploying tool wiring — only the system-prompt string is
+  fetched. Adding a new tool still needs a worker release.
+
+See ADR-015 in `docs/decisions/` for the full reasoning.
 
 ## Stubbed Tools
 

--- a/examples/agents/livekit-agent/src/agent.py
+++ b/examples/agents/livekit-agent/src/agent.py
@@ -157,8 +157,18 @@ async def entrypoint(ctx: agents.JobContext):
             logger.exception("Failed to create ModelGuide session — running without tracking")
     logger.info("ModelGuide session: %s (user: %s)", session_id, user_identifier)
 
+    # Fetch the latest compiled prompt from ModelGuide (ADR-015). Falls back to
+    # the baked-in template if INSTRUCTIONS_SOURCE=local or the fetch fails —
+    # the worker is never blocked on a missing/slow API.
+    instructions_override = await _resolve_instructions_override()
+
     # Build agent + session
-    agent = BuildProAgent(session_id=session_id, user_email=user_identifier, mcp=mcp)
+    agent = BuildProAgent(
+        session_id=session_id,
+        user_email=user_identifier,
+        mcp=mcp,
+        instructions_override=instructions_override,
+    )
     stt = create_stt()
     tts = create_tts()
 
@@ -272,6 +282,35 @@ async def entrypoint(ctx: agents.JobContext):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _resolve_instructions_override() -> str | None:
+    """Pull the latest compiled prompt from MG when INSTRUCTIONS_SOURCE=remote.
+
+    Returns ``None`` if remote fetch is disabled, the response is missing a
+    compiled prompt, or the fetch fails. The caller falls back to the baked-in
+    template — the worker is never blocked on a slow/missing API.
+    See ADR-015.
+    """
+    if config.INSTRUCTIONS_SOURCE != "remote":
+        return None
+
+    cfg = await mg_client.get_runtime_config()
+    if not cfg:
+        logger.warning("Runtime config unavailable — using baked-in prompt")
+        return None
+
+    compiled = cfg.get("compiledInstructions")
+    if not compiled:
+        logger.info("No compiled prompt set on MG agent — using baked-in prompt")
+        return None
+
+    logger.info(
+        "Using remote compiled prompt (%d chars, compiled_at=%s)",
+        len(compiled),
+        cfg.get("compiledAt"),
+    )
+    return compiled
 
 
 def _extract_text(item) -> str:

--- a/examples/agents/livekit-agent/src/buildpro.py
+++ b/examples/agents/livekit-agent/src/buildpro.py
@@ -36,13 +36,32 @@ class BuildProAgent(MCPAgent):
     ]
 
     def __init__(
-        self, *, session_id: str | None, user_email: str, mcp: mg_client.MCPConnection | None = None
+        self,
+        *,
+        session_id: str | None,
+        user_email: str,
+        mcp: mg_client.MCPConnection | None = None,
+        instructions_override: str | None = None,
     ) -> None:
+        """Build the agent.
+
+        ``instructions_override`` — when set (e.g. the compiled prompt fetched
+        from MG at session start), it replaces the baked-in template. Runtime
+        placeholders are still interpolated so {{mg_session_id}} etc. work the
+        same way regardless of the source. See ADR-015.
+        """
         self._active_cart_id: str | None = None
         self._cart_ready = asyncio.Event()
         self._reorder_product_ids: list[str] = []
 
-        instructions = build_system_prompt(session_id or "", user_email=user_email)
+        if instructions_override:
+            instructions = build_system_prompt(
+                session_id or "",
+                user_email=user_email,
+                template=instructions_override,
+            )
+        else:
+            instructions = build_system_prompt(session_id or "", user_email=user_email)
         super().__init__(session_id=session_id, mcp=mcp, instructions=instructions)
 
     # ------------------------------------------------------------------

--- a/examples/agents/livekit-agent/src/config.py
+++ b/examples/agents/livekit-agent/src/config.py
@@ -71,6 +71,13 @@ LANGFUSE_HOST: str = "https://cloud.langfuse.com"
 # Stubbed tools (comma-separated names with no MCP backend yet — returns fake success)
 STUBBED_TOOLS: str = "send_email"
 
+# Where the system prompt comes from at session start:
+#   "local"  — baked-in prompts/base.py + prompts/workflows/ (default, fastest)
+#   "remote" — fetch from MG via GET /api/agents/me/runtime-config at session
+#              start so the dashboard's compile → talk loop takes effect
+#              without redeploying the worker (ADR-015)
+INSTRUCTIONS_SOURCE: str = "local"
+
 # SIP / Telephony
 SIP_OUTBOUND_TRUNK_ID: str = ""  # Twilio outbound trunk ID (ST_xxxx)
 
@@ -122,6 +129,8 @@ def validate() -> None:
         "LANGFUSE_HOST": os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),
         # Stubbed tools
         "STUBBED_TOOLS": os.getenv("STUBBED_TOOLS", "send_email"),
+        # ADR-015 — prompt source (local | remote)
+        "INSTRUCTIONS_SOURCE": os.getenv("INSTRUCTIONS_SOURCE", "local"),
         # SIP / Telephony
         "SIP_OUTBOUND_TRUNK_ID": os.getenv("SIP_OUTBOUND_TRUNK_ID", ""),
         # Other

--- a/examples/agents/livekit-agent/src/mg_client.py
+++ b/examples/agents/livekit-agent/src/mg_client.py
@@ -73,6 +73,51 @@ async def create_session(user_identifier: str | None = None) -> str:
     return session_id
 
 
+async def get_runtime_config() -> dict | None:
+    """Fetch the agent's runtime config (latest compiled prompt + voice config).
+
+    Pairs with ``GET /api/agents/me/runtime-config`` on the API. Lets the
+    worker pull the latest compiled prompt at session start instead of using
+    the baked-in copy, so the dashboard's compile-and-talk loop takes effect
+    without redeploying the worker. See ADR-015.
+
+    Returns ``None`` on error rather than raising — the caller is expected
+    to fall back to its baked-in prompt. Errors are logged.
+
+    Response shape (success):
+        {
+            "id": "<agent uuid>",
+            "name": "...",
+            "slug": "...",
+            "modality": "voice"|"text",
+            "modelFamily": "gpt"|"claude"|"gemini"|"generic",
+            "promptConfig": {"persona": ..., "language": ..., ...},
+            "compiledInstructions": "..." | None,
+            "compiledAt": "...iso..." | None,
+            "isActive": true,
+        }
+    """
+    client = _get_http_client()
+    try:
+        res = await client.get("/api/agents/me/runtime-config")
+    except Exception:
+        logger.exception("Failed to fetch runtime config")
+        return None
+
+    if not res.is_success:
+        logger.warning(
+            "Runtime config fetch failed (status %s): %s",
+            res.status_code,
+            res.text[:200],
+        )
+        return None
+    try:
+        return res.json()
+    except Exception:
+        logger.exception("Failed to parse runtime config response")
+        return None
+
+
 async def add_messages(session_id: str, messages: list[dict]) -> None:
     """Post messages to a session. Errors are logged, not raised."""
     client = _get_http_client()

--- a/examples/agents/livekit-agent/src/prompts/__init__.py
+++ b/examples/agents/livekit-agent/src/prompts/__init__.py
@@ -17,10 +17,18 @@ def build_system_prompt(
     user_email: str = "voice-caller",
     channel: str = "voice",
     order_id: str = "",
+    template: str | None = None,
 ) -> str:
-    """Interpolate runtime values into the system prompt."""
+    """Interpolate runtime values into the system prompt.
+
+    ``template`` — when provided, replaces ``SYSTEM_PROMPT_TEMPLATE`` for this
+    call only. Used by ADR-015's runtime-fetch path so the same {{mg_session_id}}
+    / {{userEmail}} / {{channel}} / {{orderId}} placeholders are honored
+    whether the prompt is the baked-in copy or freshly compiled from MG.
+    """
+    base = template if template is not None else SYSTEM_PROMPT_TEMPLATE
     return (
-        SYSTEM_PROMPT_TEMPLATE
+        base
         .replace("{{mg_session_id}}", session_id)
         .replace("{{userEmail}}", user_email)
         .replace("{{channel}}", channel)

--- a/examples/agents/livekit-agent/tests/test_mg_client.py
+++ b/examples/agents/livekit-agent/tests/test_mg_client.py
@@ -84,6 +84,79 @@ class TestAddMessages:
             await mg_client.add_messages("sess_1", [{"role": "user", "content": "hi"}])
 
 
+class TestGetRuntimeConfig:
+    @pytest.mark.asyncio
+    async def test_returns_config_on_success(self):
+        config_payload = {
+            "id": "agt_123",
+            "name": "Sam",
+            "slug": "buildpro-sam",
+            "modality": "voice",
+            "modelFamily": "gpt",
+            "promptConfig": {"persona": "concise"},
+            "compiledInstructions": "You are Sam. Be helpful.",
+            "compiledAt": "2026-06-08T12:00:00.000Z",
+            "isActive": True,
+        }
+        client = _mock_client("get", _mock_response(200, config_payload))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.get_runtime_config()
+
+        assert result == config_payload
+        call_args = client.get.call_args
+        assert call_args[0][0] == "/api/agents/me/runtime-config"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_http_error(self):
+        client = _mock_client("get", _mock_response(401, text="Unauthorized"))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.get_runtime_config()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_failure(self):
+        client = AsyncMock()
+        client.get.side_effect = httpx.ConnectError("connection refused")
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.get_runtime_config()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_json(self):
+        resp = _mock_response(200)
+        resp.json.side_effect = ValueError("not json")
+        client = _mock_client("get", resp)
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.get_runtime_config()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_compiled_instructions_can_be_null(self):
+        # Agent without a compiled prompt — endpoint returns null, not omitted
+        config_payload = {
+            "id": "agt_123",
+            "name": "Sam",
+            "slug": "buildpro-sam",
+            "modality": "voice",
+            "modelFamily": "gpt",
+            "promptConfig": {},
+            "compiledInstructions": None,
+            "compiledAt": None,
+            "isActive": True,
+        }
+        client = _mock_client("get", _mock_response(200, config_payload))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.get_runtime_config()
+
+        assert result is not None
+        assert result["compiledInstructions"] is None
+
+
 class TestCompleteSession:
     @pytest.mark.asyncio
     async def test_patches_status(self):

--- a/examples/agents/livekit-agent/tests/test_prompts.py
+++ b/examples/agents/livekit-agent/tests/test_prompts.py
@@ -65,6 +65,48 @@ class TestBuildSystemPrompt:
         assert "two forty nine dollars" in SYSTEM_PROMPT_TEMPLATE
 
 
+class TestTemplateOverride:
+    """ADR-015 — prompts/get_runtime_config() flow."""
+
+    def test_uses_override_template_when_provided(self):
+        result = build_system_prompt(
+            "sess_1",
+            user_email="bob@x.com",
+            template="Custom: {{userEmail}} / {{mg_session_id}}",
+        )
+        assert result == "Custom: bob@x.com / sess_1"
+        # Critically: no leakage from the baked-in BuildPro template
+        assert "BuildPro" not in result
+        assert "Sam" not in result
+
+    def test_falls_back_to_baked_in_when_template_is_none(self):
+        result = build_system_prompt("sess_1", template=None)
+        assert "BuildPro" in result
+        assert "Sam" in result
+
+    def test_falls_back_to_baked_in_by_default(self):
+        # No template arg at all — same as None
+        result = build_system_prompt("sess_1")
+        assert "BuildPro" in result
+
+    def test_override_still_interpolates_all_placeholders(self):
+        template = "S:{{mg_session_id}} U:{{userEmail}} C:{{channel}} O:{{orderId}}"
+        result = build_system_prompt(
+            "sess_x",
+            user_email="alice@y.com",
+            channel="text",
+            order_id="ORD-9",
+            template=template,
+        )
+        assert result == "S:sess_x U:alice@y.com C:text O:ORD-9"
+
+    def test_empty_string_override_is_respected(self):
+        # Edge case: caller explicitly passes "" — that's a valid (empty) prompt,
+        # not a "fall back to baked-in" signal. The is-not-None check matters.
+        result = build_system_prompt("sess_1", template="")
+        assert result == ""
+
+
 class TestWorkflowLoading:
     def test_loads_all_workflows(self):
         workflows = load_all()

--- a/examples/agents/livekit-agent/tests/test_runtime_config.py
+++ b/examples/agents/livekit-agent/tests/test_runtime_config.py
@@ -1,0 +1,129 @@
+"""Tests for ADR-015 — runtime fetch of the compiled prompt.
+
+Covers the entrypoint's ``_resolve_instructions_override`` resolver and the
+BuildProAgent's ``instructions_override`` plumbing. These are isolated from
+LiveKit / asyncio internals — the agent constructor is exercised directly
+without starting an AgentSession.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import config
+from agent import _resolve_instructions_override
+from buildpro import BuildProAgent
+
+
+class TestResolveInstructionsOverride:
+    """The entrypoint helper that decides local vs remote at session start."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_source_is_local(self):
+        # Default config — INSTRUCTIONS_SOURCE=local — must never hit the network
+        with patch.object(config, "INSTRUCTIONS_SOURCE", "local"):
+            with patch(
+                "agent.mg_client.get_runtime_config", new=AsyncMock()
+            ) as mocked:
+                result = await _resolve_instructions_override()
+                assert result is None
+                mocked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_compiled_prompt_when_remote(self):
+        with patch.object(config, "INSTRUCTIONS_SOURCE", "remote"):
+            with patch(
+                "agent.mg_client.get_runtime_config",
+                new=AsyncMock(
+                    return_value={
+                        "compiledInstructions": "Be Sam. Be brief.",
+                        "compiledAt": "2026-06-08T12:00:00.000Z",
+                    }
+                ),
+            ):
+                result = await _resolve_instructions_override()
+
+        assert result == "Be Sam. Be brief."
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_fetch_returns_none(self):
+        # mg_client returns None on any failure (network, 4xx, 5xx, bad JSON)
+        # — the resolver must surface that as a "fall back to local" signal
+        with patch.object(config, "INSTRUCTIONS_SOURCE", "remote"):
+            with patch(
+                "agent.mg_client.get_runtime_config",
+                new=AsyncMock(return_value=None),
+            ):
+                result = await _resolve_instructions_override()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_compiled_is_null(self):
+        # Agent exists on MG but has no compiled prompt yet — same fallback path
+        with patch.object(config, "INSTRUCTIONS_SOURCE", "remote"):
+            with patch(
+                "agent.mg_client.get_runtime_config",
+                new=AsyncMock(
+                    return_value={
+                        "compiledInstructions": None,
+                        "compiledAt": None,
+                    }
+                ),
+            ):
+                result = await _resolve_instructions_override()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_compiled_is_empty_string(self):
+        # An explicitly empty compiled prompt isn't useful — treat as missing
+        with patch.object(config, "INSTRUCTIONS_SOURCE", "remote"):
+            with patch(
+                "agent.mg_client.get_runtime_config",
+                new=AsyncMock(return_value={"compiledInstructions": ""}),
+            ):
+                result = await _resolve_instructions_override()
+
+        assert result is None
+
+
+class TestBuildProAgentInstructionsOverride:
+    """Agent construction with and without a compiled prompt override."""
+
+    def test_default_uses_baked_in_prompt(self):
+        agent = BuildProAgent(session_id="sess_1", user_email="x@y.com")
+        # BuildPro/Sam markers come from prompts/base.py
+        assert "Sam" in agent.instructions or "BuildPro" in agent.instructions
+
+    def test_override_replaces_baked_in_prompt(self):
+        agent = BuildProAgent(
+            session_id="sess_1",
+            user_email="x@y.com",
+            instructions_override="You are Mia from ClearHealth.",
+        )
+        assert "Mia" in agent.instructions
+        assert "ClearHealth" in agent.instructions
+        # The baked-in identity must be gone — drift would silently mix prompts
+        assert "BuildPro" not in agent.instructions
+
+    def test_override_interpolates_session_id(self):
+        agent = BuildProAgent(
+            session_id="sess_runtime_42",
+            user_email="caller@x.com",
+            instructions_override=(
+                "Session: {{mg_session_id}} / Email: {{userEmail}}"
+            ),
+        )
+        assert "sess_runtime_42" in agent.instructions
+        assert "caller@x.com" in agent.instructions
+        # Raw placeholder must not leak through
+        assert "{{mg_session_id}}" not in agent.instructions
+
+    def test_explicit_none_override_keeps_baked_in(self):
+        agent = BuildProAgent(
+            session_id="sess_1",
+            user_email="x@y.com",
+            instructions_override=None,
+        )
+        assert "Sam" in agent.instructions or "BuildPro" in agent.instructions

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRuntimeConfig,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -387,6 +390,68 @@ router.openapi(createAgentRoute, async (c) => {
   const { agent, apiKey } = await createAgent(orgId, body, user.id);
 
   return c.json({ ...formatAgent(agent), apiKey }, 201);
+});
+
+// ============================================================================
+// Worker Runtime Config (agent-authenticated)
+//
+// Deployed LiveKit workers call this at session start to fetch the latest
+// compiled prompt. Lets the dashboard "Talk to agent" + "Compile prompt" loop
+// take effect without a worker redeploy. See ADR-015.
+// ============================================================================
+
+const runtimeConfigResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  modality: z.enum(["voice", "text"]),
+  modelFamily: modelFamilySchema,
+  promptConfig: promptConfigSchema,
+  compiledInstructions: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+  isActive: z.boolean(),
+});
+
+// GET /me/runtime-config
+router.get("/me/runtime-config", requireAgent());
+
+const runtimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me/runtime-config",
+  tags: ["Agents"],
+  summary: "Fetch the calling agent's runtime config",
+  description:
+    "Returns the authenticated agent's runtime config — including the latest compiled prompt. Authenticated via API key (mgk_*); user JWTs are rejected. Intended for deployed workers fetching prompt + voice settings at session start so the dashboard's compile → talk loop takes effect without a worker redeploy.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Agent runtime config",
+      content: {
+        "application/json": { schema: runtimeConfigResponseSchema },
+      },
+    },
+    401: errorResponse("API key required (user JWT not accepted)"),
+  },
+});
+
+router.openapi(runtimeConfigRoute, async (c) => {
+  const agent = getCurrentAgent(c);
+  const cfg = await getAgentRuntimeConfig(agent.organizationId, agent.id);
+
+  return c.json(
+    {
+      id: cfg.id,
+      name: cfg.name,
+      slug: cfg.slug,
+      modality: cfg.modality,
+      modelFamily: cfg.modelFamily,
+      promptConfig: (cfg.promptConfig ?? {}) as Record<string, unknown>,
+      compiledInstructions: cfg.compiledInstructions ?? null,
+      compiledAt: cfg.compiledAt?.toISOString() ?? null,
+      isActive: cfg.isActive,
+    },
+    200,
+  );
 });
 
 // ============================================================================

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -108,6 +108,45 @@ export async function listAgents(
   });
 }
 
+/**
+ * Minimal runtime config exposed to a deployed worker authenticating with its
+ * own API key. Returns the compiled prompt + prompt config so the worker can
+ * use the latest version on every session start without redeploying its image.
+ *
+ * Deliberately narrower than ``getAgentById``:
+ *  - no secrets map / external IDs / eval counts (not relevant at runtime)
+ *  - no integration URLs (worker already knows where MG lives — that's how it
+ *    just authenticated)
+ *  - no metadata (avoids leaking org-internal config the worker doesn't need)
+ *
+ * Pairs with ``mg_client.get_runtime_config()`` in
+ * ``examples/agents/livekit-agent``. See ADR-015.
+ */
+export async function getAgentRuntimeConfig(orgId: string, agentId: string) {
+  return forOrg(orgId, async (tx) => {
+    const [agent] = await tx
+      .select({
+        id: agents.id,
+        name: agents.name,
+        slug: agents.slug,
+        modality: agents.modality,
+        modelFamily: agents.modelFamily,
+        promptConfig: agents.promptConfig,
+        compiledInstructions: agents.compiledInstructions,
+        compiledAt: agents.compiledAt,
+        isActive: agents.isActive,
+      })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+
+    if (!agent) {
+      throw Errors.agentNotFound(agentId);
+    }
+
+    return agent;
+  });
+}
+
 export async function getAgentById(orgId: string, agentId: string) {
   return forOrg(orgId, async (tx) => {
     const [agent] = await tx

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,12 +8,19 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
 let orgASupportHeaders: Record<string, string>;
 let orgBAdminHeaders: Record<string, string>;
+let orgAAgentHeaders: Record<string, string>;
+let orgBAgentHeaders: Record<string, string>;
 
 /** IDs of agents created during tests (for cleanup) */
 const createdAgentIds: string[] = [];
@@ -27,6 +34,8 @@ beforeAll(async () => {
   orgAAdminHeaders = await authHeadersFor(s.orgAAdmin);
   orgASupportHeaders = await authHeadersFor(s.orgASupport);
   orgBAdminHeaders = await authHeadersFor(s.orgBAdmin);
+  orgAAgentHeaders = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+  orgBAgentHeaders = await agentHeadersFor(s.orgBAgentId, s.orgB.id);
 });
 
 afterAll(async () => {
@@ -1058,5 +1067,86 @@ describe("Agent slug uniqueness", () => {
     expect(res2.status).toBe(409);
     const body = await res2.json();
     expect(body.code).toBe("ALREADY_EXISTS");
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me/runtime-config — agent-authenticated runtime fetch
+//
+// The deployed LiveKit worker calls this at session start to pull the latest
+// compiled prompt instead of using a baked-in copy. See ADR-015.
+// ============================================================================
+
+describe("GET /api/agents/me/runtime-config", () => {
+  test("returns the authenticated agent's runtime config (200)", async () => {
+    // Set a compiled prompt on the seeded agent so we can assert it round-trips
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          compiledInstructions: "You are Sam from BuildPro. Be concise.",
+          compiledAt: new Date(),
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.slug).toBeDefined();
+    expect(body.name).toBeDefined();
+    expect(body.modality).toBe("voice");
+    expect(body.isActive).toBe(true);
+    expect(body.compiledInstructions).toBe(
+      "You are Sam from BuildPro. Be concise.",
+    );
+    expect(body.compiledAt).toBeDefined();
+    expect(body.promptConfig).toBeDefined();
+  });
+
+  test("returns compiledInstructions: null when not compiled (200)", async () => {
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({ compiledInstructions: null, compiledAt: null })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAgentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.compiledInstructions).toBeNull();
+    expect(body.compiledAt).toBeNull();
+  });
+
+  test("rejects unauthenticated request (401)", async () => {
+    const response = await request("/api/agents/me/runtime-config");
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects user JWT (401) — agent-only endpoint", async () => {
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAdminHeaders,
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test("scopes to the agent the key belongs to (cross-org)", async () => {
+    // orgB's agent key should return orgB's agent, never orgA's
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgBAgentHeaders,
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe(s.orgBAgentId);
+    expect(body.id).not.toBe(s.orgAAgentId);
   });
 });

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.test.tsx
@@ -140,6 +140,22 @@ describe('VoiceTestPanel', () => {
     expect(screen.getByRole('button', { name: /talk to agent/i })).not.toBeDisabled()
   })
 
+  it('surfaces the runtime-fetch hint when a compiled prompt is set (ADR-015)', () => {
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={configuredAgent} canMutate />, { wrapper })
+    // The hint exists so admins know a fresh "Compile" lands in the next call
+    // without redeploying the worker.
+    expect(screen.getByText(/INSTRUCTIONS_SOURCE=remote/)).toBeInTheDocument()
+    expect(screen.getByText(/ADR-015/)).toBeInTheDocument()
+  })
+
+  it('hides the runtime-fetch hint when no compiled prompt is set', () => {
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    stubMicPermission(true)
+    render(<VoiceTestPanel agent={noPrompt} canMutate />, { wrapper })
+    expect(screen.queryByText(/INSTRUCTIONS_SOURCE=remote/)).not.toBeInTheDocument()
+  })
+
   it('disables the talk button for viewers (canMutate=false)', () => {
     stubMicPermission(true)
     render(<VoiceTestPanel agent={configuredAgent} canMutate={false} />, { wrapper })

--- a/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-test-panel.tsx
@@ -23,7 +23,7 @@
 
 import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
 import { useMutation } from '@tanstack/react-query'
-import { AlertTriangle, Mic, Radio } from 'lucide-react'
+import { AlertTriangle, FileCode, Mic, Radio } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -152,11 +152,20 @@ export function VoiceTestPanel({ agent, canMutate }: VoiceTestPanelProps) {
       </CardHeader>
       <CardContent>
         {livekitConfigured ? (
-          <p className="text-sm text-fg-muted">
-            Dispatches the configured LiveKit worker with this agent's slug as{' '}
-            <code>agentName</code> metadata, then joins the room from your browser so you can talk
-            to the agent end-to-end.
-          </p>
+          <div className="space-y-2">
+            <p className="text-sm text-fg-muted">
+              Dispatches the configured LiveKit worker with this agent's slug as{' '}
+              <code>agentName</code> metadata, then joins the room from your browser so you can talk
+              to the agent end-to-end.
+            </p>
+            {agent.compiledInstructions ? (
+              <p className="flex items-center gap-1.5 text-xs text-fg-muted">
+                <FileCode className="h-3 w-3 text-success" />
+                Workers running with <code>INSTRUCTIONS_SOURCE=remote</code> pick up the latest
+                compiled prompt on each call — no redeploy needed. See ADR-015.
+              </p>
+            ) : null}
+          </div>
         ) : (
           <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-fg-secondary">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />


### PR DESCRIPTION
## Summary

Closes the dashboard's compile-and-talk loop. Editing prompt config in the UI, hitting **Compile**, then clicking **Talk to agent** now reaches a worker that picks up the freshly compiled prompt — no worker redeploy needed.

The deployed LiveKit worker fetches `compiledInstructions` via a new agent-authenticated `GET /api/agents/me/runtime-config` endpoint (mgk_* API key) at session start, with a graceful fallback to the baked-in prompt if MG is unreachable or hasn't been compiled yet. Default `INSTRUCTIONS_SOURCE=local` keeps the existing zero-config behavior — `remote` opts in.

This is the inverse of ADR-014's rejected client-side injection: MG stays authoritative, the **worker** is the one asking, and the client never names a prompt or sends bytes to bound-check.

## What changed

**API** (`modelguide-api`)
- `GET /api/agents/me/runtime-config` — new agent-key-authenticated endpoint returning a narrow runtime envelope: `id`, `slug`, `name`, `modality`, `modelFamily`, `promptConfig`, `compiledInstructions`, `compiledAt`, `isActive`. Deliberately omits secrets refs, integration URLs, eval counts, metadata.
- `getAgentRuntimeConfig()` service function (RLS-scoped).

**LiveKit worker** (`examples/agents/livekit-agent`)
- `mg_client.get_runtime_config()` — fetches the endpoint, returns `None` on any failure (network / non-2xx / bad JSON).
- `INSTRUCTIONS_SOURCE` env var (`local` | `remote`, default `local`).
- `agent.py::_resolve_instructions_override()` — single-source resolver called once per session start.
- `BuildProAgent(instructions_override=…)` + `build_system_prompt(template=…)` — placeholder interpolation works identically whether the prompt is baked-in or freshly compiled.

**UI** (`modelguide-ui`)
- Small hint in the voice-test panel surfaced when a compiled prompt is set, pointing at `INSTRUCTIONS_SOURCE=remote` and ADR-015.

**Docs**
- ADR-015 in `docs/decisions/` explains the design, the failure-mode table, what this is **not**, and how it differs from the closely-related ADR-014.
- `examples/agents/livekit-agent/README.md` adds a "Runtime Prompt Fetch" section.

## Tests (TDD red→green)

| Layer | File | Coverage |
|---|---|---|
| API integration | `agents.test.ts` | happy path, null `compiledInstructions`, 401 unauth, 401 user JWT rejected, cross-org scoping (5 new tests) |
| Worker Python | `test_mg_client.py::TestGetRuntimeConfig` | success / HTTP error / network failure / bad JSON / null compiled (5 tests) |
| Worker Python | `test_prompts.py::TestTemplateOverride` | template wins / fallback / interpolation under override / empty-string override (5 tests) |
| Worker Python | `test_runtime_config.py` *(new file)* | resolver short-circuits on `local`, returns prompt on `remote`, falls back on fetch=None / compiled=null / compiled="", BuildProAgent constructs with override (9 tests) |
| UI | `voice-test-panel.test.tsx` | hint visible iff `compiledInstructions` set (2 tests) |

All checks green locally: `make api-typecheck`, `make api-lint-check`, `make api-test-unit` (896 pass), `make ui-typecheck`, `make ui-lint`, `bun x vitest run` (270 pass), `pytest` for the agent (68 pass).

API integration tests require a Postgres container (no Docker in this sandbox) — CI runs them.

## What this is NOT

- Not a prompt-override channel from the client (ADR-014's rejection stands).
- Not a hot-reload during a live call — fetch happens at session start only, by design.
- Not a replacement for redeploying tool wiring — only the system-prompt **string** is fetched.

## Test plan

- [ ] CI passes on this branch
- [ ] On a real LiveKit Cloud worker, set `INSTRUCTIONS_SOURCE=remote`, redeploy once, then:
  - [ ] Edit prompt config in the dashboard → Compile → Talk to agent. Verify the new prompt is in effect (e.g. change the persona name and confirm the agent introduces itself with the new name).
  - [ ] Confirm a compile mid-call does NOT affect the in-progress session.
  - [ ] Temporarily revoke the worker's MG API key. Confirm calls still set up using the baked-in prompt (graceful fallback).
- [ ] Without `INSTRUCTIONS_SOURCE=remote` set, confirm zero behavior change (no extra GET, baked-in prompt used).

https://claude.ai/code/session_011S9U44bFU5GkhTbu5ynfC6

---
_Generated by [Claude Code](https://claude.ai/code/session_011S9U44bFU5GkhTbu5ynfC6)_