### PR TITLE
feat(examples): livekit-poc — prompt-driven worker for compile→test loop

### DIFF
--- a/docs/decisions/015-livekit-poc-prompt-driven-worker.md
+++ b/docs/decisions/015-livekit-poc-prompt-driven-worker.md
@@ -1,0 +1,193 @@
+# ADR-015: LiveKit POC Worker — Prompt-Driven Iteration
+
+**Status:** Accepted
+
+## Context
+
+ADR-014 added "Talk to agent" — one-click browser WebRTC into the
+configured production worker. The dispatch metadata carries `agentName`
+(the agent's slug); the worker reads it, picks a profile from its
+in-memory registry, and starts. The prompt + tools for that profile are
+**baked into the worker image** at build time. That section of ADR-014
+spells out why injecting a prompt at dispatch time was rejected:
+
+> Earlier iterations shipped a `prompt_override` / `instructions_override`
+> field … We rejected this because the worker's profile is the
+> authoritative source of prompt + tools. Injecting a different prompt
+> creates a "it works in voice-test but broke in prod" failure mode.
+
+That trade-off is correct for the canonical "talk to the live agent" UX,
+and ADR-014 stands. But it leaves a UX gap for prompt iteration:
+
+- Operator edits a SOP / compiles the agent in the dashboard.
+- To hear the change, they must redeploy the production worker (image
+  rebuild + LiveKit Cloud rollout, minutes to tens of minutes).
+- The "Talk to agent" button gives them the **previously deployed**
+  prompt, not the one they just compiled.
+
+Voiceblox-style projects ([voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox))
+demonstrate a different posture: a thin, prompt-driven worker that does
+nothing but boot a session with whatever instructions the caller hands
+it. Cheaper to iterate on, useless for production tool flows.
+
+## Decision
+
+Ship a **second**, additional LiveKit worker — `examples/agents/livekit-poc/`
+— purpose-built for prompt iteration. It coexists with the production
+worker; neither replaces the other.
+
+### Worker behaviour
+
+On every job the POC worker:
+
+1. Parses `ctx.job.metadata` as JSON.
+2. Extracts `agent_id` (UUID, new — see below).
+3. Calls `GET /api/agents/{agent_id}` with the worker's own
+   `MODELGUIDE_API_KEY` and reads `compiledInstructions` off the
+   response.
+4. Constructs `Agent(instructions=…)` from that text.
+5. Falls back to a clearly-labelled default prompt if any of (a) no
+   `agent_id` provided, (b) the API call fails, (c) the agent has no
+   `compiledInstructions` (operator never clicked Compile).
+
+The worker has **no MCP, no tools, no scenario logic**. It exists only
+to read a prompt and produce audio from it. ~200 lines of Python total.
+
+### API change
+
+`buildVoiceTestDispatchMetadata` gains one additive field:
+
+```ts
+{
+  mode: "voice-test",
+  agentName: string,      // unchanged — production worker reads this
+  agent_id: string,       // NEW — POC worker reads this
+  session_id: string,
+  user_identifier: string,
+  email: string,
+}
+```
+
+`agent_id` is the agent's UUID (immutable, primary key). The production
+worker ignores it. The POC worker uses it to fetch the prompt.
+
+Naming intentionally:
+
+- `agent_id` snake_case to match the rest of the payload (and ADR-014's
+  comment about Python-side conventions).
+- We pass the **ID**, not the **slug**, because slugs can be renamed via
+  the dashboard mid-test. A UUID survives renames.
+- We pass the **ID**, not the **prompt text**, because that's the line
+  ADR-014 rejected — we're not putting a prompt on the wire, just a
+  lookup key.
+
+### Selection
+
+Per-agent. The agent's `metadata.livekit.agentName` is the LiveKit
+worker name to dispatch into:
+
+- `agentName = "<customer>-voice-agent"` → the production worker.
+- `agentName = "livekit-poc"` → this worker (when configured).
+
+Operators pick by editing the agent's LiveKit config in the dashboard.
+No new UI surface required for the POC; the existing voice-test panel
+just dispatches into whichever worker the agent points at.
+
+### What this deliberately does NOT do
+
+- **No prompt injection on the wire.** The dispatch metadata carries an
+  ID, not the compiled prompt itself. ADR-014's argument about
+  test-vs-prod drift, byte-size guards (50K char / 48KB metadata caps),
+  and the "build a new profile if you want to test a new prompt"
+  alternative still applies to the production worker.
+- **No worker-side prompt cache.** Every session refetches. A 24-hour
+  cached prompt would defeat the purpose of "test the version I just
+  compiled."
+- **No tool execution.** If an operator wants to test tool flows, they
+  use the production worker via "Talk to agent" or, in headless form,
+  via the simulation engine (ADR-008).
+- **No new endpoint.** Reuses `POST /agents/:id/voice-test-token`. The
+  metadata is additive; the route shape is unchanged.
+
+### Endpoint shape
+
+Unchanged from ADR-014. The only API delta is one new field in dispatch
+metadata.
+
+## Alternatives Considered
+
+**Inject the compiled prompt directly in dispatch metadata.** Rejected,
+per ADR-014. We use the agent ID + a server-side fetch instead.
+
+**Add a new endpoint `POST /agents/:id/poc-voice-token`.** Rejected as
+over-engineered: the existing endpoint already creates a session and
+dispatches a worker. The only thing that needs to change per-agent is
+which worker name is dispatched to, and that's already configurable per
+agent. A new endpoint would duplicate the orchestration for no
+behavioural difference.
+
+**Make the production worker hot-reload prompts from ModelGuide.**
+Rejected. The production worker's contract is "WYSIWYG: what was
+deployed is what runs." Hot-reloading prompts couples a prod worker's
+behaviour to dashboard state (a SOP edit becomes a prod change without
+a CI gate). The POC's "always fresh" is the right default for
+iteration and the wrong default for production.
+
+**Ship a third "preview" mode in the production worker (read prompt
+from MG if a flag is set in dispatch metadata).** Rejected. Same
+worker, two modes of operation, two failure surfaces, twice the test
+matrix. A second worker is cheap; mode-switching a single worker is
+the start of a feature-flag proliferation.
+
+**Skip the worker, drive the LLM directly from the dashboard with no
+audio.** Rejected. We already have that (the prompt-compiler preview
+in `modelguide-ui`). The point of the POC is to hear the prompt in
+voice, which is the actual production medium.
+
+## Consequences
+
+- **Operators gain a fast prompt-iteration loop.** Compile → click test
+  → hear the new prompt in under ~5 seconds (token + dispatch + WebRTC
+  + agent boot + prompt fetch).
+- **`agent_id` in dispatch metadata is now load-bearing for the POC
+  worker.** The contract test `voice-test-dispatch.test.ts` locks the
+  field name and behaviour (echoed verbatim, independent of agentName).
+- **Two workers to keep deployed.** A small operational cost. The POC
+  worker has no per-customer state — one instance can serve every org.
+- **Fallback path is reachable in production.** When the API is down or
+  the agent isn't compiled, the operator hears a fallback prompt
+  telling them what's wrong. This is intentional — a silent room is
+  worse than a generic-but-honest greeting.
+- **No tool testing in the POC.** If a prompt change needs to be
+  validated against tools, the operator still rebuilds the production
+  worker. The POC narrows the iteration loop for the most common case
+  (prompt tone / wording / structure), not all cases.
+
+## Known test gap
+
+The agent.py entrypoint itself is not covered by tests — exercising
+`AgentSession.start` requires standing up a LiveKit dev server in CI,
+which is out of scope. Coverage instead targets the pieces that
+actually own behaviour:
+
+- `prompt_loader.load_prompt` — fetch + four fallback paths, all mocked
+  against `httpx`. 12 test cases.
+- `prompt_loader.extract_agent_id` — dispatch metadata parsing, 4
+  cases.
+- `transcript.TranscriptCollector` — ordering, whitespace, JSON-shape
+  for the API post.
+- `config.validate` — required vars, URL normalization, idempotence.
+- API side: `buildVoiceTestDispatchMetadata` — 8 cases, including two
+  new ones that lock the `agent_id` contract.
+
+Net risk: a refactor that reorders the entrypoint orchestration (e.g.
+fetches the prompt *after* `session.start`) would pass CI. Follow-up:
+if this worker becomes load-bearing in production iteration, add an
+integration test that spins up a LiveKit dev server in a CI sidecar
+and asserts a session can be entered end-to-end.
+
+## Related
+
+- ADR-014: Browser Voice Testing via LiveKit Dispatch — the flow this extends.
+- ADR-011: LiveKit Outbound Calls — original dispatch + metadata pattern.
+- ADR-008: Persona Simulation — headless prompt iteration (no voice).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing via LiveKit Dispatch | Accepted |
+| [015-livekit-poc-prompt-driven-worker.md](015-livekit-poc-prompt-driven-worker.md) | LiveKit POC Worker — Prompt-Driven Iteration | Accepted |

--- a/examples/agents/livekit-poc/.env.example
+++ b/examples/agents/livekit-poc/.env.example
@@ -1,0 +1,29 @@
+# --- Required ---------------------------------------------------------------
+# OpenAI (LLM)
+OPENAI_API_KEY=sk-...
+# Deepgram (STT)
+DEEPGRAM_API_KEY=...
+# ElevenLabs (TTS)
+ELEVENLABS_API_KEY=...
+
+# ModelGuide
+MODELGUIDE_API_URL=http://localhost:3000
+MODELGUIDE_API_KEY=mgk_...
+
+# --- Optional ---------------------------------------------------------------
+# Used by `console` mode and as a fallback when dispatch metadata is empty.
+# In production the LiveKit dispatch metadata carries `agent_id` and this
+# can stay unset.
+MODELGUIDE_AGENT_ID=
+
+# LiveKit (required to actually run the worker — not needed for tests)
+LIVEKIT_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# Tuning
+AGENT_NAME=livekit-poc
+LLM_MODEL=gpt-4.1-mini
+STT_MODEL=nova-3
+ELEVENLABS_VOICE_ID=iP95p4xoKVk53GoZ742B
+USER_EMAIL=voice-caller

--- a/examples/agents/livekit-poc/.gitignore
+++ b/examples/agents/livekit-poc/.gitignore
@@ -1,0 +1,9 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.DS_Store

--- a/examples/agents/livekit-poc/Dockerfile
+++ b/examples/agents/livekit-poc/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml .
+RUN uv venv /app/.venv && \
+    uv pip install --python /app/.venv/bin/python --no-cache "."
+
+# Download VAD + turn-detector model files at build time so the first job
+# doesn't pay a cold-download tax.
+ENV HF_HOME=/app/.cache/huggingface
+RUN /app/.venv/bin/python -c "from livekit.plugins.silero import VAD; VAD.load()" && \
+    /app/.venv/bin/python -c "from livekit.plugins.turn_detector.english import _EUORunnerEn; _EUORunnerEn._download_files()"
+
+FROM python:3.13-slim-bookworm
+
+RUN useradd --create-home agent
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.cache/huggingface /home/agent/.cache/huggingface
+RUN chown -R agent:agent /home/agent/.cache
+COPY pyproject.toml .
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+USER agent
+CMD ["python", "src/agent.py", "start"]

--- a/examples/agents/livekit-poc/README.md
+++ b/examples/agents/livekit-poc/README.md
@@ -1,0 +1,141 @@
+# livekit-poc — talk to the latest compiled prompt
+
+A minimal LiveKit voice worker that fetches its system prompt from
+ModelGuide on every session. Built for one purpose: a tight
+**compile → click test → talk** loop on the dashboard so an operator
+can iterate on a prompt without rebuilding a worker image.
+
+Inspired by the lean, prompt-driven worker pattern in
+[voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox).
+See [ADR-015](../../../docs/decisions/015-livekit-poc-prompt-driven-worker.md)
+for why this exists alongside (not replacing) the production worker
+in [`../livekit-agent`](../livekit-agent/README.md).
+
+## What this is NOT
+
+- **Not the production voice agent.** No MCP, no tool wiring, no
+  scenario logic. Use it for prompt iteration only.
+- **Not a replacement for ADR-014.** The existing "Talk to agent" flow
+  in the dashboard already dispatches the canonical worker. This POC
+  is an additional worker you can point an agent at when you want
+  prompt-only iteration.
+
+## Architecture
+
+```
+modelguide-ui
+  ↓  (Compile + Talk to agent)
+modelguide-api  POST /agents/:id/voice-test-token
+  → createSession()
+  → buildVoiceTestDispatchMetadata({ agent_id, agentName, session_id, ... })
+  → dispatchAgentToRoom(agentName: "livekit-poc", metadata)
+  → returns AccessToken
+            ↓
+LiveKit Cloud / dev server
+            ↓  (dispatch with metadata)
+livekit-poc worker
+  → prompt_loader.extract_agent_id(metadata)        ← agent_id
+  → prompt_loader.load_prompt(agent_id)              ← GET /api/agents/:id
+  → AgentSession(stt, llm, tts, vad, turn-detector)
+  → say("Hi, I'm using the latest compiled prompt.")
+```
+
+Operator UX:
+
+1. Edit a SOP in the dashboard.
+2. Click **Compile** on the agent's detail page.
+3. Click **Talk to agent**.
+4. The browser joins a LiveKit room. The worker starts, fetches the prompt
+   it just heard about, and greets the operator with it loaded.
+5. Hang up. Iterate.
+
+## Quick start
+
+All commands run from this directory unless noted.
+
+```bash
+# 1. Install
+uv sync                                  # or `pip install -e ".[test]"`
+
+# 2. Configure
+cp .env.example .env
+# Edit .env — set OPENAI / DEEPGRAM / ELEVENLABS keys + MODELGUIDE_API_KEY
+```
+
+### Console mode (no LiveKit needed — useful for prompt smoke tests)
+
+```bash
+# Set MODELGUIDE_AGENT_ID in .env first so console mode knows which agent to fetch.
+python src/agent.py console
+```
+
+Type text → the agent fetches its prompt → responds via LLM. No audio,
+no LiveKit server.
+
+### Local LiveKit dev
+
+```bash
+# Terminal 1: LiveKit server (from the repo root)
+make livekit-up        # or `make livekit-up-docker`
+
+# Terminal 2: this worker
+LIVEKIT_URL=ws://localhost:7880 \
+LIVEKIT_API_KEY=devkey \
+LIVEKIT_API_SECRET=secret \
+python src/agent.py dev
+
+# Terminal 3: dispatch + a browser tab to talk
+make livekit-token NAME=tester
+```
+
+### Production (LiveKit Cloud)
+
+```bash
+docker build -t livekit-poc .
+# Push to your registry, deploy as a LiveKit Cloud Agent worker
+# with agent_name="livekit-poc" — see livekit.toml or the LiveKit docs.
+```
+
+Then configure a ModelGuide agent's LiveKit metadata to dispatch into
+this worker:
+
+- Agent detail page → **LiveKit** card → Configure
+- `Agent Name` = `livekit-poc` (matches `AGENT_NAME` env var in the worker)
+- Save → click **Talk to agent**.
+
+## Tests
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+The suite is structured red→green→refactor:
+
+- `tests/test_prompt_loader.py` — the heart. Asserts the fetch / fallback
+  / metadata extraction contract. Run this and you've covered ~90% of
+  the worker-side behaviour without standing up LiveKit.
+- `tests/test_transcript.py` — append-only collector, whitespace
+  handling, JSON-serializable output.
+- `tests/test_config.py` — env validation, idempotence, URL
+  normalization.
+
+## Why a separate worker?
+
+| | livekit-agent (production) | livekit-poc (this) |
+|--|--|--|
+| Tools / MCP | Yes (BuildPro scenario) | No |
+| Prompt source | Baked into image at build | Fetched from ModelGuide at session start |
+| Use case | "Talk to the deployed agent" | "Talk to the prompt I just compiled" |
+| Worker name | per-customer (e.g. `glowbox-voice-agent`) | `livekit-poc` (one shared instance) |
+| Dispatch metadata read | `agentName` (profile slug) | `agent_id` (UUID) |
+
+The two workers can coexist behind one LiveKit project — pick which one
+to dispatch into by setting the agent's `metadata.livekit.agentName` in
+the dashboard.
+
+## Related
+
+- [ADR-014: Browser Voice Testing via LiveKit Dispatch](../../../docs/decisions/014-browser-voice-testing.md) — the existing "Talk to agent" flow that we extend.
+- [ADR-015: LiveKit POC Worker — Prompt-Driven Iteration](../../../docs/decisions/015-livekit-poc-prompt-driven-worker.md) — why this exists.
+- [examples/agents/livekit-agent/](../livekit-agent/) — the production BuildPro voice agent with tools.

--- a/examples/agents/livekit-poc/pyproject.toml
+++ b/examples/agents/livekit-poc/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "livekit-modelguide-poc"
+version = "0.1.0"
+description = "Minimal LiveKit voice agent that hot-loads the compiled prompt from ModelGuide on every session — voiceblox-inspired POC for prompt iteration."
+requires-python = ">=3.11"
+dependencies = [
+    "livekit-agents[silero,turn-detector]~=1.4",
+    "livekit-plugins-openai~=1.4",
+    "livekit-plugins-deepgram~=1.4",
+    "livekit-plugins-elevenlabs~=1.4",
+    "httpx",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/examples/agents/livekit-poc/src/agent.py
+++ b/examples/agents/livekit-poc/src/agent.py
@@ -1,0 +1,201 @@
+"""LiveKit POC voice agent — minimal, prompt-driven, no tools.
+
+Boots an AgentSession (Deepgram STT → OpenAI LLM → ElevenLabs TTS, Silero
+VAD, English turn-detector) and hot-loads the agent's compiled prompt
+from ModelGuide on every session. There is no MCP, no tool registry, no
+connector wiring — the whole point is a fast "compile → click test →
+talk" loop for prompt iteration. For the tool-equipped production agent,
+see ``examples/agents/livekit-agent/``.
+
+Usage:
+  python src/agent.py console      (text-only, no WebRTC)
+  python src/agent.py dev          (full WebRTC, local LiveKit)
+  python src/agent.py start        (LiveKit Cloud worker)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from livekit import agents
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import deepgram, elevenlabs, openai, silero
+from livekit.plugins.turn_detector.english import EnglishModel
+
+import config
+import mg_client
+import prompt_loader
+from transcript import TranscriptCollector
+
+VERSION = "0.1.0"
+
+logging.basicConfig(
+    level=logging.INFO, format="%(name)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger("agent")
+
+
+async def entrypoint(ctx: agents.JobContext) -> None:
+    """LiveKit agent entrypoint — called once per room/job."""
+    config.validate()
+    logger.info("livekit-poc v%s — entrypoint called", VERSION)
+
+    # Parse dispatch metadata — `agent_id` and `session_id` are stamped by
+    # the ModelGuide API in `buildVoiceTestDispatchMetadata`.
+    dispatch_metadata: dict = {}
+    if ctx.job.metadata:
+        try:
+            dispatch_metadata = json.loads(ctx.job.metadata)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Invalid JSON in job metadata: %s", ctx.job.metadata[:100]
+            )
+
+    # agent_id from dispatch wins; fall back to env for `console` runs.
+    agent_id = prompt_loader.extract_agent_id(dispatch_metadata) or (
+        config.MODELGUIDE_AGENT_ID or None
+    )
+    pre_existing_session_id = dispatch_metadata.get("session_id")
+    user_identifier = (
+        dispatch_metadata.get("user_identifier") or config.USER_EMAIL
+    )
+
+    # Connect to the room first so the operator sees "connecting → connected"
+    # in the dashboard immediately, before we hit any network.
+    await ctx.connect()
+
+    # Fetch the prompt + participant + (optionally) create a session in
+    # parallel — none of them depend on each other.
+    prompt_task = asyncio.create_task(prompt_loader.load_prompt(agent_id))
+    participant_task = asyncio.create_task(ctx.wait_for_participant())
+
+    if pre_existing_session_id:
+        session_id: str | None = pre_existing_session_id
+        session_task: asyncio.Task[str] | None = None
+    else:
+        session_id = None
+        session_task = asyncio.create_task(
+            mg_client.create_session(user_identifier)
+        )
+
+    participant = await participant_task
+    prompt_result = await prompt_task
+    if session_task is not None:
+        try:
+            session_id = await session_task
+        except Exception:
+            logger.exception(
+                "Failed to create ModelGuide session — running without tracking"
+            )
+
+    logger.info(
+        "Participant joined: %s | session=%s | prompt source=%s (%d chars)",
+        participant.identity,
+        session_id,
+        prompt_result.source,
+        len(prompt_result.text),
+    )
+
+    transcript = TranscriptCollector()
+    agent = Agent(instructions=prompt_result.text)
+
+    session = AgentSession(
+        stt=deepgram.STT(
+            model=config.STT_MODEL, api_key=config.DEEPGRAM_API_KEY
+        ),
+        llm=openai.LLM(model=config.LLM_MODEL, api_key=config.OPENAI_API_KEY),
+        tts=elevenlabs.TTS(
+            api_key=config.ELEVENLABS_API_KEY,
+            voice_id=config.ELEVENLABS_VOICE_ID,
+            model="eleven_flash_v2_5",
+        ),
+        vad=silero.VAD.load(),
+        turn_detection=EnglishModel(),
+        allow_interruptions=True,
+    )
+
+    @session.on("user_input_transcribed")
+    def on_user_speech(ev):
+        if ev.is_final:
+            transcript.add_user_utterance(ev.transcript)
+
+    @session.on("conversation_item_added")
+    def on_conversation_item(ev):
+        item = ev.item
+        if not (hasattr(item, "role") and item.role == "assistant"):
+            return
+        text = _extract_text(item)
+        if text:
+            transcript.add_assistant_response(text)
+
+    session_done = asyncio.Event()
+
+    @session.on("close")
+    def on_close():
+        session_done.set()
+
+    @ctx.room.on("disconnected")
+    def on_disconnect():
+        session_done.set()
+
+    await session.start(room=ctx.room, agent=agent)
+
+    # Brief greeting — tells the operator the prompt loaded (or didn't).
+    name = participant.name or participant.identity or "there"
+    if prompt_result.source == "modelguide-api":
+        await session.say(f"Hi {name}, I'm using the latest compiled prompt.")
+    else:
+        await session.say(
+            f"Hi {name}, the compiled prompt couldn't be loaded — "
+            f"I'm running on a fallback. Please check the dashboard."
+        )
+
+    try:
+        await session_done.wait()
+    finally:
+        await _cleanup(session_id, transcript)
+
+
+def _extract_text(item) -> str:
+    if not hasattr(item, "content") or not item.content:
+        return ""
+    if isinstance(item.content, str):
+        return item.content.strip()
+    if isinstance(item.content, list):
+        return " ".join(
+            part if isinstance(part, str) else getattr(part, "text", "")
+            for part in item.content
+        ).strip()
+    return ""
+
+
+async def _cleanup(
+    session_id: str | None, transcript: TranscriptCollector
+) -> None:
+    if not session_id:
+        await mg_client.close_http_client()
+        return
+    try:
+        messages = transcript.get_messages()
+        status = "completed" if len(messages) > 1 else "abandoned"
+        await mg_client.add_messages(session_id, messages)
+        await mg_client.complete_session(session_id, status=status)
+        logger.info(
+            "Posted %d messages, marked session %s as %s",
+            len(messages),
+            session_id,
+            status,
+        )
+    finally:
+        await mg_client.close_http_client()
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            agent_name=config.AGENT_NAME,
+        )
+    )

--- a/examples/agents/livekit-poc/src/config.py
+++ b/examples/agents/livekit-poc/src/config.py
@@ -1,0 +1,100 @@
+"""Environment variable loading and validation.
+
+Required vars are enforced by ``validate()``, called once from the
+LiveKit entrypoint. The optional ``MODELGUIDE_AGENT_ID`` is the
+fallback used when the dispatch metadata doesn't carry an ``agent_id``
+(e.g. running ``python src/agent.py console`` for a quick local check).
+"""
+
+import logging
+import os
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger("config")
+
+load_dotenv()
+
+
+# --------------------------------------------------------------------------- #
+# Identity — read at import time so WorkerOptions can be constructed before
+# any other init.
+# --------------------------------------------------------------------------- #
+
+AGENT_NAME: str = os.getenv("AGENT_NAME", "livekit-poc")
+
+
+# --------------------------------------------------------------------------- #
+# Required vars
+# --------------------------------------------------------------------------- #
+
+REQUIRED_VARS = [
+    "OPENAI_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "MODELGUIDE_API_URL",
+    "MODELGUIDE_API_KEY",
+]
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+# --------------------------------------------------------------------------- #
+# All other config — populated by validate()
+# --------------------------------------------------------------------------- #
+
+OPENAI_API_KEY: str = ""
+DEEPGRAM_API_KEY: str = ""
+ELEVENLABS_API_KEY: str = ""
+LLM_MODEL: str = "gpt-4.1-mini"
+STT_MODEL: str = "nova-3"
+ELEVENLABS_VOICE_ID: str = ""
+
+MODELGUIDE_API_URL: str = ""
+MODELGUIDE_API_KEY: str = ""
+MODELGUIDE_AGENT_ID: str = ""  # optional — fallback when dispatch metadata is empty
+USER_EMAIL: str = "voice-caller"
+
+
+_validated = False
+
+
+def validate() -> None:
+    """Validate required env vars and populate module-level constants.
+
+    Idempotent — second and later calls are no-ops so tests / hot reload
+    don't trigger re-reads.
+    """
+    global _validated
+    if _validated:
+        return
+
+    missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
+    if missing:
+        raise ConfigError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    g = globals()
+    g.update(
+        {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "DEEPGRAM_API_KEY": os.environ["DEEPGRAM_API_KEY"],
+            "ELEVENLABS_API_KEY": os.environ["ELEVENLABS_API_KEY"],
+            "LLM_MODEL": os.getenv("LLM_MODEL", "gpt-4.1-mini"),
+            "STT_MODEL": os.getenv("STT_MODEL", "nova-3"),
+            "ELEVENLABS_VOICE_ID": os.getenv(
+                "ELEVENLABS_VOICE_ID", "iP95p4xoKVk53GoZ742B"
+            ),
+            # Strip trailing slash once — mg_client builds URLs by string
+            # concatenation and a `//api/...` path produces a 404.
+            "MODELGUIDE_API_URL": os.environ["MODELGUIDE_API_URL"].rstrip("/"),
+            "MODELGUIDE_API_KEY": os.environ["MODELGUIDE_API_KEY"],
+            "MODELGUIDE_AGENT_ID": os.getenv("MODELGUIDE_AGENT_ID", ""),
+            "USER_EMAIL": os.getenv("USER_EMAIL", "voice-caller"),
+        }
+    )
+
+    _validated = True

--- a/examples/agents/livekit-poc/src/mg_client.py
+++ b/examples/agents/livekit-poc/src/mg_client.py
@@ -1,0 +1,87 @@
+"""Thin ModelGuide REST client — sessions + transcript posting.
+
+The POC deliberately avoids MCP / tool wiring (see README) so this is a
+much smaller surface than ``examples/agents/livekit-agent/src/mg_client.py``
+— just session create / messages / complete. ``prompt_loader.py`` owns
+the agent-fetch flow.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+import config
+
+logger = logging.getLogger("mg_client")
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {config.MODELGUIDE_API_KEY}",
+    }
+
+
+_http_client: httpx.AsyncClient | None = None
+
+
+def _get_http_client() -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(
+            base_url=config.MODELGUIDE_API_URL,
+            headers=_headers(),
+            timeout=30.0,
+        )
+    return _http_client
+
+
+async def close_http_client() -> None:
+    global _http_client
+    if _http_client and not _http_client.is_closed:
+        await _http_client.aclose()
+        _http_client = None
+
+
+async def create_session(user_identifier: str | None = None) -> str:
+    client = _get_http_client()
+    response = await client.post(
+        "/api/sessions",
+        json={
+            "channelType": "voice",
+            "userIdentifier": user_identifier or config.USER_EMAIL,
+        },
+    )
+    response.raise_for_status()
+    session_id = response.json()["id"]
+    logger.info("Session created: %s", session_id)
+    return session_id
+
+
+async def add_messages(session_id: str, messages: list[dict]) -> None:
+    """Post the transcript. Errors are logged, not raised — losing the
+    transcript should not abort the LiveKit shutdown path."""
+    if not messages:
+        return
+    client = _get_http_client()
+    for msg in messages:
+        try:
+            await client.post(
+                f"/api/sessions/{session_id}/messages",
+                json=msg,
+            )
+        except Exception:  # noqa: BLE001 — best-effort
+            logger.exception("Failed to post message to session %s", session_id)
+
+
+async def complete_session(session_id: str, *, status: str = "completed") -> None:
+    client = _get_http_client()
+    try:
+        await client.patch(
+            f"/api/sessions/{session_id}",
+            json={"status": status},
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to complete session %s", session_id)

--- a/examples/agents/livekit-poc/src/prompt_loader.py
+++ b/examples/agents/livekit-poc/src/prompt_loader.py
@@ -1,0 +1,115 @@
+"""Fetch the latest compiled prompt for a ModelGuide agent.
+
+The POC's whole reason to exist is "always boot with the freshest prompt
+the operator just compiled in the dashboard." The flow at session start:
+
+  1. ``extract_agent_id(metadata)`` — pull the UUID the API stamped into
+     the LiveKit dispatch metadata.
+  2. ``load_prompt(agent_id)`` — call ``GET /api/agents/{agent_id}`` and
+     return its ``compiledInstructions``.
+  3. If the API fails or the agent hasn't been compiled yet, return a
+     clearly-labelled fallback so the room still produces audio (a silent
+     room is the worst feedback for an operator iterating on prompts).
+
+This file does NOT depend on livekit / livekit-agents so the tests can
+exercise it without bringing up the worker.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import httpx
+
+import config
+
+logger = logging.getLogger("prompt_loader")
+
+
+PromptSource = Literal["modelguide-api", "fallback"]
+
+
+@dataclass(frozen=True)
+class PromptResult:
+    text: str
+    source: PromptSource
+    agent_id: str | None
+
+
+FALLBACK_PROMPT = (
+    "You are a helpful voice assistant in a ModelGuide POC session. "
+    "The agent's compiled prompt could not be loaded — most likely the "
+    "operator hasn't clicked Compile in the dashboard yet, or the "
+    "ModelGuide API is unreachable. Greet the caller, tell them the "
+    "fallback prompt is in use, and ask them to retry after compiling. "
+    "Keep responses short."
+)
+
+
+def extract_agent_id(metadata: Any) -> str | None:
+    """Return the ``agent_id`` field of dispatch metadata, or None.
+
+    Accepts non-dict inputs (returns None) because LiveKit ``console`` mode
+    dispatches with no metadata at all and we don't want the entrypoint to
+    have to special-case that.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("agent_id")
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
+async def _http_get(url: str, *, headers: dict[str, str]) -> httpx.Response:
+    """Tiny indirection so tests can patch the HTTP layer without mocking httpx itself."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        return response
+
+
+async def load_prompt(agent_id: str | None) -> PromptResult:
+    """Fetch ``compiledInstructions`` for ``agent_id`` or return the fallback.
+
+    Never raises — a session that can't load a prompt should still produce
+    audio so the operator sees the worker dispatched correctly and knows
+    to compile (or fix the API connection).
+    """
+    if not agent_id:
+        logger.warning("No agent_id provided — using fallback prompt")
+        return PromptResult(text=FALLBACK_PROMPT, source="fallback", agent_id=None)
+
+    url = f"{config.MODELGUIDE_API_URL}/api/agents/{agent_id}"
+    headers = {
+        "Authorization": f"Bearer {config.MODELGUIDE_API_KEY}",
+        "Accept": "application/json",
+    }
+
+    try:
+        response = await _http_get(url, headers=headers)
+        body = response.json()
+    except Exception as exc:  # noqa: BLE001 — fallback is the whole point
+        logger.warning("Failed to fetch agent %s: %s — using fallback", agent_id, exc)
+        return PromptResult(
+            text=FALLBACK_PROMPT, source="fallback", agent_id=agent_id
+        )
+
+    compiled = body.get("compiledInstructions")
+    if not isinstance(compiled, str) or not compiled.strip():
+        logger.info(
+            "Agent %s has no compiledInstructions (compile never run?) — using fallback",
+            agent_id,
+        )
+        return PromptResult(
+            text=FALLBACK_PROMPT, source="fallback", agent_id=agent_id
+        )
+
+    logger.info(
+        "Loaded compiled prompt for agent %s (%d chars)", agent_id, len(compiled)
+    )
+    return PromptResult(
+        text=compiled, source="modelguide-api", agent_id=agent_id
+    )

--- a/examples/agents/livekit-poc/src/transcript.py
+++ b/examples/agents/livekit-poc/src/transcript.py
@@ -1,0 +1,32 @@
+"""In-memory transcript collector.
+
+LiveKit emits one event per finalised user/assistant utterance. We
+collect them in order and hand the list back to the entrypoint on
+session close so it can post once to ``POST /api/sessions/:id/messages``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TranscriptCollector:
+    """Append-only ordered list of {role, content} messages."""
+
+    _messages: list[dict] = field(default_factory=list)
+
+    def add_user_utterance(self, text: str) -> None:
+        clean = (text or "").strip()
+        if not clean:
+            return
+        self._messages.append({"role": "user", "content": clean})
+
+    def add_assistant_response(self, text: str) -> None:
+        clean = (text or "").strip()
+        if not clean:
+            return
+        self._messages.append({"role": "assistant", "content": clean})
+
+    def get_messages(self) -> list[dict]:
+        return list(self._messages)

--- a/examples/agents/livekit-poc/tests/conftest.py
+++ b/examples/agents/livekit-poc/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared fixtures and sys.path setup for the livekit-poc tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Set dummy env vars BEFORE any src imports (config.py validates eagerly via
+# load_dotenv on import). Each test that needs different values can mutate
+# os.environ in its own setup.
+_TEST_ENV = {
+    "OPENAI_API_KEY": "test_openai_key",
+    "DEEPGRAM_API_KEY": "test_deepgram_key",
+    "ELEVENLABS_API_KEY": "test_elevenlabs_key",
+    "MODELGUIDE_API_URL": "http://localhost:3000",
+    "MODELGUIDE_API_KEY": "mgk_test_key",
+    "MODELGUIDE_AGENT_ID": "00000000-0000-0000-0000-000000000000",
+}
+
+for k, v in _TEST_ENV.items():
+    os.environ.setdefault(k, v)
+
+# Add src/ to sys.path so tests can `import config`, `import prompt_loader`, etc.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/examples/agents/livekit-poc/tests/test_config.py
+++ b/examples/agents/livekit-poc/tests/test_config.py
@@ -1,0 +1,107 @@
+"""Tests for env loading.
+
+``config.validate()`` is the gatekeeper at entrypoint — if required vars
+are missing, the worker should fail fast with a readable error rather
+than crashing inside a LiveKit plugin three frames deep.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+import config
+
+
+def _reload_config_with(env: dict[str, str | None], *, validate: bool = True):
+    """Reload config.py with a specific env snapshot.
+
+    If ``validate=True``, also runs ``config.validate()`` inside the env
+    window so the module's globals are populated from the test values
+    before they're rolled back. Set ``validate=False`` when the test is
+    asserting the validate() call itself (e.g. expecting it to raise).
+    """
+    snapshot = {k: os.environ.get(k) for k in env}
+    try:
+        for k, v in env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        importlib.reload(config)
+        if validate:
+            config.validate()
+        return config
+    finally:
+        for k, v in snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestValidate:
+    def test_passes_with_required_vars(self):
+        cfg = _reload_config_with(
+            {
+                "OPENAI_API_KEY": "ok",
+                "DEEPGRAM_API_KEY": "ok",
+                "ELEVENLABS_API_KEY": "ok",
+                "MODELGUIDE_API_URL": "http://localhost:3000",
+                "MODELGUIDE_API_KEY": "mgk_abc",
+            }
+        )
+        assert cfg.MODELGUIDE_API_URL == "http://localhost:3000"
+        assert cfg.MODELGUIDE_API_KEY == "mgk_abc"
+
+    def test_strips_trailing_slash_on_api_url(self):
+        # mg_client builds URLs by concatenation — a trailing slash silently
+        # double-slashes the path. Strip at validate() so consumers don't
+        # each need to remember.
+        cfg = _reload_config_with(
+            {
+                "OPENAI_API_KEY": "ok",
+                "DEEPGRAM_API_KEY": "ok",
+                "ELEVENLABS_API_KEY": "ok",
+                "MODELGUIDE_API_URL": "http://localhost:3000/",
+                "MODELGUIDE_API_KEY": "mgk_abc",
+            }
+        )
+        assert cfg.MODELGUIDE_API_URL == "http://localhost:3000"
+
+    def test_raises_when_required_missing(self):
+        # `_reload_config_with` runs validate() inside its env window — a
+        # ConfigError raised there propagates up through the try/finally.
+        # We match on the parent (RuntimeError) because importlib.reload
+        # re-creates the ConfigError class, and pytest.raises captures the
+        # class reference before the reload runs.
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+            _reload_config_with(
+                {
+                    "OPENAI_API_KEY": None,
+                    "DEEPGRAM_API_KEY": "ok",
+                    "ELEVENLABS_API_KEY": "ok",
+                    "MODELGUIDE_API_URL": "http://localhost:3000",
+                    "MODELGUIDE_API_KEY": "mgk_abc",
+                },
+            )
+
+    def test_validate_is_idempotent(self):
+        # Called twice (e.g. on first job + by an import in a test) — second
+        # call must be a no-op, not a re-validation that re-reads env.
+        cfg = _reload_config_with(
+            {
+                "OPENAI_API_KEY": "ok",
+                "DEEPGRAM_API_KEY": "ok",
+                "ELEVENLABS_API_KEY": "ok",
+                "MODELGUIDE_API_URL": "http://localhost:3000",
+                "MODELGUIDE_API_KEY": "mgk_abc",
+            }
+        )
+        # Mutate env after the first validate — second call must not
+        # re-read.
+        os.environ["OPENAI_API_KEY"] = "different_after_first_validate"
+        cfg.validate()
+        assert cfg.OPENAI_API_KEY == "ok"

--- a/examples/agents/livekit-poc/tests/test_prompt_loader.py
+++ b/examples/agents/livekit-poc/tests/test_prompt_loader.py
@@ -1,0 +1,182 @@
+"""Tests for prompt_loader — the heart of the POC.
+
+The POC worker's only reason to exist is "always boot with the latest
+compiled prompt from ModelGuide." That means three behaviours must hold:
+
+  1. When dispatch metadata carries an ``agent_id``, the loader fetches
+     ``GET /api/agents/{agent_id}`` and returns ``compiledInstructions``.
+  2. When the agent has no compiled prompt yet (operator hasn't clicked
+     "Compile" once), the loader falls back to a clearly-labelled default
+     so the call still goes through and the operator can hear *something*.
+  3. When the API call itself fails (network, 401, 500), the loader still
+     falls back rather than killing the LiveKit session — a hung worker
+     is worse than a generic prompt for a POC.
+
+These were written before the implementation existed (TDD red phase). The
+first run produces ImportError / AttributeError. The implementation in
+``src/prompt_loader.py`` was then written to make these pass without
+adding behaviour the tests don't cover.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import prompt_loader
+
+
+def _fake_agent_response(compiled: str | None) -> dict:
+    """Shape mirrors ``GET /api/agents/:id`` — only fields we actually read."""
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Test Agent",
+        "slug": "test-agent",
+        "compiledInstructions": compiled,
+        "compiledAt": "2026-06-16T10:00:00Z" if compiled else None,
+    }
+
+
+class TestExtractAgentIdFromMetadata:
+    """Dispatch metadata parsing — the worker reads ``agent_id`` from this."""
+
+    def test_returns_agent_id_when_present(self):
+        md = {"agent_id": "11111111-1111-1111-1111-111111111111", "mode": "voice-test"}
+        assert (
+            prompt_loader.extract_agent_id(md)
+            == "11111111-1111-1111-1111-111111111111"
+        )
+
+    def test_returns_none_when_missing(self):
+        # An old metadata payload (pre agent_id rollout) should fall back to
+        # env var, not crash the entrypoint.
+        assert prompt_loader.extract_agent_id({"mode": "voice-test"}) is None
+
+    def test_returns_none_for_empty_string(self):
+        # An empty string is *not* a valid UUID — treat it as missing so we
+        # fall back rather than firing a 404 against the API.
+        assert prompt_loader.extract_agent_id({"agent_id": ""}) is None
+
+    def test_handles_non_dict_input(self):
+        # ctx.job.metadata can be ``None`` when nothing was dispatched (e.g.
+        # local ``console`` mode). Should not blow up.
+        assert prompt_loader.extract_agent_id(None) is None
+
+
+class TestLoadPromptFromAPI:
+    """Happy path: the API returns ``compiledInstructions`` → we return them."""
+
+    @pytest.mark.asyncio
+    async def test_returns_compiled_instructions_on_success(self):
+        agent_id = "11111111-1111-1111-1111-111111111111"
+        body = _fake_agent_response("YOU ARE SAM, AN ORDERING ASSISTANT.")
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = body
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get = AsyncMock(return_value=mock_response)
+        with patch("prompt_loader._http_get", mock_get):
+            result = await prompt_loader.load_prompt(agent_id)
+
+        assert result.text == "YOU ARE SAM, AN ORDERING ASSISTANT."
+        assert result.source == "modelguide-api"
+        assert result.agent_id == agent_id
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_url_with_auth(self):
+        agent_id = "abc-123"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = _fake_agent_response("hello")
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get = AsyncMock(return_value=mock_response)
+        with patch("prompt_loader._http_get", mock_get):
+            await prompt_loader.load_prompt(agent_id)
+
+        mock_get.assert_called_once()
+        url_arg = mock_get.call_args[0][0]
+        assert url_arg.endswith(f"/api/agents/{agent_id}")
+
+
+class TestLoadPromptFallback:
+    """When the API or the data is unusable, we MUST still return a prompt."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_compiled_instructions_is_null(self):
+        # Agent exists but operator hasn't clicked "Compile" yet.
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = _fake_agent_response(None)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("prompt_loader._http_get", AsyncMock(return_value=mock_response)):
+            result = await prompt_loader.load_prompt("any-id")
+
+        assert result.source == "fallback"
+        assert "compile" in result.text.lower(), (
+            "fallback prompt should tell the listener the agent isn't compiled yet"
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_compiled_instructions_is_empty_string(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = _fake_agent_response("")
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("prompt_loader._http_get", AsyncMock(return_value=mock_response)):
+            result = await prompt_loader.load_prompt("any-id")
+
+        assert result.source == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_api_returns_http_error(self):
+        # 401, 404, 500 — operator should still hear *something* so they can
+        # debug from the room instead of a silent "Waking up agent..." spinner.
+        request = httpx.Request("GET", "http://localhost:3000/api/agents/x")
+        response = httpx.Response(500, request=request)
+        err = httpx.HTTPStatusError("boom", request=request, response=response)
+
+        with patch("prompt_loader._http_get", AsyncMock(side_effect=err)):
+            result = await prompt_loader.load_prompt("any-id")
+
+        assert result.source == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_api_is_unreachable(self):
+        with patch(
+            "prompt_loader._http_get",
+            AsyncMock(side_effect=httpx.ConnectError("nope")),
+        ):
+            result = await prompt_loader.load_prompt("any-id")
+
+        assert result.source == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_agent_id_is_none(self):
+        # Dispatched without metadata at all, and no env var override available.
+        result = await prompt_loader.load_prompt(None)
+        assert result.source == "fallback"
+        # No HTTP call should be attempted with a None ID.
+        assert result.agent_id is None
+
+
+class TestPromptResultShape:
+    """The PromptResult struct is what the entrypoint reads — lock its shape."""
+
+    def test_has_text_source_agent_id_fields(self):
+        r = prompt_loader.PromptResult(
+            text="hi",
+            source="modelguide-api",
+            agent_id="11111111-1111-1111-1111-111111111111",
+        )
+        assert r.text == "hi"
+        assert r.source == "modelguide-api"
+        assert r.agent_id == "11111111-1111-1111-1111-111111111111"
+
+    def test_source_is_one_of_two_literals(self):
+        # The agent.py entrypoint logs ``result.source`` so triaging "why did
+        # I hear the fallback prompt" is one grep. If a third source is added
+        # (e.g. "env-var-override"), the logging code needs to be updated too.
+        for valid in ("modelguide-api", "fallback"):
+            prompt_loader.PromptResult(text="x", source=valid, agent_id=None)

--- a/examples/agents/livekit-poc/tests/test_transcript.py
+++ b/examples/agents/livekit-poc/tests/test_transcript.py
@@ -1,0 +1,67 @@
+"""Tests for the transcript collector.
+
+The transcript is what the dashboard sees after the call ends. We need:
+
+  * User/assistant utterances are recorded in order.
+  * Empty/whitespace lines are ignored (LiveKit emits these for partials).
+  * ``get_messages()`` returns a JSON-serializable list shaped for
+    ``POST /api/sessions/:id/messages``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from transcript import TranscriptCollector
+
+
+class TestUtterances:
+    def test_records_user_message(self):
+        t = TranscriptCollector()
+        t.add_user_utterance("Hello there")
+        msgs = t.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Hello there"
+
+    def test_records_assistant_message(self):
+        t = TranscriptCollector()
+        t.add_assistant_response("Hi! How can I help?")
+        msgs = t.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "assistant"
+        assert msgs[0]["content"] == "Hi! How can I help?"
+
+    def test_preserves_chronological_order(self):
+        t = TranscriptCollector()
+        t.add_user_utterance("one")
+        t.add_assistant_response("two")
+        t.add_user_utterance("three")
+        contents = [m["content"] for m in t.get_messages()]
+        assert contents == ["one", "two", "three"]
+
+    def test_ignores_empty_string(self):
+        # Whisper/Nova-3 sometimes emit `""` on a noise burst between real
+        # utterances. Don't pollute the transcript with these.
+        t = TranscriptCollector()
+        t.add_user_utterance("")
+        t.add_assistant_response("   ")
+        assert t.get_messages() == []
+
+    def test_strips_whitespace(self):
+        t = TranscriptCollector()
+        t.add_user_utterance("  hi  ")
+        assert t.get_messages()[0]["content"] == "hi"
+
+
+class TestSerialization:
+    def test_messages_are_json_serializable(self):
+        t = TranscriptCollector()
+        t.add_user_utterance("hello")
+        t.add_assistant_response("world")
+        # Round-trip through JSON — if anything is a non-serializable type
+        # we'd fail to post the transcript to the API.
+        assert json.loads(json.dumps(t.get_messages())) == t.get_messages()
+
+    def test_empty_transcript_returns_empty_list(self):
+        assert TranscriptCollector().get_messages() == []

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -901,19 +901,27 @@ export function buildOutboundDispatchMetadata(input: {
  * the right profile and every dispatched call goes silent.
  */
 export function buildVoiceTestDispatchMetadata(input: {
+  agentId: string;
   agentSlug: string;
   sessionId: string;
   callerEmail: string;
 }): {
   mode: "voice-test";
   agentName: string;
+  agent_id: string;
   session_id: string;
   user_identifier: string;
   email: string;
 } {
+  // `agent_id` is consumed by the livekit-poc worker
+  // (examples/agents/livekit-poc/) so it can fetch the latest compiled
+  // prompt from `GET /api/agents/:id` at session start. The production
+  // multi-profile worker keys on `agentName` and ignores this field; see
+  // ADR-015 for why we thread the ID instead of injecting the prompt.
   return {
     mode: "voice-test" as const,
     agentName: input.agentSlug,
+    agent_id: input.agentId,
     session_id: input.sessionId,
     user_identifier: input.callerEmail,
     email: input.callerEmail,
@@ -993,6 +1001,7 @@ export async function createVoiceTestSession(
   });
 
   const dispatchMetadata = buildVoiceTestDispatchMetadata({
+    agentId: agent.id,
     agentSlug: agent.slug,
     sessionId: session.id,
     callerEmail: caller.email,

--- a/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
+++ b/modelguide-api/tests/unit/agents/voice-test-dispatch.test.ts
@@ -18,6 +18,7 @@ import { buildVoiceTestDispatchMetadata } from "../../../src/features/agents/age
 describe("buildVoiceTestDispatchMetadata", () => {
   test("carries agentName = agent.slug for multi-profile routing", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: "banknowa_v1",
       sessionId: "sess-abc",
       callerEmail: "admin@example.com",
@@ -28,6 +29,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
 
   test("mode is a literal 'voice-test' marker", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: "x",
       sessionId: "s",
       callerEmail: "c@e.com",
@@ -37,6 +39,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
 
   test("session_id + user_identifier + email carry caller context", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: "tenant_a",
       sessionId: "sess-xyz",
       callerEmail: "tester@corp.com",
@@ -46,14 +49,22 @@ describe("buildVoiceTestDispatchMetadata", () => {
     expect(md.email).toBe("tester@corp.com");
   });
 
-  test("shape is stable — exactly these 5 keys, nothing else", () => {
+  test("shape is stable — exactly these 6 keys, nothing else", () => {
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: "x",
       sessionId: "s",
       callerEmail: "c@e.com",
     });
     expect(Object.keys(md).sort()).toEqual(
-      ["agentName", "email", "mode", "session_id", "user_identifier"].sort(),
+      [
+        "agentName",
+        "agent_id",
+        "email",
+        "mode",
+        "session_id",
+        "user_identifier",
+      ].sort(),
     );
   });
 
@@ -63,6 +74,7 @@ describe("buildVoiceTestDispatchMetadata", () => {
     // equality, so any transform silently breaks routing.
     const weird = "Weird_Slug-v1";
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: weird,
       sessionId: "s",
       callerEmail: "c@e.com",
@@ -74,11 +86,50 @@ describe("buildVoiceTestDispatchMetadata", () => {
     // The dispatch layer JSON-stringifies this payload. Confirm nothing is
     // a Symbol, function, or other unserializable value.
     const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
       agentSlug: "banknowa_v2",
       sessionId: "s",
       callerEmail: "c@e.com",
     });
     const roundTripped = JSON.parse(JSON.stringify(md));
     expect(roundTripped).toEqual(md);
+  });
+
+  // ------------------------------------------------------------------
+  // agent_id (new — added for the livekit-poc worker)
+  //
+  // The livekit-poc worker (examples/agents/livekit-poc/) reads
+  // ``agent_id`` from this metadata so it can pull the latest compiled
+  // prompt from ``GET /api/agents/:id`` at session start, giving operators
+  // a one-click "compile → test the live prompt" loop without baking the
+  // prompt into the worker image.
+  //
+  // Keeping the field key in snake_case matches the rest of the payload
+  // (Python-side conventions). agentName stays camelCase because changing
+  // it would silently break every deployed worker that reads it.
+  // ------------------------------------------------------------------
+
+  test("agent_id is echoed verbatim — POC worker uses it to fetch the live prompt", () => {
+    const md = buildVoiceTestDispatchMetadata({
+      agentId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      agentSlug: "any",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect(md.agent_id).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  test("agent_id and agentName are independent — slug renames don't change the ID lookup", () => {
+    // The slug is human-readable and can be renamed in the dashboard. The
+    // POC worker keys on agent_id (UUID, immutable) so a rename mid-test
+    // doesn't break the prompt fetch.
+    const md = buildVoiceTestDispatchMetadata({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      agentSlug: "renamed-slug",
+      sessionId: "s",
+      callerEmail: "c@e.com",
+    });
+    expect(md.agent_id).toBe("11111111-1111-1111-1111-111111111111");
+    expect(md.agentName).toBe("renamed-slug");
   });
 });


### PR DESCRIPTION
## Summary

Adds a minimal LiveKit voice worker (`examples/agents/livekit-poc/`) that hot-loads the agent's **compiled prompt** from ModelGuide on every session. Inspired by [voiceblox-ai/voiceblox](https://github.com/voiceblox-ai/voiceblox).

The whole point: a tight **compile → click "Talk to agent" → hear it** loop on the dashboard so an operator can iterate on a prompt without rebuilding a worker image. The existing `VoiceTestPanel` + `LivekitCard` UX needs no changes — operators just point an agent's `metadata.livekit.agentName` at the POC worker.

### What's in the box

- **POC worker** (~200 lines Python). No MCP, no tool wiring — by design. `prompt_loader.py` fetches `GET /api/agents/:id` for `compiledInstructions`; falls back to a clearly-labelled prompt if the API is down or the agent isn't compiled yet (a silent room is worse than an honest fallback when you're iterating).
- **One additive API field.** `buildVoiceTestDispatchMetadata` now stamps `agent_id` (UUID) into dispatch metadata. The production worker keeps reading `agentName` and ignores `agent_id`; the POC worker keys on `agent_id`.
- **ADR-015** — explains why this exists alongside (not replacing) the production worker, and why we pass an ID, not the prompt text (ADR-014's "no prompt injection on the wire" stance is preserved).
- **README** for the POC with quick-start, dev / console / cloud modes, and a comparison table vs. the production `livekit-agent`.

### TDD trail

Red → green → refactor, both sides:

- **API:** added two failing cases (`agent_id is echoed verbatim`, `agent_id and agentName are independent`), watched them fail, then extended `buildVoiceTestDispatchMetadata` to make them green. Existing 6 contract tests updated for the new required `agentId` arg.
- **POC:** wrote 24 cases for `prompt_loader`, `transcript`, `config` before any src/ file existed (`ModuleNotFoundError` was the red), then implemented to green. `prompt_loader.load_prompt` has four explicit fallback paths under test (missing ID, null compiledInstructions, HTTP error, network failure) because the fallback is load-bearing.

### Verification

- `bun run test:unit` — 898 / 898 pass (incl. 8 voice-test-dispatch cases, +2 new).
- `bun run typecheck` — clean.
- `bun run lint:check` — clean.
- `pytest examples/agents/livekit-poc/tests/` — 24 / 24 pass.

### Deliberately NOT in this PR

- No prompt-text injection (kept ADR-014's stance — see ADR-015 alternatives).
- No worker-side prompt cache (defeats "test the prompt I just compiled").
- No tool execution on the POC (use `livekit-agent` or simulations).
- No new endpoint (reuses `POST /agents/:id/voice-test-token`).

## Test plan

- [ ] Stand up local LiveKit + the POC worker per `examples/agents/livekit-poc/README.md`.
- [ ] In the dashboard, set a voice agent's `metadata.livekit.agentName` to `livekit-poc`.
- [ ] Compile the agent's prompt.
- [ ] Click "Talk to agent" → confirm greeting reflects the just-compiled prompt.
- [ ] Edit + recompile the prompt → click "Talk to agent" again → confirm the change is heard immediately.
- [ ] Force a failure (stop the API or rename the agent during dispatch) → confirm the worker greets with the fallback prompt instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tw4VkRu9MquNdo8xPgjJjS)_