### PR TITLE
feat(agents): worker-pulled runtime config for LiveKit voice agents (POC)

### DIFF
--- a/docs/decisions/015-worker-pulled-runtime-config.md
+++ b/docs/decisions/015-worker-pulled-runtime-config.md
@@ -1,0 +1,112 @@
+# ADR-015: Worker-Pulled Runtime Config for LiveKit Voice Agents
+
+**Status:** Proposed (POC)
+
+## Context
+
+ADR-014 shipped browser voice testing — admins can click **Talk to agent** on the agent detail page and start a WebRTC conversation with the configured LiveKit worker. Once that loop existed, the next gap was obvious: **prompt edits don't reach the worker without a redeploy.**
+
+The example LiveKit worker (`examples/agents/livekit-agent/src/buildpro.py`) bakes its system prompt into the Python package via `prompts/base.py`. A dashboard user can compile a new prompt, click Talk, and hear *the old prompt*. The compiled prompt sits in `agents.compiledInstructions` in the DB; the worker has never heard of it.
+
+ADR-014 deliberately rejected the "obvious" fix — embedding the compiled prompt in LiveKit dispatch metadata — for two reasons:
+
+1. It creates an asymmetry where voice-test uses prompt X but real inbound calls use prompt Y. "Works in test, broke in prod."
+2. Prompts can be tens of KBs; dispatch metadata is the wrong envelope (LiveKit caps it ~48KB; the byte-size guards become load-bearing).
+
+We agree with that rejection. We need a path that doesn't suffer from either failure mode.
+
+## Decision
+
+The worker **pulls** its own current runtime config from ModelGuide via its existing agent API key at session start.
+
+Concretely:
+
+1. **API endpoint** — `GET /api/agents/me/runtime-config`, gated by `requireAgent()` (agent API key auth, not user JWT). The endpoint resolves the agent from the bearer token, so the worker never needs to embed its own agent ID. Returns `{ id, name, slug, modality, modelFamily, agentPlatform, promptConfig, compiledInstructions, compiledAt }`.
+
+2. **Worker client** — `mg_client.fetch_runtime_config()` calls that endpoint, returning the parsed payload on success and `None` on any failure (HTTP error, transport error, timeout). A stale prompt is always better than a hard crash mid-call.
+
+3. **Resolution policy** — `mg_client.resolve_instructions(fetched, local)` picks the dashboard-compiled prompt when it's a non-empty string, otherwise falls back to the locally bundled prompt. The local prompt remains the floor: an agent that has never been compiled still has something to say.
+
+4. **Wiring** — `agent.py` (entrypoint) calls `fetch_runtime_config()` once per room, passes the result to `BuildProAgent`, which threads it through `resolve_instructions()` before calling `super().__init__(instructions=...)`.
+
+The fetch happens for **every flow** — voice-test, inbound SIP, outbound SIP — so there is no test/prod asymmetry. The pulled prompt is the prompt the user just compiled.
+
+## Why pull, not push
+
+| Concern | Push (rejected in ADR-014) | Pull (this ADR) |
+|---|---|---|
+| Test/prod parity | Voice-test gets the injected prompt, real calls get the worker's bundled prompt | Both call the same fetch path |
+| Size limits | LiveKit metadata cap (~48KB) becomes load-bearing | HTTP body, no practical cap for our prompts |
+| Source of truth | Dispatch metadata duplicates DB state | DB is authoritative; worker reads from DB |
+| Failure mode | Empty room if metadata is malformed | Falls back to local prompt; call still works |
+| Auth surface | Anyone with dispatch rights can inject a prompt | Worker must own a valid agent API key |
+| Cold-start cost | None — prompt is in the dispatch | One extra HTTP GET (~30ms in-region) |
+
+The pull cost is the only real trade-off. We accept it: 30ms is invisible against the existing 2s click-to-audio budget from ADR-014, and a failed fetch is a hard fallback to the bundled prompt — not a broken call.
+
+## What this deliberately does NOT do
+
+- **No runtime tool config.** The endpoint returns prompt + identity, not connector tool assignments. Tool wiring still flows through MCP, where it can be hot-reloaded on the existing connection. Mixing the two would couple the prompt loop to the MCP catalog loop and turn one careful endpoint into two.
+- **No caching.** The fetch happens once per voice session. Caching adds invalidation problems for a path that already takes O(seconds) end-to-end. Revisit if voice sessions per minute climbs into the hundreds.
+- **No streaming.** This is a one-shot bootstrap, not a long-poll. Mid-call prompt updates are out of scope; the operator can hang up and try again.
+- **No "compiled prompt required" gate.** The endpoint happily returns `compiledInstructions: null` for agents that have never compiled — the worker's local prompt covers that case.
+
+## Endpoint shape
+
+`GET /api/agents/me/runtime-config`
+
+| Status | Condition |
+|---|---|
+| 200 | Returns runtime config for the agent owning this API key |
+| 401 | Missing / invalid agent API key (user JWTs are explicitly rejected by `requireAgent()`) |
+
+The route is registered before `/:id` in `agents.routes.ts` so the literal `me` segment isn't routed to the UUID-typed get/update handlers.
+
+### Why "me" (singular) instead of "/agents/:id/runtime-config"
+
+The agent API key carries the agent identity. Asking the caller to also embed its own ID in the URL is redundant and creates a class of bugs where the URL says A but the key belongs to B. We resolve the agent from the token, full stop. Same pattern as `/users/me` on the dashboard side.
+
+## Security
+
+- API key auth via the existing `verifyApiKey` middleware (SHA-256 hashed at rest, `mgk_` prefix, scoped to a single agent, deactivation revokes immediately).
+- Payload excludes secrets — no API keys, no connector configs, no webhook URLs. Just the prompt and the metadata needed to identify which agent's prompt it is.
+- An exfiltrated API key already grants MCP tool execution; exposing the compiled prompt is a strictly smaller blast radius.
+
+## Alternatives considered
+
+**Push prompt via dispatch metadata** — rejected in ADR-014 for the test/prod-asymmetry and size reasons summarized above.
+
+**Embed prompt in the LiveKit access token** — token has hard size limits, encoded in URL params during connect; same drawbacks as dispatch metadata with worse failure modes.
+
+**Push prompt via SSE / WebSocket from API to worker** — would require new transport, new auth, new reconnect logic. The fetch path uses the worker's existing API key and existing HTTP client. Revisit if we add mid-call updates.
+
+**Reuse `GET /api/agents/:id`** with relaxed auth — would either require API keys to see another agent's record (security regression) or a separate auth branch (effectively this ADR). The dedicated endpoint is cheaper and easier to reason about.
+
+## Consequences
+
+- **Closes the loop.** Click *Compile prompt* in the dashboard, click *Talk to agent*, hear the new prompt. No worker redeploy.
+- **One extra HTTP call per voice session.** ~30ms in-region, soft-fails to the bundled prompt on any error.
+- **The example worker now treats the bundled prompt as a floor, not a ceiling.** Scenario customization still happens by editing `prompts/`, but the dashboard's compiled prompt overrides it whenever it's set.
+- **TTS warm-up uses the resolved prompt.** `_warmup_prompt_cache()` in `agent.py` sends `agent.instructions` to the LLM as the system message; that now warms the cache for whichever prompt actually runs.
+- **The endpoint is small surface area.** It's a read of one row plus formatting — easy to keep stable as a public-ish contract for future custom workers.
+
+## Test coverage
+
+- **API integration** (`modelguide-api/tests/integration/agents.test.ts`):
+  - 401 without auth
+  - 401 with user JWT (agent-only endpoint)
+  - 200 returns the right shape, including `compiledInstructions` and `promptConfig`
+  - 200 with `null` compiled prompt for never-compiled agents
+- **Worker unit** (`examples/agents/livekit-agent/tests/test_runtime_config.py`):
+  - Hits the correct endpoint path
+  - Returns parsed payload on 200
+  - Returns `None` on HTTP error (no crash)
+  - Returns `None` on transport error (no crash)
+  - `resolve_instructions()` policy: prefer fetched compiled prompt; fall back to local when fetched is `None`, blank, or missing
+
+Both test suites were written before the implementation (red → green TDD) and live alongside the existing API and worker tests.
+
+## Related
+
+- ADR-011: LiveKit Outbound Calls — established the dispatch + worker pattern.
+- ADR-014: Browser Voice Testing — established the voice-test surface this ADR closes the prompt loop on. Read ADR-014's "Embed prompt in metadata" rejection alongside this ADR's pull-vs-push table.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,7 @@ Historical note: ADR filenames contain duplicate numeric IDs (`002` and `008`) f
 | [009-eval-suites.md](009-eval-suites.md) | Eval Suites | Accepted |
 | [010-cli-onboarding-tool.md](010-cli-onboarding-tool.md) | CLI Onboarding Tool | Accepted |
 | [011-livekit-outbound-calls.md](011-livekit-outbound-calls.md) | LiveKit Outbound Calls | Accepted |
