### PR TITLE
feat(agents): prompt-driven Voice Prototype for LiveKit (ADR-015)

### DIFF
--- a/docs/decisions/015-livekit-prompt-driven-voice-prototype.md
+++ b/docs/decisions/015-livekit-prompt-driven-voice-prototype.md
@@ -1,0 +1,189 @@
+# ADR-015: Prompt-Driven Voice Prototype for LiveKit
+
+**Status:** Accepted
+
+**Supersedes part of:** ADR-014 ("No prompt injection. Earlier iterations
+shipped a `prompt_override` field in dispatch metadata… We rejected this…")
+— for the prototype path only. ADR-014 still governs the production
+"Talk to agent" flow unchanged.
+
+## Context
+
+The platform now has two LiveKit-shaped surfaces with different goals.
+
+**Production "Talk to agent"** (ADR-014) exists to answer: *will the agent
+that runs in production today behave correctly?* So the worker profile owns
+the prompt + tool list, and the dispatch carries only correlation data
+(`agentName`, `session_id`, `email`). Any prompt drift between the
+admin's draft and the worker's reality is treated as a bug.
+
+**Prompt iteration loop** is a different goal. An admin who's editing a SOP
+or compiling a new prompt wants to hear *the prompt I just compiled*, not
+*the prompt the worker happens to be running today*. The compile → sync →
+test loop is the day-to-day reason ElevenLabs already exists in the
+product (see `syncAgentToElevenLabs`). LiveKit didn't have an equivalent.
+The user-reported pain point: "I've compiled a new prompt, I want to hear
+it, but Talk-to-agent gives me yesterday's deployment."
+
+ADR-014 deliberately rejected injecting the prompt into dispatch metadata
+for the production path. The argument was sound — a prompt that works in
+voice-test but not in prod is worse than the redeploy cost it avoids. That
+argument doesn't carry over to a prototype surface that is explicitly
+labelled as "what I just compiled, not what's running in prod."
+
+## Decision
+
+Add a **second, separate** voice path called Voice Prototype:
+
+1. New API endpoint `POST /agents/:id/voice-prototype-token` —
+   permission `agents:activate`, same auth + RLS posture as voice-test.
+2. New dispatch builder `buildVoicePrototypeDispatchMetadata` — same five
+   correlation fields as voice-test, plus `agent_id` and `compiled_prompt`.
+   The shape is locked behind a unit test (see "Contract" below).
+3. New Python entrypoint `examples/agents/livekit-agent/src/prompt_entry.py`
+   that registers as LiveKit agent name `voice-prototype` and parses the
+   dispatch metadata into a `PromptAgentConfig` *before* connecting to the
+   room. Malformed metadata → fail fast (no dead-air).
+4. New UI panel `<VoicePrototypePanel>` on the agent detail page,
+   rendered below the existing `<VoiceTestPanel>`. Same WebRTC plumbing
+   (mic-permission probe + `<LiveKitRoom>` + `RoomController`), different
+   endpoint + label.
+
+**Both panels render on the same page.** The operator picks the path that
+matches their question: "does it work in prod?" → Talk to agent. "does my
+latest compile sound right?" → Talk to prototype.
+
+### What the prototype deliberately doesn't do
+
+These omissions are the price of separating the prototype from production:
+
+- **No tool calling.** The prototype is for prompt iteration, not full-
+  stack tool regression. If a prompt change relies on a tool being wired
+  correctly, exercise it through Talk-to-agent against a deployed profile.
+- **No SIP / outbound calls.** WebRTC only. PSTN integration belongs in
+  the production path.
+- **No worker-side prompt validation.** The API guarantees a non-empty
+  compiled prompt; the worker doesn't lint it or scan for prompt-injection
+  payloads (see Security below).
+- **No prompt-pinning guarantee.** A successful Voice Prototype run does
+  *not* prove the same prompt will behave the same way once deployed to a
+  worker profile — only that it sounds right when fed straight to the LLM.
+
+### Contract (locked behind tests)
+
+```jsonc
+{
+  "mode": "voice-prototype",
+  "agentName": "<agent.slug>",
+  "agent_id": "<agent uuid>",
+  "session_id": "<session uuid>",
+  "user_identifier": "<caller email>",
+  "email": "<caller email>",
+  "compiled_prompt": "<verbatim compiled instructions>"
+}
+```
+
+Tests on both sides will fail if either side drifts:
+
+- TS: `modelguide-api/tests/unit/agents/voice-prototype-dispatch.test.ts`
+- Python: `examples/agents/livekit-agent/tests/test_prompt_agent.py`
+
+The Python side rejects `mode != "voice-prototype"` so a stray voice-test
+dispatch (without `compiled_prompt`) can never accidentally land in the
+prototype worker.
+
+### Endpoint shape
+
+`POST /agents/:id/voice-prototype-token` — same error taxonomy as voice-test
+plus one more 400:
+
+| Status | Condition |
+|---|---|
+| 400 | Agent not active; modality ≠ voice; platform ≠ livekit; LiveKit URL/credentials missing; **no compiled prompt** |
+| 401 | unauthenticated |
+| 403 | authenticated but lacks `agents:activate` |
+| 404 | agent doesn't exist (or in a different org) |
+| 500 | LiveKit dispatch or token mint failed (session rolled to `abandoned`) |
+
+### Security
+
+- AccessToken is room-scoped and short-lived, identical to voice-test.
+- LiveKit dispatch metadata travels over LiveKit's signaling channel,
+  which is TLS-encrypted between the API and LiveKit Cloud. The prompt is
+  not logged at INFO; only the character count is.
+- **Prompt sourcing.** The compiled prompt comes from `agents.compiledInstructions`,
+  written by the platform's compiler (`compiler.service.ts`). The compiler
+  is the only writer in the data flow, which means a malicious admin can
+  only inject content that already passes the compiler's input validation
+  (SOP + guardrail steps), not arbitrary strings.
+- **Prototype workers should run on the same trust boundary as production
+  workers.** The metadata payload is treated as authenticated by virtue
+  of the LiveKit signing secret; if a prototype worker is exposed to a
+  LiveKit project that other tenants can dispatch to, an attacker could
+  craft a prompt. Mitigation: deploy the prototype worker in the same
+  LiveKit project the API uses for that org, never a shared one.
+
+## Alternatives Considered
+
+**Wedge the prompt into the existing voice-test endpoint behind a feature
+flag.** Rejected — it would dilute ADR-014's "production parity" promise.
+A flag is also one more thing for a future operator to misread as
+"prototypes are the default now."
+
+**Push the compiled prompt to the worker out-of-band (S3 / DB) and have it
+poll.** Rejected for a prototype. Polling adds infra for a flow that
+already has a perfectly good metadata channel; the per-dispatch overhead
+of an extra HTTP fetch is wasted when the data is right there in
+`ctx.job.metadata`. Worth revisiting if the prompt outgrows the safe
+metadata envelope size (LiveKit's documented cap is well above typical
+prompt sizes today).
+
+**Reuse `BuildProAgent` with an override.** Rejected — `BuildProAgent`
+hard-codes 11 tools and several scenario-specific hooks (cart-id injection,
+reorder guardrails). Smuggling a different prompt in keeps the wrong-tools
+problem. `PromptAgent` is intentionally tool-less to make the prototype's
+scope obvious.
+
+**Skip the ADR and do it inline.** Rejected — ADR-014 explicitly debates
+this exact trade-off and lands on "no prompt injection." Reintroducing it
+without an ADR would look like an oversight; with an ADR it's a documented
+deviation scoped to a separate code path.
+
+## Consequences
+
+- Two voice paths to keep in sync. Adding a feature to `<VoiceTestPanel>`
+  (e.g. the equalizer landed in PR #242) now means asking "should this
+  also land on `<VoicePrototypePanel>`?". They share `RoomController` to
+  cap how much code can diverge; UI polish that lives in `RoomController`
+  is automatic for the prototype.
+- The MG-agent-slug → worker-profile-slug contract is still load-bearing
+  for voice-test but doesn't apply to voice-prototype, where the worker
+  is `voice-prototype` for *every* agent. Operators reading dispatch logs
+  should expect to see both worker names.
+- "Compile prompt → Talk to prototype" is now the documented prompt
+  iteration loop for LiveKit, matching the ElevenLabs `sync` flow's
+  spirit. The "Talk to agent" button is still the answer to "does it work
+  in prod".
+- The prototype worker is a separate process (separate Railway service is
+  the cleanest deploy shape). One image, two entrypoints — see
+  `PROMPT_AGENT.md`.
+
+## Known gaps
+
+- The happy path (dispatch + token mint + 201) still has no end-to-end
+  integration test for the same reasons enumerated in ADR-014 (no LiveKit
+  in CI). What's covered: contract-shape unit tests on both sides + the
+  same error-path integration coverage that exists for voice-test.
+- The prototype worker doesn't yet wire MCP tools. A SOP that's
+  declarative-prompt-only will sound right; a SOP that depends on tool
+  side effects will read as "the LLM tried to make up an answer." This is
+  by design for v1 but is the most likely next iteration.
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls — the existing dispatch pattern.
+- ADR-014: Browser Voice Testing — the production "Talk to agent" flow this
+  intentionally diverges from.
+- `examples/agents/livekit-agent/PROMPT_AGENT.md` — how-to.
+- `modelguide-api/src/features/agents/agents.service.ts` —
+  `createVoicePrototypeSession` and `buildVoicePrototypeDispatchMetadata`.

--- a/examples/agents/livekit-agent/PROMPT_AGENT.md
+++ b/examples/agents/livekit-agent/PROMPT_AGENT.md
@@ -1,0 +1,125 @@
+# Voice Prototype — Prompt-Driven LiveKit Agent
+
+A LiveKit worker that takes the **agent's latest compiled prompt** off the
+dispatch metadata and runs an `AgentSession` with that prompt verbatim.
+Sibling to `BuildProAgent`/`agent.py`, not a replacement.
+
+## Why a separate entrypoint?
+
+The production "Talk to agent" panel (`POST /agents/:id/voice-test-token`,
+ADR-014) dispatches a worker whose **profile owns the prompt** — slug-to-
+profile routing on the worker, prompt baked into Python at deploy time.
+That keeps the voice-test path in lockstep with what gets paged in production.
+
+The prototype path, on the other hand, is the loop an admin uses while
+iterating on a prompt:
+
+```
+edit SOP → recompile prompt → click "Talk to prototype" → hear it
+```
+
+Redeploying a worker profile in the middle of that loop would kill it. So
+the prototype ships the compiled prompt **in dispatch metadata** and the
+worker uses it directly. See `docs/decisions/015-livekit-prompt-driven-voice-prototype.md`
+for the trade-off (and what we deliberately gave up — tool calling, SIP,
+and the prompt-pinning guarantee of ADR-014).
+
+## How it differs from `BuildProAgent`
+
+| Aspect | `BuildProAgent` (production) | `PromptAgent` (prototype) |
+|---|---|---|
+| Entrypoint | `src/agent.py` | `src/prompt_entry.py` |
+| Worker `agent_name` | `buildpro-sam` (slug-routed) | `voice-prototype` |
+| System prompt | Built from `prompts/base.py` + workflows | `dispatch_metadata.compiled_prompt` |
+| Tools | 11 `@function_tool` methods → MCP | None (chat-only — by design) |
+| SIP / outbound | Yes | No |
+| Stubbed tools | Yes | N/A |
+| Transcript posted to MG | Yes | Yes |
+| Langfuse tracing | Yes (opt-in) | Future work |
+
+## Local development
+
+```bash
+# From the repo root
+make lk-agent-setup       # if not already done
+cd examples/agents/livekit-agent
+cp .env.example .env
+# fill in OPENAI_API_KEY, DEEPGRAM_API_KEY, MODELGUIDE_*, etc.
+
+source .venv/bin/activate
+python src/prompt_entry.py dev
+```
+
+Then from the dashboard, on a LiveKit agent that has a compiled prompt,
+click **Talk to prototype**.
+
+> Console mode (`python src/prompt_entry.py console`) is useful for trying
+> the entrypoint without LiveKit/WebRTC, but it bypasses dispatch metadata
+> — so it always says "the prompt is empty". To exercise the dispatch path,
+> use `dev` and click through from the dashboard.
+
+## Dispatch metadata contract
+
+The API (`createVoicePrototypeSession` in
+`modelguide-api/src/features/agents/agents.service.ts`) JSON-encodes:
+
+```jsonc
+{
+  "mode": "voice-prototype",          // entrypoint refuses anything else
+  "agentName": "your-agent-slug",     // mirrors agent.slug (same as voice-test)
+  "agent_id": "uuid",                 // for transcript + Langfuse correlation
+  "session_id": "uuid",               // ModelGuide session row created up-front
+  "user_identifier": "caller@x",      // becomes the session's userIdentifier
+  "email": "caller@x",                // duplicate for legacy worker compat
+  "compiled_prompt": "..."            // verbatim system prompt, no trim/transform
+}
+```
+
+Both ends of this contract are covered by tests:
+
+- API side: `modelguide-api/tests/unit/agents/voice-prototype-dispatch.test.ts`
+- Worker side: `examples/agents/livekit-agent/tests/test_prompt_agent.py::TestParseDispatchMetadata`
+
+If you change the shape, both tests must move together.
+
+## Tests
+
+Worker:
+
+```bash
+cd examples/agents/livekit-agent
+source .venv/bin/activate
+pytest tests/test_prompt_agent.py -v
+```
+
+API:
+
+```bash
+cd modelguide-api
+bun test --preload ./tests/setup/unit-preload.ts tests/unit/agents/voice-prototype-dispatch.test.ts
+```
+
+UI:
+
+```bash
+cd modelguide-ui
+bun run test src/features/agents/components/voice-prototype-panel.test.tsx
+```
+
+## Deploying alongside the production worker
+
+You can run both workers from the same image — they just register different
+`agent_name`s with LiveKit. Two `python` processes, two `WorkerOptions`:
+
+```dockerfile
+# Production "Talk to agent"
+CMD ["python", "src/agent.py", "start"]
+```
+
+```dockerfile
+# Prototype "Talk to prototype" (separate Railway service)
+CMD ["python", "src/prompt_entry.py", "start"]
+```
+
+LiveKit dispatches by `agent_name`, so the API picks the right worker for
+each panel and the two stay out of each other's way.

--- a/examples/agents/livekit-agent/src/prompt_agent.py
+++ b/examples/agents/livekit-agent/src/prompt_agent.py
@@ -1,0 +1,174 @@
+"""Prompt-driven LiveKit Agent — the prototype "Voice Prototype" surface.
+
+Unlike ``BuildProAgent`` (which bakes prompts + tools into Python at deploy
+time), ``PromptAgent`` takes the compiled system prompt off the dispatch
+metadata and uses that verbatim. The ModelGuide API attaches the agent's
+latest ``compiledInstructions`` field to every voice-prototype dispatch, so
+clicking "Talk to agent (prototype)" after a prompt compile always
+exercises the prompt that's actually saved in the database.
+
+See ``docs/decisions/015-livekit-prompt-driven-voice-prototype.md`` for why
+this is a separate code path from the production voice-test flow defined in
+ADR-014.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from livekit.agents import Agent
+
+from transcript import TranscriptCollector
+
+logger = logging.getLogger("prompt_agent")
+
+
+VOICE_PROTOTYPE_MODE = "voice-prototype"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DispatchMetadataError(ValueError):
+    """Raised when LiveKit dispatch metadata is missing or malformed.
+
+    Surfaced as an actionable startup error so an operator can see at a
+    glance that the API and worker are out of sync — far better than a
+    silent fall-through into a blank LLM session.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Config carrier
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptAgentConfig:
+    compiled_prompt: str
+    agent_id: str
+    session_id: str
+    user_identifier: str
+
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+
+def parse_dispatch_metadata(raw: str | None) -> PromptAgentConfig:
+    """Parse the JSON dispatch metadata into a ``PromptAgentConfig``.
+
+    Required keys: ``compiled_prompt``, ``agent_id``, ``session_id``, and
+    one of ``user_identifier`` / ``email``. ``mode`` must equal
+    ``voice-prototype`` so a routine "voice-test" dispatch never lands in
+    this entrypoint by mistake.
+    """
+    if raw is None:
+        raise DispatchMetadataError("Dispatch metadata is missing")
+
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise DispatchMetadataError(
+            f"Dispatch metadata is not valid JSON: {exc}"
+        ) from exc
+
+    mode = data.get("mode")
+    if mode != VOICE_PROTOTYPE_MODE:
+        raise DispatchMetadataError(
+            f"Expected mode=voice-prototype, got mode={mode!r}. "
+            "This entrypoint only services voice-prototype dispatches."
+        )
+
+    compiled_prompt = data.get("compiled_prompt")
+    if not compiled_prompt or not str(compiled_prompt).strip():
+        raise DispatchMetadataError(
+            "Dispatch metadata is missing required field: compiled_prompt"
+        )
+
+    agent_id = data.get("agent_id")
+    if not agent_id:
+        raise DispatchMetadataError(
+            "Dispatch metadata is missing required field: agent_id"
+        )
+
+    session_id = data.get("session_id")
+    if not session_id:
+        raise DispatchMetadataError(
+            "Dispatch metadata is missing required field: session_id"
+        )
+
+    user_identifier = data.get("user_identifier") or data.get("email")
+    if not user_identifier:
+        raise DispatchMetadataError(
+            "Dispatch metadata is missing required field: user_identifier (or email)"
+        )
+
+    return PromptAgentConfig(
+        compiled_prompt=str(compiled_prompt),
+        agent_id=str(agent_id),
+        session_id=str(session_id),
+        user_identifier=str(user_identifier),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class PromptAgent(Agent):
+    """LiveKit Agent driven solely by a ModelGuide-compiled system prompt.
+
+    Has no ``@function_tool`` methods on purpose — the prototype's job is to
+    let an admin hear how the latest compiled prompt sounds in voice, not to
+    re-exercise the whole tool stack. When tool wiring is needed too, copy
+    ``BuildProAgent`` instead.
+    """
+
+    def __init__(self, *, config: PromptAgentConfig) -> None:
+        prompt = config.compiled_prompt
+        if not prompt or not prompt.strip():
+            raise ValueError(
+                "PromptAgent requires a non-empty compiled_prompt"
+            )
+
+        self._config = config
+        self._transcript = TranscriptCollector()
+        super().__init__(instructions=prompt)
+
+    # ------------------------------------------------------------------
+    # Accessors (kept simple so they're easy to mock in tests)
+    # ------------------------------------------------------------------
+
+    @property
+    def session_id(self) -> str:
+        return self._config.session_id
+
+    @property
+    def agent_id(self) -> str:
+        return self._config.agent_id
+
+    @property
+    def user_identifier(self) -> str:
+        return self._config.user_identifier
+
+    # ------------------------------------------------------------------
+    # Transcript helpers — thin wrappers so the entrypoint doesn't have to
+    # know about TranscriptCollector internals.
+    # ------------------------------------------------------------------
+
+    def record_user_utterance(self, text: str) -> None:
+        self._transcript.add_user_utterance(text)
+
+    def record_agent_response(self, text: str) -> None:
+        self._transcript.add_assistant_response(text)
+
+    def transcript_messages(self) -> list[dict]:
+        return self._transcript.get_messages()

--- a/examples/agents/livekit-agent/src/prompt_entry.py
+++ b/examples/agents/livekit-agent/src/prompt_entry.py
@@ -1,0 +1,174 @@
+"""LiveKit entrypoint for the prompt-driven Voice Prototype.
+
+Usage:
+  python src/prompt_entry.py dev      # local LiveKit
+  python src/prompt_entry.py start    # production worker
+  python src/prompt_entry.py console  # text-only, useful for unit-tests
+
+This is intentionally a smaller cousin of ``agent.py``. Where ``agent.py``
+boots the BuildPro scenario (baked-in prompt + 11 MCP tools + SIP handling),
+this entrypoint:
+
+  1. Reads the compiled prompt out of the dispatch metadata
+     (``compiled_prompt`` field — set by ``createVoicePrototypeSession`` in
+     the ModelGuide API).
+  2. Spins up an ``AgentSession`` with that prompt.
+  3. Posts the transcript back to ModelGuide on disconnect using the same
+     ``mg_client`` helpers BuildPro already uses.
+
+What this does NOT do (on purpose, for now):
+
+  - No tool calling. The prototype's job is "does the prompt sound right",
+    not "does the whole tool stack still work".
+  - No SIP handling. WebRTC only.
+  - No outbound calls. Click-to-dial is a separate feature (ADR-011).
+
+See ``docs/decisions/015-livekit-prompt-driven-voice-prototype.md`` for the
+why; ``examples/agents/livekit-agent/PROMPT_AGENT.md`` for the how.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from livekit import agents
+from livekit.agents import AgentSession
+from livekit.plugins import openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+import mg_client
+from prompt_agent import (
+    DispatchMetadataError,
+    PromptAgent,
+    parse_dispatch_metadata,
+)
+from providers import create_stt, create_tts
+
+PROMPT_AGENT_NAME = "voice-prototype"
+
+logging.basicConfig(level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s")
+logger = logging.getLogger("prompt_entry")
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    """LiveKit prompt-driven entrypoint — called once per voice-prototype room."""
+    config.validate()
+
+    # Parse the prompt + correlation ids out of dispatch metadata BEFORE we
+    # touch the room. If the metadata is malformed, fail fast so the operator
+    # sees the error in worker logs instead of hearing dead air.
+    try:
+        cfg = parse_dispatch_metadata(ctx.job.metadata)
+    except DispatchMetadataError as err:
+        logger.error("Rejecting dispatch: %s", err)
+        return
+
+    logger.info(
+        "Voice prototype starting — agent_id=%s session_id=%s prompt_chars=%d",
+        cfg.agent_id,
+        cfg.session_id,
+        len(cfg.compiled_prompt),
+    )
+
+    await ctx.connect()
+    participant = await ctx.wait_for_participant()
+    logger.info("Participant joined: %s", participant.identity)
+
+    agent = PromptAgent(config=cfg)
+
+    session = AgentSession(
+        stt=create_stt(),
+        llm=openai.LLM(model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY),
+        tts=create_tts(),
+        vad=silero.VAD.load(),
+        turn_detection="stt" if config.STT_MODEL == "flux" else EnglishModel(),
+        allow_interruptions=True,
+        min_interruption_duration=1.0,
+        min_endpointing_delay=0.5,
+    )
+
+    @session.on("user_input_transcribed")
+    def _on_user_speech(ev):
+        if ev.is_final:
+            agent.record_user_utterance(ev.transcript)
+
+    @session.on("conversation_item_added")
+    def _on_item(ev):
+        item = ev.item
+        if not (hasattr(item, "role") and item.role == "assistant"):
+            return
+        text = _extract_text(item)
+        if text:
+            agent.record_agent_response(text)
+
+    session_done = asyncio.Event()
+
+    @session.on("close")
+    def _on_close():
+        session_done.set()
+
+    @ctx.room.on("disconnected")
+    def _on_disconnect():
+        session_done.set()
+
+    await session.start(room=ctx.room, agent=agent)
+
+    # First-utterance greeting kept generic — the compiled prompt drives the
+    # personality, so we don't want a baked greeting that contradicts it.
+    try:
+        await session.say("Hi! I'm ready when you are.")
+    except Exception:
+        logger.exception("Greeting failed (non-fatal)")
+
+    try:
+        await session_done.wait()
+    finally:
+        await _cleanup(agent)
+
+
+def _extract_text(item) -> str:
+    """Pull the text content out of a LiveKit conversation item."""
+    if not hasattr(item, "content") or not item.content:
+        return ""
+    if isinstance(item.content, str):
+        return item.content.strip()
+    if isinstance(item.content, list):
+        return " ".join(
+            part if isinstance(part, str) else getattr(part, "text", "")
+            for part in item.content
+        ).strip()
+    return ""
+
+
+async def _cleanup(agent: PromptAgent) -> None:
+    """Post transcript + complete the ModelGuide session.
+
+    Mirrors ``agent.py`` so an admin reviewing the dashboard sees the same
+    shape of session record regardless of which entrypoint produced it.
+    """
+    try:
+        messages = agent.transcript_messages()
+        status = "completed" if len(messages) > 1 else "abandoned"
+        if messages:
+            await mg_client.add_messages(agent.session_id, messages)
+            logger.info(
+                "Posted %d messages to session %s", len(messages), agent.session_id
+            )
+        await mg_client.complete_session(agent.session_id, status=status)
+    except Exception:
+        logger.exception(
+            "Failed to post transcript / complete session %s", agent.session_id
+        )
+    finally:
+        await mg_client.close_http_client()
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=PROMPT_AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-agent/tests/test_prompt_agent.py
+++ b/examples/agents/livekit-agent/tests/test_prompt_agent.py
@@ -1,0 +1,181 @@
+"""Tests for PromptAgent — the prompt-driven LiveKit agent prototype.
+
+PromptAgent is the heart of the LiveKit "Voice Prototype" flow. It takes a
+compiled system prompt (sourced from ModelGuide on every dispatch) and runs
+the LiveKit AgentSession with that prompt. No baked-in personality, no
+hard-coded tool list — what's in the dispatch metadata is what the LLM sees.
+
+These tests are written red-then-green: they describe the contract before
+the class exists, then the implementation is filled in until they pass.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prompt_agent import (
+    PromptAgent,
+    PromptAgentConfig,
+    DispatchMetadataError,
+    parse_dispatch_metadata,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_dispatch_metadata — the contract between API and worker
+# ---------------------------------------------------------------------------
+
+
+class TestParseDispatchMetadata:
+    def test_extracts_compiled_prompt_and_session(self):
+        raw = json.dumps({
+            "mode": "voice-prototype",
+            "agentName": "demo-bot",
+            "agent_id": "agt_123",
+            "session_id": "sess_abc",
+            "user_identifier": "tester@example.com",
+            "email": "tester@example.com",
+            "compiled_prompt": "You are a helpful assistant.",
+        })
+
+        cfg = parse_dispatch_metadata(raw)
+
+        assert cfg.compiled_prompt == "You are a helpful assistant."
+        assert cfg.agent_id == "agt_123"
+        assert cfg.session_id == "sess_abc"
+        assert cfg.user_identifier == "tester@example.com"
+
+    def test_raises_when_missing_compiled_prompt(self):
+        raw = json.dumps({
+            "mode": "voice-prototype",
+            "agentName": "demo-bot",
+            "agent_id": "agt_123",
+            "session_id": "sess_abc",
+            "user_identifier": "tester@example.com",
+            "email": "tester@example.com",
+        })
+
+        # In prototype mode the prompt is the whole point — if it's missing
+        # something upstream is broken and we should fail fast, not silently
+        # serve a blank prompt.
+        with pytest.raises(DispatchMetadataError) as exc:
+            parse_dispatch_metadata(raw)
+
+        assert "compiled_prompt" in str(exc.value)
+
+    def test_raises_when_metadata_is_not_json(self):
+        with pytest.raises(DispatchMetadataError):
+            parse_dispatch_metadata("not-json-at-all")
+
+    def test_raises_when_metadata_is_none(self):
+        with pytest.raises(DispatchMetadataError):
+            parse_dispatch_metadata(None)
+
+    def test_raises_when_mode_is_not_voice_prototype(self):
+        raw = json.dumps({
+            "mode": "voice-test",
+            "compiled_prompt": "Hi.",
+            "session_id": "s",
+            "agent_id": "a",
+            "user_identifier": "u",
+            "email": "u",
+        })
+
+        # The prototype path must refuse plain voice-test dispatches so we
+        # never accidentally hijack the production "Talk to agent" flow (see
+        # ADR-014 + ADR-015 for the separation rationale).
+        with pytest.raises(DispatchMetadataError) as exc:
+            parse_dispatch_metadata(raw)
+
+        assert "voice-prototype" in str(exc.value)
+
+    def test_user_identifier_falls_back_to_email_when_absent(self):
+        raw = json.dumps({
+            "mode": "voice-prototype",
+            "compiled_prompt": "Hi.",
+            "session_id": "s",
+            "agent_id": "a",
+            "email": "u@example.com",
+        })
+
+        cfg = parse_dispatch_metadata(raw)
+        assert cfg.user_identifier == "u@example.com"
+
+
+# ---------------------------------------------------------------------------
+# PromptAgent — the LiveKit Agent subclass that runs the prompt
+# ---------------------------------------------------------------------------
+
+
+class TestPromptAgentConstruction:
+    def test_uses_compiled_prompt_as_instructions(self):
+        agent = PromptAgent(
+            config=PromptAgentConfig(
+                compiled_prompt="You are Sam, a contractor supply assistant.",
+                agent_id="agt_1",
+                session_id="sess_1",
+                user_identifier="caller@example.com",
+            ),
+        )
+
+        # LiveKit's Agent base class exposes `instructions` — the prompt the
+        # LLM is initialised with.  We bind it from compiled_prompt verbatim,
+        # which is the entire purpose of the prototype.
+        assert agent.instructions == "You are Sam, a contractor supply assistant."
+
+    def test_exposes_session_id_for_transcript_posting(self):
+        agent = PromptAgent(
+            config=PromptAgentConfig(
+                compiled_prompt="Hello.",
+                agent_id="agt_1",
+                session_id="sess_xyz",
+                user_identifier="u@example.com",
+            ),
+        )
+        assert agent.session_id == "sess_xyz"
+
+    def test_records_user_identifier(self):
+        agent = PromptAgent(
+            config=PromptAgentConfig(
+                compiled_prompt="Hello.",
+                agent_id="agt_1",
+                session_id="sess_xyz",
+                user_identifier="caller@example.com",
+            ),
+        )
+        assert agent.user_identifier == "caller@example.com"
+
+    def test_blank_prompt_is_rejected(self):
+        # We reject blank prompts because the dispatch-metadata parser already
+        # rejects missing prompts; this guards a second silent failure mode
+        # where the prompt key exists but contains only whitespace.
+        with pytest.raises(ValueError):
+            PromptAgent(
+                config=PromptAgentConfig(
+                    compiled_prompt="   ",
+                    agent_id="agt_1",
+                    session_id="sess_xyz",
+                    user_identifier="caller@example.com",
+                ),
+            )
+
+    def test_collects_transcript_for_session_post(self):
+        agent = PromptAgent(
+            config=PromptAgentConfig(
+                compiled_prompt="Hello.",
+                agent_id="agt_1",
+                session_id="sess_xyz",
+                user_identifier="caller@example.com",
+            ),
+        )
+
+        # We reuse TranscriptCollector so the session-complete cleanup path
+        # already wired for BuildPro applies unchanged.
+        agent.record_user_utterance("hi there")
+        agent.record_agent_response("hello, how can I help?")
+
+        messages = agent.transcript_messages()
+        assert any(m.get("role") == "user" for m in messages)
+        assert any(m.get("role") == "assistant" for m in messages)

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -22,6 +22,7 @@ import {
   assignConnectorToAgent,
   createAgent,
   createOutboundCall,
+  createVoicePrototypeSession,
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
@@ -1354,6 +1355,69 @@ router.openapi(voiceTestTokenRoute, async (c) => {
   const { id } = c.req.valid("param");
 
   const result = await createVoiceTestSession(orgId, id, {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+  });
+
+  return c.json(result, 201);
+});
+
+// ============================================================================
+// Voice Prototype (browser WebRTC + compiled prompt injected via metadata)
+// ============================================================================
+
+router.post(
+  "/:id/voice-prototype-token",
+  requireUser(),
+  requirePermission("agents:activate"),
+  requireOrganization(),
+);
+
+const voicePrototypeTokenResponseSchema = z.object({
+  livekitUrl: z.string(),
+  roomName: z.string(),
+  token: z.string(),
+  sessionId: z.string().uuid(),
+  dispatchId: z.string(),
+  agentName: z.string(),
+  identity: z.string(),
+  promptChars: z.number().int().nonnegative(),
+});
+
+const voicePrototypeTokenRoute = createRoute({
+  method: "post",
+  path: "/{id}/voice-prototype-token",
+  tags: ["Agents"],
+  summary: "Issue a LiveKit voice-prototype token",
+  description:
+    "Like /voice-test-token, but dispatches the prompt-driven prototype worker with the agent's compiled instructions injected into dispatch metadata. Lets an admin compile a prompt and immediately hear how it sounds without redeploying a worker profile. See ADR-015 for why this is a separate code path from the production voice-test flow.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: agentIdParams,
+  },
+  responses: {
+    201: {
+      description: "Voice prototype session created",
+      content: {
+        "application/json": { schema: voicePrototypeTokenResponseSchema },
+      },
+    },
+    400: errorResponse(
+      "LiveKit not configured, agent not active, modality wrong, or no compiled prompt",
+    ),
+    401: errorResponse("Not authenticated"),
+    403: errorResponse("Insufficient permissions"),
+    404: errorResponse("Agent not found"),
+  },
+});
+
+router.openapi(voicePrototypeTokenRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const user = getCurrentUser(c);
+  const { id } = c.req.valid("param");
+
+  const result = await createVoicePrototypeSession(orgId, id, {
     userId: user.id,
     email: user.email,
     name: user.name,

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -1060,3 +1060,197 @@ export async function createVoiceTestSession(
     identity,
   };
 }
+
+// ============================================================================
+// Voice Prototype (browser WebRTC + compiled prompt injected via metadata)
+//
+// This is the prototype counterpart to the production "Voice Test" flow
+// above. The contract — and the rationale for keeping them as separate code
+// paths — is documented in ADR-015. Short version: the prototype injects the
+// agent's compiled prompt into dispatch metadata so an admin can iterate on
+// a prompt and immediately hear it without redeploying a worker profile.
+// ============================================================================
+
+const PROTOTYPE_AGENT_WORKER = "voice-prototype";
+
+/**
+ * Build the dispatch-metadata payload for a voice-prototype session.
+ *
+ * Mirrors the contract enforced on the Python side by
+ * ``prompt_agent.parse_dispatch_metadata`` — if either side drifts, dispatched
+ * calls silently land in a worker that refuses them. The contract test on the
+ * TS side is ``tests/unit/agents/voice-prototype-dispatch.test.ts``; on the
+ * Python side it's ``tests/test_prompt_agent.py::TestParseDispatchMetadata``.
+ */
+export function buildVoicePrototypeDispatchMetadata(input: {
+  agentId: string;
+  agentSlug: string;
+  sessionId: string;
+  callerEmail: string;
+  compiledPrompt: string;
+}): {
+  mode: "voice-prototype";
+  agentName: string;
+  agent_id: string;
+  session_id: string;
+  user_identifier: string;
+  email: string;
+  compiled_prompt: string;
+} {
+  if (!input.compiledPrompt || !input.compiledPrompt.trim()) {
+    throw Errors.invalidInput(
+      "Voice prototype requires a non-empty compiled prompt — compile the agent first.",
+    );
+  }
+
+  return {
+    mode: "voice-prototype" as const,
+    agentName: input.agentSlug,
+    agent_id: input.agentId,
+    session_id: input.sessionId,
+    user_identifier: input.callerEmail,
+    email: input.callerEmail,
+    compiled_prompt: input.compiledPrompt,
+  };
+}
+
+export interface VoicePrototypeSession {
+  livekitUrl: string;
+  roomName: string;
+  token: string;
+  sessionId: string;
+  dispatchId: string;
+  agentName: string;
+  identity: string;
+  promptChars: number;
+}
+
+export async function createVoicePrototypeSession(
+  orgId: string,
+  agentId: string,
+  caller: { userId: string; email: string; name: string },
+): Promise<VoicePrototypeSession> {
+  const agent = await forOrg(orgId, async (tx) => {
+    const a = await requireAgent(tx, agentId);
+    if (!a.isActive) {
+      throw Errors.invalidInput("Agent is not active");
+    }
+    if (a.modality !== "voice") {
+      throw Errors.invalidInput("Voice prototype requires a voice agent");
+    }
+    if (a.agentPlatform !== "livekit") {
+      throw Errors.invalidInput(
+        "Voice prototype is only supported for LiveKit agents",
+      );
+    }
+    if (!a.compiledInstructions || !a.compiledInstructions.trim()) {
+      throw Errors.invalidInput(
+        "Agent has no compiled prompt — compile the prompt before testing.",
+      );
+    }
+    return a;
+  });
+
+  const meta = (agent.metadata ?? {}) as Record<string, unknown>;
+  const lkMeta = (meta.livekit ?? {}) as Record<string, unknown>;
+  const livekitUrl = lkMeta.url as string | undefined;
+
+  if (!livekitUrl) {
+    throw Errors.invalidInput(
+      "LiveKit URL is not configured for this agent. Configure it first.",
+    );
+  }
+
+  const apiKey = await getAgentSecretByType(orgId, agentId, "livekit_api_key");
+  const apiSecret = await getAgentSecretByType(
+    orgId,
+    agentId,
+    "livekit_api_secret",
+  );
+
+  if (!apiKey || !apiSecret) {
+    throw Errors.invalidInput(
+      "LiveKit credentials not found. Re-configure LiveKit for this agent.",
+    );
+  }
+
+  const roomName = `voice-prototype-${nanoid()}`;
+  const identity = `user-${caller.userId.slice(0, 8)}-${nanoid(6)}`;
+
+  // Create the session row first so a failed dispatch still gets attributed
+  // and rolled forward (same pattern as createVoiceTestSession).
+  const session = await createSession(orgId, agentId, {
+    channelType: "voice",
+    userIdentifier: caller.email,
+    userMetadata: {
+      voicePrototype: true,
+      userId: caller.userId,
+      name: caller.name,
+      roomName,
+    },
+  });
+
+  // compiledInstructions is non-null here — guarded above inside forOrg.
+  const compiledPrompt = agent.compiledInstructions as string;
+
+  const dispatchMetadata = buildVoicePrototypeDispatchMetadata({
+    agentId: agent.id,
+    agentSlug: agent.slug,
+    sessionId: session.id,
+    callerEmail: caller.email,
+    compiledPrompt,
+  });
+
+  let dispatchId: string;
+  try {
+    dispatchId = await dispatchAgentToRoom(
+      livekitUrl,
+      apiKey,
+      apiSecret,
+      PROTOTYPE_AGENT_WORKER,
+      roomName,
+      dispatchMetadata,
+    );
+  } catch (err) {
+    try {
+      await updateSession(orgId, session.id, agentId, { status: "abandoned" });
+    } catch (rollbackErr) {
+      getLogger().error(
+        { orgId, agentId, sessionId: session.id, rollbackErr },
+        "failed to abandon voice-prototype session after dispatch failure",
+      );
+    }
+    throw err;
+  }
+
+  const token = await generateVoiceTestToken({
+    apiKey,
+    apiSecret,
+    roomName,
+    identity,
+    name: caller.name,
+  });
+
+  getLogger().info(
+    {
+      orgId,
+      agentId,
+      sessionId: session.id,
+      dispatchId,
+      roomName,
+      promptChars: compiledPrompt.length,
+    },
+    "voice-prototype dispatched",
+  );
+
+  return {
+    livekitUrl,
+    roomName,
+    token,
+    sessionId: session.id,
+    dispatchId,
+    agentName: PROTOTYPE_AGENT_WORKER,
+    identity,
+    promptChars: compiledPrompt.length,
+  };
+}

--- a/modelguide-api/tests/unit/agents/voice-prototype-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/voice-prototype-dispatch.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Voice-prototype dispatch metadata — locks in the contract between the
+ * ModelGuide API and the prompt-driven LiveKit entrypoint
+ * (`examples/agents/livekit-agent/src/prompt_entry.py`).
+ *
+ * The worker's ``parse_dispatch_metadata`` rejects anything that doesn't
+ * carry ``mode = voice-prototype`` and the four payload fields below —
+ * which is exactly the safety the production "Talk to agent" flow loses
+ * by injecting a prompt (see ADR-014 vs ADR-015). So this test is the
+ * counterpart to ``tests/test_prompt_agent.py::TestParseDispatchMetadata``
+ * on the API side: if either side drifts, voice-prototype goes silent
+ * and CI catches it before a release.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildVoicePrototypeDispatchMetadata } from "../../../src/features/agents/agents.service";
+
+describe("buildVoicePrototypeDispatchMetadata", () => {
+  test("mode is the literal 'voice-prototype' marker", () => {
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_1",
+      agentSlug: "demo-bot",
+      sessionId: "sess_1",
+      callerEmail: "tester@example.com",
+      compiledPrompt: "You are helpful.",
+    });
+    expect(md.mode).toBe("voice-prototype");
+  });
+
+  test("compiled prompt is echoed verbatim — no trimming or transform", () => {
+    // Whitespace + newlines matter for prompt rendering; a "helpful" trim
+    // here would silently change behavior the operator just compiled.
+    const prompt = "  You are Sam.\n\nAlways answer in one sentence.\n  ";
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_1",
+      agentSlug: "demo-bot",
+      sessionId: "sess_1",
+      callerEmail: "tester@example.com",
+      compiledPrompt: prompt,
+    });
+    expect(md.compiled_prompt).toBe(prompt);
+  });
+
+  test("agent_id + session_id + email carry correlation context", () => {
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_xyz",
+      agentSlug: "demo-bot",
+      sessionId: "sess_xyz",
+      callerEmail: "admin@corp.com",
+      compiledPrompt: "Hi.",
+    });
+    expect(md.agent_id).toBe("agt_xyz");
+    expect(md.session_id).toBe("sess_xyz");
+    expect(md.user_identifier).toBe("admin@corp.com");
+    expect(md.email).toBe("admin@corp.com");
+  });
+
+  test("agentName mirrors agent.slug so a multi-profile worker still routes", () => {
+    // We don't run a *separate* worker for the prototype — operators reuse
+    // the existing LiveKit worker process. Mirroring the slug here keeps
+    // the dispatch path identical so multi-profile routing stays intact.
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_1",
+      agentSlug: "Weird_Slug-v1",
+      sessionId: "sess_1",
+      callerEmail: "tester@example.com",
+      compiledPrompt: "Hi.",
+    });
+    expect(md.agentName).toBe("Weird_Slug-v1");
+  });
+
+  test("shape is stable — exactly these 7 keys, nothing else", () => {
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_1",
+      agentSlug: "demo-bot",
+      sessionId: "sess_1",
+      callerEmail: "tester@example.com",
+      compiledPrompt: "Hi.",
+    });
+    expect(Object.keys(md).sort()).toEqual(
+      [
+        "agentName",
+        "agent_id",
+        "compiled_prompt",
+        "email",
+        "mode",
+        "session_id",
+        "user_identifier",
+      ].sort(),
+    );
+  });
+
+  test("round-trips through JSON without dropping fields", () => {
+    const md = buildVoicePrototypeDispatchMetadata({
+      agentId: "agt_1",
+      agentSlug: "demo-bot",
+      sessionId: "sess_1",
+      callerEmail: "tester@example.com",
+      compiledPrompt: "Hi.",
+    });
+    const roundTripped = JSON.parse(JSON.stringify(md));
+    expect(roundTripped).toEqual(md);
+  });
+
+  test("throws if compiled prompt is empty — the whole point is the prompt", () => {
+    expect(() =>
+      buildVoicePrototypeDispatchMetadata({
+        agentId: "agt_1",
+        agentSlug: "demo-bot",
+        sessionId: "sess_1",
+        callerEmail: "tester@example.com",
+        compiledPrompt: "",
+      }),
+    ).toThrow(/compiled prompt/i);
+  });
+
+  test("throws if compiled prompt is whitespace-only", () => {
+    // Guard the second failure mode the Python parser also guards: a
+    // "present but blank" prompt that would silently degrade to a no-op LLM.
+    expect(() =>
+      buildVoicePrototypeDispatchMetadata({
+        agentId: "agt_1",
+        agentSlug: "demo-bot",
+        sessionId: "sess_1",
+        callerEmail: "tester@example.com",
+        compiledPrompt: "   \n\t  ",
+      }),
+    ).toThrow(/compiled prompt/i);
+  });
+});