+| [012-evaluator-override-model.md](012-evaluator-override-model.md) | Evaluator Override Model | Accepted |
+| [013-mocked-connectors-and-eval-mock-strategy.md](013-mocked-connectors-and-eval-mock-strategy.md) | Mocked Connectors and Eval Mock Strategy | Accepted |
+| [014-browser-voice-testing.md](014-browser-voice-testing.md) | Browser Voice Testing | Accepted |
+| [015-worker-pulled-runtime-config.md](015-worker-pulled-runtime-config.md) | Worker-Pulled Runtime Config for LiveKit Voice Agents | Proposed |

--- a/examples/agents/livekit-agent/PROMPT_SYNC.md
+++ b/examples/agents/livekit-agent/PROMPT_SYNC.md
@@ -1,0 +1,101 @@
+# Prompt Sync — Talk to the agent with your latest compiled prompt
+
+This document describes the **POC** that closes the loop from "edit prompt in the dashboard" to "hear it in a browser voice test", without redeploying the LiveKit worker.
+
+The pieces:
+
+| Piece | What it does | Where it lives |
+|---|---|---|
+| `GET /api/agents/me/runtime-config` | Returns the agent's compiled prompt + prompt config, authenticated by the agent's own API key | `modelguide-api/src/features/agents/agents.routes.ts` |
+| `mg_client.fetch_runtime_config()` | Worker-side fetch with graceful fallback to local | `examples/agents/livekit-agent/src/mg_client.py` |
+| `BuildProAgent(runtime_config=...)` | Threads the resolved prompt into the LiveKit agent's `instructions` | `examples/agents/livekit-agent/src/buildpro.py` |
+| Voice Test panel | Existing "Talk to agent" button on the agent detail page | `modelguide-ui/src/features/agents/components/voice-test-panel.tsx` |
+
+## The loop
+
+```
+Dashboard (modelguide-ui)
+   │
+   │ 1. Edit prompt config (persona / language / filler phrases)
+   │ 2. Click "Compile Prompt" → POST /api/agents/:id/compile
+   │ 3. agents.compiledInstructions written to Postgres
+   │ 4. Click "Talk to agent" → POST /api/agents/:id/voice-test-token
+   │     → API dispatches the LiveKit worker into a fresh room
+   ▼
+LiveKit worker (examples/agents/livekit-agent)
+   │
+   │ 5. entrypoint() fires for the new room
+   │ 6. mg_client.fetch_runtime_config()  ── GET /api/agents/me/runtime-config
+   │ 7. BuildProAgent(runtime_config=…)   ── resolve_instructions(fetched, local)
+   │ 8. AgentSession starts with the freshly-fetched prompt
+   ▼
+Browser ◄── WebRTC audio ── Speaks with the new prompt
+```
+
+Step 6 is the new bit. Everything else already existed (see ADR-014 for the voice-test dispatch).
+
+## Trying it locally
+
+You need a working LiveKit dev setup — see [README.md](./README.md) for the three-terminal flow. With that running:
+
+```bash
+# 1. Open the dashboard, navigate to an agent detail page
+make ui-dev
+
+# 2. Edit the persona / language / filler phrases under Prompt → Configuration,
+#    save the configuration.
+
+# 3. Switch to Prompt → Compiled and click "Compile Prompt".
+
+# 4. Scroll down to Voice Test and click "Talk to agent".
+#    Look in the worker logs for:
+#      mg_client | INFO | runtime-config fetched: agent=... slug=... compiled=True
+#      buildpro  | INFO | Using dashboard-compiled prompt (N chars, agent=...)
+```
+
+If you see `compiled=False`, the dashboard hasn't compiled a prompt for this agent yet (or the compiled column is null). The worker falls back to the bundled `prompts/base.py` and the call still works — that's the safety net.
+
+## What if the fetch fails?
+
+`fetch_runtime_config()` returns `None` on:
+
+- HTTP non-2xx (e.g. expired API key → 401, agent inactive → 401)
+- transport errors (DNS, connection refused, timeout)
+- any other exception
+
+`resolve_instructions(None, local)` then returns the local prompt. The voice call still connects and the agent still talks — just with the pre-deployment prompt. The failure is logged, not raised. We prefer a stale prompt to a dropped call.
+
+## Where the contract lives
+
+The endpoint is small on purpose. If you need to add a field:
+
+1. Add the column read in `getAgentRuntimeConfig` (`modelguide-api/src/features/agents/agents.service.ts`).
+2. Add it to `agentRuntimeConfigResponseSchema` in `agents.routes.ts`.
+3. Read it on the worker side and decide the policy (override? merge? bail?).
+
+Don't dump arbitrary `metadata.*` into the response — the endpoint is read by external workers and stays a stable contract by keeping its shape small. See ADR-015 for the boundary rationale.
+
+## Tests
+
+- API integration: `modelguide-api/tests/integration/agents.test.ts` → `describe("GET /api/agents/me/runtime-config")`
+- Worker unit: `examples/agents/livekit-agent/tests/test_runtime_config.py`
+
+Both were written before the implementation (red-green TDD). Run them with:
+
+```bash
+# API integration (requires a running Postgres; CI runs them in pipelines)
+make api-test-integration
+
+# Worker unit (no infra needed)
+cd examples/agents/livekit-agent
+uv sync --extra test
+uv run pytest tests/test_runtime_config.py -v
+```
+
+## Status & follow-ups
+
+This is a POC. Status in [ADR-015](../../../docs/decisions/015-worker-pulled-runtime-config.md): **Proposed**. The path is wired end-to-end and tested, but a few rough edges remain before it's production-ready:
+
+- The worker fetches on every room. Hundreds of voice sessions per minute would put real load on the API. Add a 5-30s cache (keyed on agent slug) before we exceed that volume.
+- There's no mid-call refresh. Editing a prompt during a live call has no effect until the next call. Out of scope for this POC.
+- The example agent (`BuildProAgent`) still owns scenario-specific Python (the 11 `@function_tool` methods, the cart state machine, the guardrails). Only the system prompt is dynamic. A fully prompt-driven worker — where tools come from MCP catalog discovery and the agent class is a thin shell — is a separate, larger project.

--- a/examples/agents/livekit-agent/README.md
+++ b/examples/agents/livekit-agent/README.md
@@ -294,3 +294,9 @@ No code changes needed. The tool's `@function_tool` definition and MCP name mapp
 ## LiveKit Cloud Deployment
 
 See [DEPLOY.md](./DEPLOY.md) for full deployment instructions.
+
+## Dashboard prompt sync (POC)
+
+The worker fetches its latest compiled prompt from ModelGuide at session start so the dashboard's "edit prompt → click Talk to agent" loop works without a redeploy. Falls back to the locally bundled prompt on any failure.
+
+See [PROMPT_SYNC.md](./PROMPT_SYNC.md) for the loop, the tests, and the known follow-ups. The architectural rationale lives in [ADR-015](../../../docs/decisions/015-worker-pulled-runtime-config.md).

--- a/examples/agents/livekit-agent/src/agent.py
+++ b/examples/agents/livekit-agent/src/agent.py
@@ -106,6 +106,11 @@ async def entrypoint(ctx: agents.JobContext):
             logger.exception("Failed to open persistent MCP connection — falling back to one-shot")
             return None
 
+    # Pull the latest compiled prompt from ModelGuide so dashboard prompt
+    # edits land on the next call without redeploying the worker. None on
+    # any failure — BuildProAgent then uses its bundled local prompt.
+    runtime_config = await mg_client.fetch_runtime_config()
+
     if outbound_phone:
         # --- Outbound flow: dial first, then handle participant ---
         logger.info("Outbound call to %s (room: %s)", outbound_phone, ctx.room.name)