--- a/modelguide-ui/bun.lock
+++ b/modelguide-ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "modelguide-ui",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@livekit/components-react": "^2.9.20",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-router-devtools": "^1.158.1",
@@ -192,6 +193,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
     "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
@@ -211,6 +218,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@livekit/components-core": ["@livekit/components-core@0.12.13", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "loglevel": "1.9.1", "rxjs": "7.8.2" }, "peerDependencies": { "livekit-client": "^2.17.2", "tslib": "^2.6.2" } }, "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw=="],
+
+    "@livekit/components-react": ["@livekit/components-react@2.9.21", "", { "dependencies": { "@livekit/components-core": "0.12.13", "clsx": "2.1.1", "events": "^3.3.0", "jose": "^6.0.12", "usehooks-ts": "3.1.1" }, "peerDependencies": { "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0", "livekit-client": "^2.18.2", "react": ">=18", "react-dom": ">=18", "tslib": "^2.6.2" }, "optionalPeers": ["@livekit/krisp-noise-filter"] }, "sha512-6hU9VucJJL+gAhilNGe4MBCDCZVk64qyjP9Ck86krvOIdVU76WeWksddg1MYUP10AlUwwrfD7davz41pJTcMJw=="],
 
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
 
@@ -858,6 +869,8 @@
 
     "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -1172,6 +1185,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -1235,6 +1250,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@livekit/components-core/loglevel": ["loglevel@1.9.1", "", {}, "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.3", "", {}, "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q=="],
 