@@ -158,7 +163,12 @@ async def entrypoint(ctx: agents.JobContext):
     logger.info("ModelGuide session: %s (user: %s)", session_id, user_identifier)
 
     # Build agent + session
-    agent = BuildProAgent(session_id=session_id, user_email=user_identifier, mcp=mcp)
+    agent = BuildProAgent(
+        session_id=session_id,
+        user_email=user_identifier,
+        mcp=mcp,
+        runtime_config=runtime_config,
+    )
     stt = create_stt()
     tts = create_tts()
 

--- a/examples/agents/livekit-agent/src/buildpro.py
+++ b/examples/agents/livekit-agent/src/buildpro.py
@@ -36,13 +36,25 @@ class BuildProAgent(MCPAgent):
     ]
 
     def __init__(
-        self, *, session_id: str | None, user_email: str, mcp: mg_client.MCPConnection | None = None
+        self,
+        *,
+        session_id: str | None,
+        user_email: str,
+        mcp: mg_client.MCPConnection | None = None,
+        runtime_config: dict | None = None,
     ) -> None:
         self._active_cart_id: str | None = None
         self._cart_ready = asyncio.Event()
         self._reorder_product_ids: list[str] = []
 
-        instructions = build_system_prompt(session_id or "", user_email=user_email)
+        local = build_system_prompt(session_id or "", user_email=user_email)
+        instructions = mg_client.resolve_instructions(runtime_config, local)
+        if runtime_config and instructions is not local:
+            logger.info(
+                "Using dashboard-compiled prompt (%d chars, agent=%s)",
+                len(instructions),
+                runtime_config.get("slug"),
+            )
         super().__init__(session_id=session_id, mcp=mcp, instructions=instructions)
 
     # ------------------------------------------------------------------