--- a/modelguide-ui/src/features/agents/components/voice-prototype-panel.test.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-prototype-panel.test.tsx
@@ -1,0 +1,171 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '~/schemas/agents'
+import { VoicePrototypePanel } from './voice-prototype-panel'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPost = vi.fn()
+const mockTokenResponse = {
+  livekitUrl: 'wss://test.livekit.cloud',
+  roomName: 'voice-prototype-abc',
+  token: 'test-token-456',
+  sessionId: '00000000-0000-0000-0000-000000000002',
+  dispatchId: 'disp_xyz',
+  agentName: 'voice-prototype',
+  identity: 'user-xyz',
+  promptChars: 412,
+}
+
+vi.mock('~/lib/api', () => ({
+  api: {
+    post: (url: string) => {
+      mockPost(url)
+      return {
+        json: () => Promise.resolve(mockTokenResponse),
+      }
+    },
+  },
+}))
+
+vi.mock('livekit-client', () => ({
+  ParticipantKind: { AGENT: 'agent' },
+  RoomEvent: { ParticipantConnected: 'participantConnected' },
+}))
+
+vi.mock('@livekit/components-react', () => ({
+  LiveKitRoom: ({ children }: { children: ReactNode }) => (
+    <div data-testid="lk-room">{children}</div>
+  ),
+  RoomAudioRenderer: () => <div data-testid="lk-audio" />,
+  useRoomContext: () => ({
+    localParticipant: { setMicrophoneEnabled: vi.fn().mockResolvedValue(undefined) },
+    remoteParticipants: new Map([['agent-1', { kind: 'agent', identity: 'agent-1' }]]),
+    on: vi.fn().mockReturnThis(),
+    off: vi.fn().mockReturnThis(),
+    disconnect: vi.fn(),
+  }),
+  useVoiceAssistant: () => ({ state: 'listening', audioTrack: undefined }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseAgent: Agent = {
+  id: 'agent-1',
+  name: 'Test Agent',
+  slug: 'test-agent',
+  description: null,
+  modality: 'voice',
+  modelFamily: 'gpt',
+  agentPlatform: 'livekit',
+  isActive: true,
+  evalSuiteCount: 0,
+  promptConfig: {},
+  metadata: { livekit: { url: 'wss://test.livekit.cloud', agentName: 'test-agent' } },
+  hasElevenLabsKey: false,
+  hasWebhookSecret: false,
+  keyPrefix: null,
+  integrationUrls: undefined,
+  compiledInstructions: 'You are a voice agent. Be helpful.',
+  compiledAt: '2026-04-01T00:00:00Z',
+  compiledFrom: null,
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+const configuredAgent: Agent = {
+  ...baseAgent,
+  secrets: { livekit_api_key: 'sec-1', livekit_api_secret: 'sec-2' },
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+function stubMicPermission(grant = true) {
+  const state: PermissionState = grant ? 'granted' : 'denied'
+  const getUserMedia = grant
+    ? vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: vi.fn() }],
+      })
+    : vi.fn().mockRejectedValue(Object.assign(new Error('denied'), { name: 'NotAllowedError' }))
+  // @ts-expect-error — jsdom does not provide mediaDevices by default
+  navigator.mediaDevices = { getUserMedia }
+  // @ts-expect-error — jsdom does not provide Permissions API by default
+  navigator.permissions = {
+    query: vi.fn().mockResolvedValue({ state }),
+  }
+  return getUserMedia
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VoicePrototypePanel', () => {
+  it('renders nothing for non-livekit agents', () => {
+    const elevenAgent = { ...configuredAgent, agentPlatform: 'elevenlabs' } as Agent
+    const { container } = render(<VoicePrototypePanel agent={elevenAgent} canMutate />, { wrapper })
+    expect(container.textContent).toBe('')
+  })
+
+  it('disables the prototype button when LiveKit is not fully configured', () => {
+    const unconfigured = { ...baseAgent } as Agent
+    render(<VoicePrototypePanel agent={unconfigured} canMutate />, { wrapper })
+    expect(screen.getByRole('button', { name: /talk to prototype/i })).toBeDisabled()
+    expect(screen.getByText(/configure the livekit/i)).toBeInTheDocument()
+  })
+
+  it('blocks the prototype button when there is no compiled prompt', () => {
+    // The prototype's whole job is to exercise the compiled prompt — refuse
+    // to start if there isn't one and tell the operator to compile first.
+    const noPrompt = { ...configuredAgent, compiledInstructions: null } as Agent
+    render(<VoicePrototypePanel agent={noPrompt} canMutate />, { wrapper })
+    expect(screen.getByRole('button', { name: /talk to prototype/i })).toBeDisabled()
+    expect(screen.getByText(/compile the prompt first/i)).toBeInTheDocument()
+  })
+
+  it('disables the prototype button for viewers (canMutate=false)', () => {
+    render(<VoicePrototypePanel agent={configuredAgent} canMutate={false} />, { wrapper })
+    expect(screen.getByRole('button', { name: /talk to prototype/i })).toBeDisabled()
+  })
+
+  it('hits the prototype endpoint and mounts the LiveKit room on click', async () => {
+    stubMicPermission(true)
+    render(<VoicePrototypePanel agent={configuredAgent} canMutate />, { wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: /talk to prototype/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('agents/agent-1/voice-prototype-token')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lk-room')).toBeInTheDocument()
+      expect(screen.getByTestId('lk-audio')).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces a clear error when mic permission is denied', async () => {
+    stubMicPermission(false)
+    render(<VoicePrototypePanel agent={configuredAgent} canMutate />, { wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: /talk to prototype/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/microphone permission denied/i)
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/modelguide-ui/src/features/agents/components/voice-prototype-panel.tsx
+++ b/modelguide-ui/src/features/agents/components/voice-prototype-panel.tsx
@@ -1,0 +1,207 @@
+/**
+ * Voice Prototype panel — sibling of VoiceTestPanel that exercises the
+ * prompt-driven LiveKit worker.
+ *
+ * The difference from "Voice Test" is one endpoint and one Python
+ * entrypoint: the prototype dispatches the ``voice-prototype`` worker
+ * with the agent's compiled prompt embedded in dispatch metadata. The
+ * worker then runs the agent with that prompt verbatim — so an admin can
+ * compile a prompt and immediately hear how it sounds, without rolling a
+ * new worker profile. See ADR-015 for the separation rationale.
+ *
+ * UX-wise this reuses the exact same RoomController + LiveKitRoom plumbing
+ * as VoiceTestPanel; we deliberately don't duplicate the in-call toolbar
+ * or visualizer so any polish landing on Voice Test (e.g. PR #242) lands
+ * here for free.
+ */
+
+import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react'
+import { useMutation } from '@tanstack/react-query'
+import { AlertTriangle, FlaskConical, Mic } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
+import { api } from '~/lib/api'
+import type { Agent, VoicePrototypeTokenResponse } from '~/schemas/agents'
+
+import { ensureMicPermission } from './voice-test/mic-permission'
+import { RoomController } from './voice-test/room-controller'
+import { PHASE_LABEL, type WidgetState } from './voice-test/state'
+
+interface VoicePrototypePanelProps {
+  agent: Agent
+  canMutate: boolean
+}
+
+export function VoicePrototypePanel({ agent, canMutate }: VoicePrototypePanelProps) {
+  const [state, setState] = useState<WidgetState>('IDLE')
+  const [token, setToken] = useState<string | null>(null)
+  const [wsUrl, setWsUrl] = useState<string | null>(null)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const endingRef = useRef(false)
+  const disconnectRef = useRef<(() => void) | null>(null)
+
+  const isLivekit = agent.agentPlatform === 'livekit'
+  const lkMeta = ((agent.metadata ?? {}) as Record<string, unknown>).livekit as
+    | Record<string, unknown>
+    | undefined
+  const secretsMap = agent.secrets ?? {}
+  const livekitConfigured =
+    !!lkMeta?.url && !!secretsMap.livekit_api_key && !!secretsMap.livekit_api_secret
+  const hasCompiledPrompt = !!agent.compiledInstructions && agent.compiledInstructions.trim() !== ''
+
+  const reset = useCallback(() => {
+    endingRef.current = false
+    setToken(null)
+    setWsUrl(null)
+    setSessionId(null)
+    setErrorMsg(null)
+    setState('IDLE')
+  }, [])
+
+  const startMutation = useMutation({
+    mutationFn: async (): Promise<VoicePrototypeTokenResponse> => {
+      setErrorMsg(null)
+      setState('CHECKING_MIC')
+      await ensureMicPermission()
+      setState('REQUESTING_TOKEN')
+      return api
+        .post(`agents/${agent.id}/voice-prototype-token`)
+        .json<VoicePrototypeTokenResponse>()
+    },
+    onSuccess: (resp) => {
+      setSessionId(resp.sessionId)
+      setToken(resp.token)
+      setWsUrl(resp.livekitUrl)
+      setState('CONNECTING')
+    },
+    onError: (err) => {
+      setState('ERROR')
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to start voice prototype')
+    },
+  })
+
+  const handleHangUp = useCallback(() => {
+    endingRef.current = true
+    setState('ENDING')
+    disconnectRef.current?.()
+  }, [])
+
+  const handleDisconnected = useCallback(() => {
+    setToken(null)
+    setWsUrl(null)
+    setState('ENDED')
+  }, [])
+
+  const handleRoomError = useCallback(
+    (err: Error) => {
+      if (endingRef.current || state === 'ENDED' || state === 'IDLE') return
+      const name = (err as unknown as { name?: string })?.name
+      const msg =
+        name === 'NotAllowedError'
+          ? 'Microphone access was revoked.'
+          : (err?.message ?? 'Connection lost.')
+      setErrorMsg(msg)
+      setState('ERROR')
+    },
+    [state],
+  )
+
+  if (!isLivekit) return null
+
+  const inCall =
+    state === 'CHECKING_MIC' ||
+    state === 'REQUESTING_TOKEN' ||
+    state === 'CONNECTING' ||
+    state === 'CONNECTED' ||
+    state === 'ENDING'
+
+  const showStartButton = state === 'IDLE' || state === 'ENDED' || state === 'ERROR'
+  const canStart = canMutate && livekitConfigured && hasCompiledPrompt
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <FlaskConical className="h-4 w-4" />
+            Voice Prototype
+          </CardTitle>
+          <Badge variant={state === 'CONNECTED' ? 'success' : 'default'} dot>
+            {PHASE_LABEL[state]}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {!livekitConfigured ? (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-fg-secondary">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            Configure the LiveKit URL, API key, and secret for this agent before testing.
+          </div>
+        ) : !hasCompiledPrompt ? (
+          <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-fg-secondary">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            Compile the prompt first — the prototype dispatches the latest compiled instructions to
+            the worker.
+          </div>
+        ) : (
+          <p className="text-sm text-fg-muted">
+            Dispatches the <code>voice-prototype</code> worker with the agent's latest compiled
+            prompt injected in metadata. Use it to hear changes immediately after a compile, without
+            redeploying a worker profile.
+          </p>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          {showStartButton ? (
+            <Button
+              onClick={() => {
+                reset()
+                startMutation.mutate()
+              }}
+              loading={startMutation.isPending}
+              disabled={!canStart}
+            >
+              <Mic className="h-4 w-4" />
+              {state === 'ENDED' ? 'Talk again' : 'Talk to prototype'}
+            </Button>
+          ) : null}
+
+          {token && wsUrl ? (
+            <LiveKitRoom
+              serverUrl={wsUrl}
+              token={token}
+              connect={true}
+              audio={true}
+              video={false}
+              onDisconnected={handleDisconnected}
+              onError={handleRoomError}
+            >
+              <RoomAudioRenderer />
+              <RoomController
+                state={state}
+                setState={setState}
+                onHangUp={handleHangUp}
+                endingRef={endingRef}
+                disconnectRef={disconnectRef}
+              />
+            </LiveKitRoom>
+          ) : null}
+        </div>
+
+        {errorMsg ? (
+          <p className="mt-3 text-xs text-error" role="alert">
+            {errorMsg}
+          </p>
+        ) : null}
+
+        {inCall && sessionId ? (
+          <p className="mt-3 font-mono text-[11px] text-fg-muted">Session {sessionId}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
+++ b/modelguide-ui/src/routes/_authenticated/agents.$id.tsx
@@ -27,6 +27,7 @@ import { IntegrationCard } from '~/features/agents/components/integration-card'
 import { OutboundCallDialog } from '~/features/agents/components/outbound-call-dialog'
 import { PlatformCard } from '~/features/agents/components/platform-card'
 import { PromptSection } from '~/features/agents/components/prompt-section'
+import { VoicePrototypePanel } from '~/features/agents/components/voice-prototype-panel'
 import { VoiceTestPanel } from '~/features/agents/components/voice-test-panel'
 import { api } from '~/lib/api'
 import type { PaginatedResponse } from '~/lib/pagination'
@@ -464,6 +465,9 @@ function AgentDetailPage() {
 
           {/* Row 3b: Voice test (LiveKit agents only, rendered by the panel) */}
           <VoiceTestPanel agent={agent} canMutate={isAdmin} />
+
+          {/* Row 3c: Voice prototype — prompt-driven LiveKit worker. ADR-015. */}
+          <VoicePrototypePanel agent={agent} canMutate={isAdmin} />
 
           {/* Row 4: Integration (full width) */}
           <IntegrationCard agent={agent} isAdmin={isAdmin} onRegenerateSuccess={setNewApiKey} />

--- a/modelguide-ui/src/schemas/agents.ts
+++ b/modelguide-ui/src/schemas/agents.ts
@@ -142,3 +142,16 @@ export const voiceTestTokenResponseSchema = z.object({
 })
 
 export type VoiceTestTokenResponse = z.infer<typeof voiceTestTokenResponseSchema>
+
+export const voicePrototypeTokenResponseSchema = z.object({
+  livekitUrl: z.string(),
+  roomName: z.string(),
+  token: z.string(),
+  sessionId: z.string().uuid(),
+  dispatchId: z.string(),
+  agentName: z.string(),
+  identity: z.string(),
+  promptChars: z.number().int().nonnegative(),
+})
+
+export type VoicePrototypeTokenResponse = z.infer<typeof voicePrototypeTokenResponseSchema>


### PR DESCRIPTION
## Summary

Adds a second LiveKit voice path on the agent detail page — **Talk to prototype** — that injects the agent's latest compiled prompt into the worker via dispatch metadata. The compile → click → talk loop now works for LiveKit, matching what the ElevenLabs `sync` flow already gives operators.

This explicitly **does not** replace the production "Talk to agent" flow (ADR-014). Both panels now render on the same page; operators pick the one that matches their question:

- *Does it work in prod?* → **Talk to agent** (worker profile owns the prompt — unchanged)
- *Does my latest compile sound right?* → **Talk to prototype** (compiled prompt injected per-dispatch — new)

ADR-015 documents the scoped deviation from ADR-014's "no prompt injection" rule, including what the prototype intentionally gives up (no tools, no SIP, no prompt-pinning guarantee).

## What's in the diff

- **API** — `POST /agents/:id/voice-prototype-token` + `createVoicePrototypeSession` + `buildVoicePrototypeDispatchMetadata`. Same auth/RLS/error-taxonomy posture as voice-test, plus one new 400 for "no compiled prompt yet."
- **LiveKit worker** — `examples/agents/livekit-agent/src/prompt_agent.py` (`PromptAgent` + `parse_dispatch_metadata`, both tool-less by design) and `src/prompt_entry.py` (sibling entrypoint registered as `agent_name=voice-prototype`). Transcript still posts back to ModelGuide on disconnect.
- **UI** — `<VoicePrototypePanel>` rendered below `<VoiceTestPanel>` on the agent detail page. Disables itself until a compiled prompt exists. Reuses `RoomController` + mic-permission probe so UX polish flows both ways.
- **Docs** — `docs/decisions/015-livekit-prompt-driven-voice-prototype.md` (why) and `examples/agents/livekit-agent/PROMPT_AGENT.md` (how).
- **Tests (red-then-green TDD on every layer)**:
  - Python — `tests/test_prompt_agent.py` (11 tests covering parser + agent construction)
  - Bun — `tests/unit/agents/voice-prototype-dispatch.test.ts` (8 contract-shape tests)
  - Vitest — `voice-prototype-panel.test.tsx` (6 tests covering gating + click flow)

The dispatch-metadata contract is locked behind tests on both sides: if either side drifts (`agent_id`, `compiled_prompt`, `mode == "voice-prototype"`), CI fails before a release.

## Local results

- `bun run typecheck` ✅ (API + UI)
- `bun run lint:check` ✅ (API) / `bun run lint` ✅ (UI)
- `bun test --preload ./tests/setup/unit-preload.ts tests/unit` ✅ 904/904
- `pytest tests/test_prompt_agent.py` ✅ 11/11
- `vitest src/features/agents/components/` ✅ 12/12 (incl. existing voice-test panel)

## Test plan

- [ ] Compile a prompt on a LiveKit agent in dev, click **Talk to prototype**, confirm the worker greets you and the LLM responds in the compiled prompt's voice.
- [ ] Try clicking with no compiled prompt — button is disabled with the "compile first" hint.
- [ ] Try on an ElevenLabs agent — panel renders nothing.
- [ ] Try as a viewer (`canMutate=false`) — button is disabled.
- [ ] Deny mic permission — alert surfaces "microphone permission denied," no token fetched.
- [ ] Check worker logs — `prompt_chars=N` line should match the compiled prompt length; the prompt itself is not logged.
- [ ] Confirm the production "Talk to agent" button is unchanged.

## Deploying the prototype worker

Same image, second entrypoint. Cleanest shape is a separate Railway service:

```
CMD ["python", "src/prompt_entry.py", "start"]
```

LiveKit dispatches by `agent_name`, so the API picks the right worker for each panel.

https://claude.ai/code/session_01Lc4QurupgGmAYe7sdh9RDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc4QurupgGmAYe7sdh9RDr)_