--- a/examples/agents/livekit-agent/src/mg_client.py
+++ b/examples/agents/livekit-agent/src/mg_client.py
@@ -52,6 +52,64 @@ async def close_http_client() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Runtime config (REST) — fetched at session start
+# ---------------------------------------------------------------------------
+
+
+async def fetch_runtime_config() -> dict | None:
+    """Fetch the agent's current compiled prompt and prompt config.
+
+    Hits ``GET /api/agents/me/runtime-config``. The endpoint is gated on the
+    agent's own API key, so the worker doesn't need to know its own UUID —
+    the API resolves it from the bearer token.
+
+    Returns the parsed JSON payload on success, ``None`` on any failure.
+    Falling back to the locally bundled prompt is far better than crashing a
+    voice call when the platform is briefly unavailable.
+    """
+    try:
+        async with httpx.AsyncClient(
+            base_url=config.MODELGUIDE_API_URL,
+            headers=_headers(),
+            timeout=10.0,
+        ) as client:
+            res = await client.get("/api/agents/me/runtime-config")
+            if not res.is_success:
+                logger.warning(
+                    "runtime-config fetch failed (status %s): %s",
+                    res.status_code,
+                    res.text[:200],
+                )
+                return None
+            data = res.json()
+            logger.info(
+                "runtime-config fetched: agent=%s slug=%s compiled=%s",
+                data.get("id"),
+                data.get("slug"),
+                bool(data.get("compiledInstructions")),
+            )
+            return data
+    except Exception:
+        logger.exception("runtime-config fetch raised")
+        return None
+
+
+def resolve_instructions(fetched: dict | None, local: str) -> str:
+    """Pick between the dashboard-compiled prompt and the locally bundled one.
+
+    Local prompts ship with the worker so it always has something to say,
+    even on a cold start with a network blip. Compiled prompts come from
+    the dashboard and represent the latest configuration — use them when
+    available and non-empty.
+    """
+    if fetched:
+        compiled = fetched.get("compiledInstructions")
+        if isinstance(compiled, str) and compiled.strip():
+            return compiled
+    return local
+
+
+# ---------------------------------------------------------------------------
 # Session management (REST)
 # ---------------------------------------------------------------------------
 

--- a/examples/agents/livekit-agent/tests/test_runtime_config.py
+++ b/examples/agents/livekit-agent/tests/test_runtime_config.py
@@ -1,0 +1,140 @@
+"""Tests for the runtime-config fetch path.
+
+Workers call ``mg_client.fetch_runtime_config()`` at the start of every voice
+session so the dashboard's "compile prompt → click Talk → hear it" loop
+works without a redeploy. These tests pin down the contract:
+
+* hits the ``GET /api/agents/me/runtime-config`` endpoint with the agent's
+  API key in the Authorization header
+* returns the parsed JSON payload on success
+* returns ``None`` on transport / HTTP errors instead of raising — a stale
+  prompt is preferable to a hard crash mid-call
+
+The agent.py side then chooses between the fetched compiled prompt and the
+local fallback (see ``buildpro.BuildProAgent``).
+"""
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mg_client
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    text: str = "",
+):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data or {}
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+def _mock_client(method="get", response=None):
+    client = AsyncMock()
+    getattr(client, method).return_value = response or _mock_response(200)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+SAMPLE_PAYLOAD = {
+    "id": "agt_abc",
+    "name": "Sam",
+    "slug": "buildpro-sam",
+    "modality": "voice",
+    "modelFamily": "gpt",
+    "agentPlatform": "livekit",
+    "promptConfig": {
+        "persona": "Friendly contractor concierge.",
+        "language": "English",
+        "fillerPhrases": ["One moment.", "Let me check."],
+    },
+    "compiledInstructions": "You are Sam. Help contractors order supplies.",
+    "compiledAt": "2026-06-18T00:00:00Z",
+}
+
+
+class TestFetchRuntimeConfig:
+    @pytest.mark.asyncio
+    async def test_hits_runtime_config_endpoint(self):
+        """The endpoint path matters — the worker MUST hit /api/agents/me/runtime-config."""
+        client = _mock_client("get", _mock_response(200, SAMPLE_PAYLOAD))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            await mg_client.fetch_runtime_config()
+
+        # First positional arg is the URL path
+        assert client.get.called
+        path = client.get.call_args[0][0]
+        assert path == "/api/agents/me/runtime-config"
+
+    @pytest.mark.asyncio
+    async def test_returns_parsed_payload(self):
+        client = _mock_client("get", _mock_response(200, SAMPLE_PAYLOAD))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.fetch_runtime_config()
+
+        assert result is not None
+        assert result["id"] == "agt_abc"
+        assert result["compiledInstructions"].startswith("You are Sam")
+        assert result["promptConfig"]["language"] == "English"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_http_error(self):
+        """A 401/500 from the API should NOT crash the voice session —
+        the worker falls back to its local prompt instead."""
+        client = _mock_client("get", _mock_response(500, text="boom"))
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.fetch_runtime_config()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_transport_error(self):
+        client = AsyncMock()
+        client.get.side_effect = httpx.ConnectError("nope")
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        with patch("mg_client.httpx.AsyncClient", return_value=client):
+            result = await mg_client.fetch_runtime_config()
+
+        assert result is None
+
+
+class TestResolveInstructions:
+    """The agent.py-level helper that picks between fetched and local."""
+
+    def test_prefers_fetched_compiled_prompt(self):
+        # We use a small pure-function helper so the policy is testable.
+        resolved = mg_client.resolve_instructions(
+            fetched={"compiledInstructions": "FROM API"},
+            local="FROM LOCAL",
+        )
+        assert resolved == "FROM API"
+
+    def test_falls_back_to_local_when_fetched_is_none(self):
+        resolved = mg_client.resolve_instructions(fetched=None, local="FROM LOCAL")
+        assert resolved == "FROM LOCAL"
+
+    def test_falls_back_to_local_when_compiled_is_blank(self):
+        resolved = mg_client.resolve_instructions(
+            fetched={"compiledInstructions": ""},
+            local="FROM LOCAL",
+        )
+        assert resolved == "FROM LOCAL"
+
+    def test_falls_back_to_local_when_compiled_missing(self):
+        resolved = mg_client.resolve_instructions(
+            fetched={"compiledInstructions": None},
+            local="FROM LOCAL",
+        )
+        assert resolved == "FROM LOCAL"

--- a/modelguide-api/src/features/agents/agents.routes.ts
+++ b/modelguide-api/src/features/agents/agents.routes.ts
@@ -10,8 +10,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createRouter } from "@lib/create-app";
 import { Errors } from "@lib/errors";
 import {
+  getCurrentAgent,
   getCurrentUser,
   getOrganizationId,
+  requireAgent,
   requireOrganization,
   requirePermission,
   requireUser,
@@ -25,6 +27,7 @@ import {
   createVoiceTestSession,
   deleteAgent,
   getAgentById,
+  getAgentRuntimeConfig,
   listAgentConnectors,
   listAgents,
   pingLivekitConfig,
@@ -387,6 +390,56 @@ router.openapi(createAgentRoute, async (c) => {
   const { agent, apiKey } = await createAgent(orgId, body, user.id);
 
   return c.json({ ...formatAgent(agent), apiKey }, 201);
+});
+
+// ============================================================================
+// Agent self / runtime config (API-key authenticated)
+// Workers (LiveKit voice agent, etc.) fetch the latest compiled prompt and
+// dashboard-side settings via their own API key at session start. That's how
+// the dashboard's "compile prompt → click Talk → hear the new prompt" loop
+// works without redeploying the worker.
+// Registered before /:id so the literal `me` segment isn't routed to the
+// UUID-typed get/update handlers.
+// ============================================================================
+
+router.get("/me/runtime-config", requireAgent(), requireOrganization());
+
+const agentRuntimeConfigResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  modality: z.enum(["voice", "text"]),
+  modelFamily: modelFamilySchema,
+  agentPlatform: z.enum(["custom", "elevenlabs", "livekit"]),
+  promptConfig: promptConfigSchema.passthrough(),
+  compiledInstructions: z.string().nullable(),
+  compiledAt: z.string().nullable(),
+});
+
+const agentRuntimeConfigRoute = createRoute({
+  method: "get",
+  path: "/me/runtime-config",
+  tags: ["Agents"],
+  summary: "Fetch runtime config for the calling agent",
+  description:
+    "Returns the compiled prompt, prompt-config knobs (persona, language, filler phrases) and identity for the agent that owns this API key. Designed for workers — LiveKit voice agent, custom runners — to refresh themselves at session start without a redeploy.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Runtime config for the calling agent",
+      content: {
+        "application/json": { schema: agentRuntimeConfigResponseSchema },
+      },
+    },
+    401: errorResponse("Agent authentication required"),
+  },
+});
+
+router.openapi(agentRuntimeConfigRoute, async (c) => {
+  const orgId = getOrganizationId(c);
+  const agent = getCurrentAgent(c);
+  const config = await getAgentRuntimeConfig(orgId, agent.id);
+  return c.json(config, 200);
 });
 
 // ============================================================================

--- a/modelguide-api/src/features/agents/agents.service.ts
+++ b/modelguide-api/src/features/agents/agents.service.ts
@@ -108,6 +108,48 @@ export async function listAgents(
   });
 }
 
+/**
+ * Runtime config a worker (e.g. LiveKit voice agent) needs to bootstrap a
+ * session against the latest dashboard state. Exposed via API-key auth so the
+ * worker can fetch it at session start — that's what makes the "compile
+ * prompt → click Talk → hear the new prompt" loop work without redeploying
+ * the worker.
+ *
+ * Keep this payload small and stable. Anything that needs deeper auth
+ * (secrets, connector IDs) belongs on the user-facing endpoints.
+ */
+export interface AgentRuntimeConfig {
+  id: string;
+  name: string;
+  slug: string;
+  modality: Modality;
+  modelFamily: ModelFamily;
+  agentPlatform: AgentPlatform;
+  promptConfig: PromptConfig;
+  compiledInstructions: string | null;
+  compiledAt: string | null;
+}
+
+export async function getAgentRuntimeConfig(
+  orgId: string,
+  agentId: string,
+): Promise<AgentRuntimeConfig> {
+  return forOrg(orgId, async (tx) => {
+    const agent = await requireAgent(tx, agentId);
+    return {
+      id: agent.id,
+      name: agent.name,
+      slug: agent.slug,
+      modality: agent.modality,
+      modelFamily: agent.modelFamily,
+      agentPlatform: agent.agentPlatform,
+      promptConfig: (agent.promptConfig ?? {}) as PromptConfig,
+      compiledInstructions: agent.compiledInstructions ?? null,
+      compiledAt: agent.compiledAt?.toISOString() ?? null,
+    };
+  });
+}
+
 export async function getAgentById(orgId: string, agentId: string) {
   return forOrg(orgId, async (tx) => {
     const [agent] = await tx

--- a/modelguide-api/tests/integration/agents.test.ts
+++ b/modelguide-api/tests/integration/agents.test.ts
@@ -8,7 +8,12 @@ import app from "@/app";
 import { forApp } from "@db/rls";
 import { agentConnectorTools, agents } from "@db/schema";
 import { eq, inArray } from "drizzle-orm";
-import { type TestSeed, authHeadersFor, getTestSeed } from "../helpers/seed";
+import {
+  type TestSeed,
+  agentHeadersFor,
+  authHeadersFor,
+  getTestSeed,
+} from "../helpers/seed";
 
 let s: TestSeed;
 let orgAAdminHeaders: Record<string, string>;
@@ -1008,6 +1013,96 @@ describe("POST /api/agents/:id/voice-test-token", () => {
     );
 
     expect(response.status).toBe(403);
+  });
+});
+
+// ============================================================================
+// GET /api/agents/me/runtime-config — agent-API-key-authenticated
+// Worker (e.g. LiveKit voice agent) fetches its own compiled prompt + config
+// at session start. Lets the dashboard's "compile prompt → talk" loop work
+// without redeploying the worker.
+// ============================================================================
+
+describe("GET /api/agents/me/runtime-config", () => {
+  test("returns 401 without auth", async () => {
+    const response = await request("/api/agents/me/runtime-config");
+    expect(response.status).toBe(401);
+  });
+
+  test("returns 401 with a user JWT (agent API key only)", async () => {
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: orgAAdminHeaders,
+    });
+    // The route is gated behind requireAgent — JWTs don't satisfy it.
+    expect(response.status).toBe(401);
+  });
+
+  test("returns runtime config for the API-key-owning agent (200)", async () => {
+    // Seeded agents are inactive by default; activate orgA's agent so the
+    // requireAgent middleware doesn't trip the agentInactive guard.
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({
+          isActive: true,
+          compiledInstructions: "You are Sam, a contractor supply agent.",
+          promptConfig: {
+            persona: "Friendly contractor concierge.",
+            language: "English",
+            fillerPhrases: ["One moment.", "Let me check."],
+          },
+        })
+        .where(eq(agents.id, s.orgAAgentId)),
+    );
+
+    const agentHeaders = await agentHeadersFor(s.orgAAgentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: agentHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.id).toBe(s.orgAAgentId);
+    expect(body.slug).toBeDefined();
+    expect(body.compiledInstructions).toBe(
+      "You are Sam, a contractor supply agent.",
+    );
+    expect(body.promptConfig).toEqual({
+      persona: "Friendly contractor concierge.",
+      language: "English",
+      fillerPhrases: ["One moment.", "Let me check."],
+    });
+    expect(body.modality).toBe("voice");
+  });
+
+  test("returns null compiledInstructions when the agent has never compiled", async () => {
+    // Create a fresh agent and explicitly clear any compiled prompt.
+    const createResp = await request("/api/agents", {
+      method: "POST",
+      headers: orgAAdminHeaders,
+      body: JSON.stringify({ name: "Uncompiled Runtime Config Agent" }),
+    });
+    expect(createResp.status).toBe(201);
+    const { id: agentId } = await createResp.json();
+    createdAgentIds.push(agentId);
+
+    await forApp((tx) =>
+      tx
+        .update(agents)
+        .set({ isActive: true, compiledInstructions: null })
+        .where(eq(agents.id, agentId)),
+    );
+
+    const agentHeaders = await agentHeadersFor(agentId, s.orgA.id);
+    const response = await request("/api/agents/me/runtime-config", {
+      headers: agentHeaders,
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.compiledInstructions).toBeNull();
+    // promptConfig defaults to {} for unconfigured agents.
+    expect(body.promptConfig).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the loop from dashboard **Compile Prompt** to browser **Talk to agent** without redeploying the LiveKit worker. The worker fetches its own current compiled prompt at session start via a new agent-API-key-gated endpoint and falls back to its bundled prompt on any failure.

Inspired by the [voiceblox](https://github.com/voiceblox-ai/voiceblox) sample referenced in the request, but kept inside the existing ModelGuide architecture (dispatch + worker + MCP) rather than forking a new flow.

ADR-014 explicitly rejected pushing prompts via dispatch metadata (size + test/prod-asymmetry). This PR takes the opposite shape — a **pull** by the worker over the agent's existing API key — which avoids both failure modes. The reasoning lives in [ADR-015](./docs/decisions/015-worker-pulled-runtime-config.md).

### What changed

- **API** — new `GET /api/agents/me/runtime-config`, gated by `requireAgent()`. Returns `{ id, name, slug, modality, modelFamily, agentPlatform, promptConfig, compiledInstructions, compiledAt }`.
- **Worker** — `mg_client.fetch_runtime_config()` (graceful `None` on any failure) + `resolve_instructions(fetched, local)` (policy: prefer fetched compiled prompt, fall back to local).
- **Wiring** — `agent.py` fetches once per room and threads the result into `BuildProAgent(runtime_config=…)`.
- **Docs** — ADR-015 (Proposed) and `examples/agents/livekit-agent/PROMPT_SYNC.md` walk through the loop, the contract, and the known follow-ups.

### Why this is a POC, not a finished feature

- Fetches once per session — no caching. Fine for current volume; revisit at hundreds of sessions/min.
- No mid-call refresh — operator hangs up and tries again to pick up a fresh prompt.
- The example worker still owns its `@function_tool` methods, cart state machine, and guardrails. Only the system prompt is dynamic. A fully prompt-driven worker is a separate, larger project.

## Test plan

Red-green TDD on both sides — failing tests committed first, then implementation made them pass.

- [x] **API integration** — `modelguide-api/tests/integration/agents.test.ts` → `describe("GET /api/agents/me/runtime-config")`
  - 401 without auth
  - 401 with user JWT (agent-only endpoint)
  - 200 returns the right shape with `compiledInstructions` + `promptConfig`
  - 200 with `null` compiled prompt for never-compiled agents
- [x] **Worker unit** — `examples/agents/livekit-agent/tests/test_runtime_config.py` (8 tests, all passing)
  - hits the correct endpoint path
  - parses the payload on 200
  - returns `None` on HTTP error (no crash)
  - returns `None` on transport error (no crash)
  - `resolve_instructions()` policy across fetched / local / blank / missing
- [x] **No regressions** — `make api-typecheck`, `make api-lint-check`, `make api-test-unit` (896 pass), `make ui-typecheck`, `make ui-test` (268 pass), all pre-existing Python tests still green.

### Manual verification (requires local LiveKit stack)

- [ ] `make livekit-up && make lk-agent-dev && make livekit-token` — Talk to agent
- [ ] Edit persona / language / filler phrases in the dashboard → Save → Compile Prompt
- [ ] Click Talk to agent again — worker logs `Using dashboard-compiled prompt (N chars, agent=…)` and the new persona is reflected in the conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScS64uJWNrVNUk4XtS6BHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScS64uJWNrVNUk4XtS6BHp)_